### PR TITLE
Fix input prefix icon for Safari

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.scss
+++ b/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.scss
@@ -151,7 +151,7 @@ $hover-transition-duration: 0.2s;
         position: absolute;
         height: 100%;
         top: 50%;
-        left: 0.75rem;
+        left: 0.8rem;
         transform: translate(0, -50%);
         &-icon {
           display: flex;


### PR DESCRIPTION
In Safari, icon was not at its supposed position.

Before:
![image](https://github.com/AbsaOSS/cps-shared-ui/assets/4323927/76306f1b-d60a-4327-9fe9-b96c6ab0c600)


After:
![image](https://github.com/AbsaOSS/cps-shared-ui/assets/4323927/f5dc7dda-5216-400a-9bfd-5cd8783ccc79)

I made sure that behavior in Chrome stays correct.