### PR TITLE
Update showRowRemoveButton property to default to true in TableRowMen…

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-table/components/internal/table-row-menu/table-row-menu.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/components/internal/table-row-menu/table-row-menu.component.ts
@@ -31,7 +31,7 @@ export class TableRowMenuComponent implements OnInit {
    */
   @Output() removeRowBtnClicked = new EventEmitter<any>();
 
-  private _showRowRemoveButton = false;
+  private _showRowRemoveButton = true;
 
   /**
    * Determines whether the 'Remove' button should be displayed in the menu.

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
@@ -267,7 +267,8 @@
       <td *ngIf="showRowMenu" class="cps-table-row-menu-cell">
         <table-row-menu
           (editRowBtnClicked)="onEditRowClicked(item)"
-          (removeRowBtnClicked)="onRemoveRowClicked(item)"></table-row-menu>
+          (removeRowBtnClicked)="onRemoveRowClicked(item)"
+          [showRowRemoveButton]="showRowRemoveButton"></table-row-menu>
       </td>
     </tr>
   </ng-template>

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -143,6 +143,14 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() showRowMenu = false;
 
   /**
+   * Determines whether the 'Remove' button should be displayed in the row menu.
+   * If true, 'Remove' button is shown. If false, it's hidden.
+   * Note: This setting only takes effect if 'showRowMenu' is true.
+   * @group Props
+   */
+  @Input() showRowRemoveButton = true;
+
+  /**
    * Whether the table should have re-orderable rows.
    * @group Props
    */


### PR DESCRIPTION
# Fix/add-default-value-true-showRowRemoveButton

Resolves  #297

This pull request fixes the issue of the 'Remove' button not being displayed in the row menu by default. The `showRowRemoveButton` property in the `TableRowMenuComponent` was set to `false`, which caused the button to be hidden unless explicitly set to `true` by the user. This pull request changes the default value of the property to `true`, so that the button is always visible unless the user chooses to hide it.

## Changes

- Changed the default value of the `showRowRemoveButton` property in the `TableRowMenuComponent` from `false` to `true`.
- Added the `[showRowRemoveButton]` input binding to the `<table-row-menu>` element in the `CpsTableComponent` template, so that the user can control the visibility of the button.
- Updated the documentation for the `CpsTableComponent` to reflect the new default behavior and the new input binding.