### PR TITLE
Show description of service method parameters and make their types clickable

### DIFF
--- a/projects/composition/src/app/app-routing.module.ts
+++ b/projects/composition/src/app/app-routing.module.ts
@@ -241,7 +241,7 @@ const routes: Routes = [
       )
   },
   {
-    matcher: pathMatcher('notifications'),
+    matcher: pathMatcher('notification'),
     title: 'Notifications',
     loadComponent: () =>
       import('./pages/notification-page/notification-page.component').then(

--- a/projects/composition/src/app/components/navigation-sidebar/navigation-sidebar.component.ts
+++ b/projects/composition/src/app/components/navigation-sidebar/navigation-sidebar.component.ts
@@ -81,7 +81,7 @@ export class NavigationSidebarComponent implements OnInit {
     },
     {
       title: 'Notifications',
-      url: '/notifications'
+      url: '/notification'
     },
     {
       title: 'Paginator',

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
@@ -53,6 +53,8 @@
                             <span>{{ param.type }}</span>
                           </ng-template>
                         </span>
+                      } @empty {
+                        null
                       }
                     </div>
                   </td>

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
@@ -37,8 +37,8 @@
                     <div class="parameters">
                       @for (param of method.parameters; track param.name) {
                         <span>
-                          <strong [cpsTooltip]="param.description || ''"
-                            >{{ param.name }}:
+                          <strong [cpsTooltip]="param.description || ''">
+                            {{ param.name }}:
                           </strong>
                           <a
                             *ngIf="

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
@@ -34,7 +34,27 @@
                     <span>{{ method.name }}</span>
                   </td>
                   <td class="highlighted-text">
-                    {{ parseParameters(method.parameters) || 'null' }}
+                    <div class="parameters">
+                      @for (param of method.parameters; track param.name) {
+                        <span>
+                          <strong [cpsTooltip]="param.description || ''"
+                            >{{ param.name }}:
+                          </strong>
+                          <a
+                            *ngIf="
+                              param.type | detectType: TypesMap as type;
+                              else simpleType
+                            "
+                            [routerLink]="'/' + TypesMap[type] + '/api'"
+                            fragment="{{ type }}">
+                            {{ param.type }}
+                          </a>
+                          <ng-template #simpleType>
+                            <span>{{ param.type }}</span>
+                          </ng-template>
+                        </span>
+                      }
+                    </div>
                   </td>
                   <td class="highlighted-text">
                     <a

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.scss
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.scss
@@ -19,12 +19,6 @@
     border-bottom: 1px solid var(--cps-color-line-light);
     white-space: pre-line;
 
-    span {
-      display: flex;
-      max-width: min-content;
-      white-space: pre-line;
-    }
-
     &.highlighted-bg {
       span {
         color: var(--cps-color-depth-darken4);
@@ -60,6 +54,16 @@
           monospace;
         background-color: var(--cps-color-bg-mid);
         border: 1px solid var(--cps-color-line-light);
+      }
+    }
+
+    .parameters {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+
+      strong {
+        cursor: pointer;
       }
     }
   }

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.ts
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.ts
@@ -1,7 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { ServiceAPI } from '../../models/service-api.model';
 import { CommonModule } from '@angular/common';
-import { CpsTabComponent, CpsTabGroupComponent } from 'cps-ui-kit';
+import {
+  CpsTabComponent,
+  CpsTabGroupComponent,
+  CpsTooltipDirective
+} from 'cps-ui-kit';
 import { ViewerComponent } from '../viewer/viewer.component';
 import TypesMap from '../../api-data/types_map.json';
 import { RouterLink } from '@angular/router';
@@ -17,7 +21,8 @@ import { DetectTypePipe } from '../../pipes/detect-type.pipe';
     CpsTabComponent,
     CpsTabGroupComponent,
     RouterLink,
-    DetectTypePipe
+    DetectTypePipe,
+    CpsTooltipDirective
   ]
 })
 export class ServiceDocsViewerComponent extends ViewerComponent {


### PR DESCRIPTION
- parameter description is displayed in a tooltip
- types of parameters are clickable
- changed `notifications` route to `notification` (it takes suffix from `cps-notification` folder)

![image](https://github.com/AbsaOSS/cps-shared-ui/assets/4323927/6bf526d8-21d9-4a7f-b6c4-9e042e06af4d)
