### PR TITLE
Update closeAll to close dialogs in all instances

### DIFF
--- a/projects/composition/src/app/app.module.ts
+++ b/projects/composition/src/app/app.module.ts
@@ -21,8 +21,7 @@ import { CpsDialogService, CpsIconComponent } from 'cps-ui-kit';
     CpsIconComponent
   ],
   providers: [
-    { provide: TitleStrategy, useClass: AppPrefixTitleStrategy },
-    CpsDialogService
+    { provide: TitleStrategy, useClass: AppPrefixTitleStrategy }
     // provideClientHydration()
   ],
   bootstrap: [AppComponent]

--- a/projects/composition/src/app/app.module.ts
+++ b/projects/composition/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { AppComponent } from './app.component';
 import { NavigationSidebarComponent } from './components/navigation-sidebar/navigation-sidebar.component';
 import { TitleStrategy } from '@angular/router';
 import { AppPrefixTitleStrategy } from './app.prefix-title-strategy';
-import { CpsDialogService, CpsIconComponent } from 'cps-ui-kit';
+import { CpsIconComponent } from 'cps-ui-kit';
 
 @NgModule({
   declarations: [AppComponent],

--- a/projects/composition/src/app/app.module.ts
+++ b/projects/composition/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { AppComponent } from './app.component';
 import { NavigationSidebarComponent } from './components/navigation-sidebar/navigation-sidebar.component';
 import { TitleStrategy } from '@angular/router';
 import { AppPrefixTitleStrategy } from './app.prefix-title-strategy';
-import { CpsIconComponent } from 'cps-ui-kit';
+import { CpsDialogService, CpsIconComponent } from 'cps-ui-kit';
 
 @NgModule({
   declarations: [AppComponent],
@@ -21,7 +21,8 @@ import { CpsIconComponent } from 'cps-ui-kit';
     CpsIconComponent
   ],
   providers: [
-    { provide: TitleStrategy, useClass: AppPrefixTitleStrategy }
+    { provide: TitleStrategy, useClass: AppPrefixTitleStrategy },
+    CpsDialogService
     // provideClientHydration()
   ],
   bootstrap: [AppComponent]

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.component.html
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.component.html
@@ -23,6 +23,9 @@
     <cps-button
       label="Bottom-right positioned dialog"
       (clicked)="openBottomRightPositionedDialog()"></cps-button>
+    <cps-button
+      label="Top-left positioned dialog opened from the root instance"
+      (clicked)="openDialogFromRootInstance()"></cps-button>
   </div>
   <div class="close-dlg-btns-group">
     <cps-button

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.component.ts
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CpsButtonComponent, CpsDialogService } from 'cps-ui-kit';
 import { DialogContentComponent } from '../../components/dialog-content/dialog-content.component';
@@ -12,12 +12,16 @@ import ServiceData from '../../api-data/cps-dialog.json';
   imports: [CommonModule, CpsButtonComponent, ServiceDocsViewerComponent],
   templateUrl: './dialog-page.component.html',
   styleUrls: ['./dialog-page.component.scss'],
-  host: { class: 'composition-page' }
+  host: { class: 'composition-page' },
+  providers: [CpsDialogService]
 })
 export class DialogPageComponent {
   serviceData = ServiceData;
   // eslint-disable-next-line no-useless-constructor
-  constructor(private _dialogService: CpsDialogService) {}
+  constructor(
+    public _dialogService: CpsDialogService,
+    @SkipSelf() public _dialogServiceRoot: CpsDialogService
+  ) {}
 
   openConfirmationDialog() {
     const dialogRef = this._dialogService.openConfirmationDialog({
@@ -149,6 +153,18 @@ export class DialogPageComponent {
       modal: false,
       data: {
         info: 'Greetings from the dialog content component',
+        icon: 'like'
+      }
+    });
+  }
+
+  openDialogFromRootInstance() {
+    this._dialogServiceRoot.open(DialogContentComponent, {
+      headerTitle: 'Top-left positioned dialog opened from root instance',
+      position: 'top-left',
+      modal: false,
+      data: {
+        info: 'Greetings from the dialog content component opened from root instance',
         icon: 'like'
       }
     });

--- a/projects/cps-ui-kit/src/lib/services/cps-dialog/cps-dialog.service.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-dialog/cps-dialog.service.ts
@@ -23,7 +23,7 @@ import { CpsConfirmationComponent } from './internal/components/cps-confirmation
  * Service for showing CpsDialog.
  * @group Services
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class CpsDialogService implements OnDestroy {
   get openDialogs(): CpsDialogRef<any>[] {
     return this._parentDialogService


### PR DESCRIPTION
Main motivation is to support multi-instance usage of `CpsDialogService`. We might need multiple instances, as some services injected in the component that is open as a dialog might not be provided at the root level.

- all the open dialogs are tracked in the top-most instance of `CpsDialogService`
- if the instance is destroyed and it was the top-most instance, all the dialogs are also destroyed

The inspiration for the solution was taken from Angular Components lib - [CDK dialog](https://github.com/angular/components/blob/9cb07615158c64c0046bdf9bbb5a4b7ec9147c8e/src/cdk/dialog/dialog.ts) and [Material dialog](https://github.com/angular/components/blob/9cb07615158c64c0046bdf9bbb5a4b7ec9147c8e/src/material/dialog/dialog.ts)
