### PR TITLE
Make getCpsColors return unique colors

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - 'package.json'
+      - 'angular.json'
       - 'tsconfig.generator.json'
       - 'api-generator/**'
       - 'projects/cps-ui-kit/src/**'

--- a/angular.json
+++ b/angular.json
@@ -124,7 +124,12 @@
                   "maximumError": "22kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              }
             },
             "development": {
               "buildOptimizer": false,

--- a/projects/cps-ui-kit/src/lib/utils/colors-utils.ts
+++ b/projects/cps-ui-kit/src/lib/utils/colors-utils.ts
@@ -43,22 +43,28 @@ const isDark = (color: string): boolean => {
 };
 
 export const getCpsColors = (): [string, string][] =>
-  [...(document.styleSheets as any)].filter(isSameDomain).reduce(
-    (finalArr, sheet) =>
-      finalArr.concat(
-        [...sheet.cssRules].filter(isStyleRule).reduce((propValArr, rule) => {
-          const props = [...rule.style]
-            .map((propName) => [
-              propName.trim(),
-              rule.style.getPropertyValue(propName).trim()
-            ])
-            .filter(([propName]) => propName.indexOf('--cps-color') === 0);
+  [...(document.styleSheets as any)]
+    .filter(isSameDomain)
+    .reduce(
+      (finalArr, sheet) =>
+        finalArr.concat(
+          [...sheet.cssRules].filter(isStyleRule).reduce((propValArr, rule) => {
+            const props = [...rule.style]
+              .map((propName) => [
+                propName.trim(),
+                rule.style.getPropertyValue(propName).trim()
+              ])
+              .filter(([propName]) => propName.indexOf('--cps-color') === 0);
 
-          return [...propValArr, ...props];
-        }, [])
-      ),
-    []
-  );
+            return [...propValArr, ...props];
+          }, [])
+        ),
+      []
+    )
+    .filter(
+      (value: [string, string], index: number, array: [string, string][]) =>
+        array.findIndex((val) => val[0] === value[0]) === index
+    );
 
 export const getCSSColor = (val: string): string => {
   if (!val) return '';

--- a/projects/cps-ui-kit/src/lib/utils/colors-utils.ts
+++ b/projects/cps-ui-kit/src/lib/utils/colors-utils.ts
@@ -43,28 +43,22 @@ const isDark = (color: string): boolean => {
 };
 
 export const getCpsColors = (): [string, string][] =>
-  [...(document.styleSheets as any)]
-    .filter(isSameDomain)
-    .reduce(
-      (finalArr, sheet) =>
-        finalArr.concat(
-          [...sheet.cssRules].filter(isStyleRule).reduce((propValArr, rule) => {
-            const props = [...rule.style]
-              .map((propName) => [
-                propName.trim(),
-                rule.style.getPropertyValue(propName).trim()
-              ])
-              .filter(([propName]) => propName.indexOf('--cps-color') === 0);
+  [...(document.styleSheets as any)].filter(isSameDomain).reduce(
+    (finalArr, sheet) =>
+      finalArr.concat(
+        [...sheet.cssRules].filter(isStyleRule).reduce((propValArr, rule) => {
+          const props = [...rule.style]
+            .map((propName) => [
+              propName.trim(),
+              rule.style.getPropertyValue(propName).trim()
+            ])
+            .filter(([propName]) => propName.indexOf('--cps-color') === 0);
 
-            return [...propValArr, ...props];
-          }, [])
-        ),
-      []
-    )
-    .filter(
-      (value: [string, string], index: number, array: [string, string][]) =>
-        array.findIndex((val) => val[0] === value[0]) === index
-    );
+          return [...propValArr, ...props];
+        }, [])
+      ),
+    []
+  );
 
 export const getCSSColor = (val: string): string => {
   if (!val) return '';


### PR DESCRIPTION
Production build has `optimization` set to true, which, among other things, inlines styles that it considers to be critical, see https://angular.io/guide/workspace-config#styles-optimization-options. As a result, styles containing color definitions are inlined (they become part of `index.html` inside the `<style></style>` tag) but are also inside the linked `style.css` file.

I was wondering if the style redundancy is the expected result of the build process (why are the styles that have been inlined not removed from the style.css file to remove the redundancy and also to reduce the file size), so I've [opened an issue](https://github.com/angular/angular-cli/issues/27040) for this in the angular-cli repo.

<s>For now, as a fix, I make sure that the `getCpsColors` func returns unique colors by filtering the result (it adds additional computation complexity, but as the number of all colors is ~250 and we don't expect to be adding thousands of colors it doesn't affect the runtime).</s>

We've decided to solve this by turning off the `inlineCritical` build option as this would also solve the issue without slowing FCP time in our case (tested with the Lighthouse), another benefit is that we'll notice if someone accidentally introduces new color having the same name as some of the existent colors.