### PR TITLE
Support rendering HTML data in table & column filtering input

### DIFF
--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -163,7 +163,7 @@
                         "readonly": false,
                         "type": "boolean",
                         "default": "true",
-                        "description": "If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.\nNote: This setting only takes effect if 'filterableByColumns' is true."
+                        "description": "If true, automatically detects filter type based on values, otherwise sets 'text' filter type for all columns.\nNote: This setting only takes effect if 'filterableByColumns' is true."
                     },
                     {
                         "name": "sortMode",

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -155,7 +155,7 @@
                         "readonly": false,
                         "type": "boolean",
                         "default": "true",
-                        "description": "If true, automatically detect filter type based on values, otherwise sets string filter type for all columns.\nOnly applied when filterableByColumns is true."
+                        "description": "If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.\nOnly applied when filterableByColumns is true."
                     },
                     {
                         "name": "sortMode",

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -155,7 +155,7 @@
                         "readonly": false,
                         "type": "boolean",
                         "default": "true",
-                        "description": "If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.\nOnly applied when filterableByColumns is true."
+                        "description": "If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.\nNote: This setting only takes effect if 'filterableByColumns' is true."
                     },
                     {
                         "name": "sortMode",

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -142,6 +142,22 @@
                         "description": "Makes all columns sortable if columns prop is provided."
                     },
                     {
+                        "name": "filterableByColumns",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "boolean",
+                        "default": "false",
+                        "description": "Enable filtering on all columns."
+                    },
+                    {
+                        "name": "autoColumnFilterType",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "boolean",
+                        "default": "true",
+                        "description": "If true, automatically detect filter type based on values, otherwise sets string filter type for all columns.\nOnly applied when filterableByColumns is true."
+                    },
+                    {
                         "name": "sortMode",
                         "optional": false,
                         "readonly": false,

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -510,6 +510,14 @@
                         "description": "Array of initial columns to show in the table. If not provided, all columns are initially visible."
                     },
                     {
+                        "name": "renderDataAsHTML",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "boolean",
+                        "default": "false",
+                        "description": "If set to true, row data are rendered using innerHTML."
+                    },
+                    {
                         "name": "data",
                         "optional": false,
                         "readonly": false,

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -38,6 +38,14 @@
                         "description": "A key used to retrieve the filter type from columns."
                     },
                     {
+                        "name": "colDateFormatName",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "string",
+                        "default": "dateFormat",
+                        "description": "A key used to retrieve the date format from columns."
+                    },
+                    {
                         "name": "striped",
                         "optional": false,
                         "readonly": false,

--- a/projects/composition/src/app/api-data/cps-table.json
+++ b/projects/composition/src/app/api-data/cps-table.json
@@ -30,6 +30,14 @@
                         "description": "A key used to retrieve the field from columns."
                     },
                     {
+                        "name": "colFilterTypeName",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "string",
+                        "default": "filterType",
+                        "description": "A key used to retrieve the filter type from columns."
+                    },
+                    {
                         "name": "striped",
                         "optional": false,
                         "readonly": false,

--- a/projects/composition/src/app/pages/table-page/table-page.component.html
+++ b/projects/composition/src/app/pages/table-page/table-page.component.html
@@ -28,7 +28,7 @@
 
         <ng-template let-item #body>
           <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date : 'MM/dd/yyyy' }}</td>
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
           <td>{{ item.c | percent }}</td>
           <td [style.color]="item.d ? 'green' : 'red'">
             {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -47,7 +47,8 @@
         [virtualScroll]="true"
         [showColumnsToggleBtn]="true"
         scrollHeight="500px"
-        toolbarTitle="Sortable table with virtual scroller, global filter and internal columns toggle">
+        toolbarTitle="Sortable table with virtual scroller, global filter, internal columns toggle and with column filtering enabled"
+        [filterableByColumns]="true">
       </cps-table>
     </cps-tab>
     <cps-tab label="Table 3">
@@ -78,7 +79,7 @@
 
         <ng-template let-item #body>
           <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date : 'MM/dd/yyyy' }}</td>
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
           <td>{{ item.c | percent }}</td>
           <td [style.color]="item.d ? 'green' : 'red'">
             {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -117,7 +118,7 @@
         <ng-template let-item #body>
           <ng-container *ngFor="let scol of selCols" [ngSwitch]="scol.field">
             <td *ngSwitchCase="'a'">{{ item.a | uppercase }}</td>
-            <td *ngSwitchCase="'b'">{{ item.b | date : 'MM/dd/yyyy' }}</td>
+            <td *ngSwitchCase="'b'">{{ item.b | date: 'MM/dd/yyyy' }}</td>
             <td *ngSwitchCase="'c'">{{ item.c | percent }}</td>
             <td *ngSwitchCase="'d'" [style.color]="item.d ? 'green' : 'red'">
               {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -164,7 +165,7 @@
         </ng-template>
         <ng-template let-item #body>
           <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date : 'MM/dd/yyyy' }}</td>
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
           <td>{{ item.c | percent }}</td>
           <td [style.color]="item.d ? 'green' : 'red'">
             {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -193,7 +194,7 @@
 
         <ng-template let-item #body>
           <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date : 'MM/dd/yyyy' }}</td>
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
           <td>{{ item.c | percent }}</td>
           <td [style.color]="item.d ? 'green' : 'red'">
             {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -219,7 +220,7 @@
 
         <ng-template let-item #body>
           <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date : 'MM/dd/yyyy' }}</td>
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
           <td>{{ item.c | percent }}</td>
           <td [style.color]="item.d ? 'green' : 'red'">
             {{ item.d ? '&#10004;' : '&#10008;' }}
@@ -256,7 +257,9 @@
         [renderDataAsHTML]="renderAsHTML"
         [showActionBtn]="true"
         toolbarTitle="Table containing HTML"
-        actionBtnTitle="renderAsHTML is set to {{ renderAsHTML ? 'true' : 'false' }}"
+        actionBtnTitle="renderAsHTML is set to {{
+          renderAsHTML ? 'true' : 'false'
+        }}"
         (actionBtnClicked)="renderAsHTML = !renderAsHTML">
       </cps-table>
     </cps-tab>

--- a/projects/composition/src/app/pages/table-page/table-page.component.html
+++ b/projects/composition/src/app/pages/table-page/table-page.component.html
@@ -248,5 +248,17 @@
         toolbarTitle="Table in data loading state">
       </cps-table>
     </cps-tab>
+    <cps-tab label="Table 10">
+      <cps-table
+        [data]="dataWithHTML"
+        scrollHeight="400px"
+        [columns]="colsVirtual"
+        [renderDataAsHTML]="renderAsHTML"
+        [showActionBtn]="true"
+        toolbarTitle="Table containing HTML"
+        actionBtnTitle="renderAsHTML is set to {{ renderAsHTML ? 'true' : 'false' }}"
+        (actionBtnClicked)="renderAsHTML = !renderAsHTML">
+      </cps-table>
+    </cps-tab>
   </cps-tab-group>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -347,14 +347,26 @@ export class TablePageComponent implements OnInit {
 
   selCols: { [key: string]: any }[] = [];
 
-  dataVirtual: { a: string; b: string; c: number; d: Date; e: boolean }[] = [];
+  dataVirtual: {
+    a: string;
+    b: string;
+    c: number;
+    d: Date;
+    e: boolean;
+    f: Date;
+  }[] = [];
 
   colsVirtual = [
     { field: 'a', header: 'String' },
     { field: 'b', header: 'String (only 5 distinct values)' },
     { field: 'c', header: 'Number' },
     { field: 'd', header: 'Date' },
-    { field: 'e', header: 'Boolean' }
+    { field: 'e', header: 'Boolean' },
+    {
+      field: 'f',
+      header: 'Date but with category filter',
+      filterType: 'category'
+    }
   ];
 
   componentData = ComponentData;
@@ -365,6 +377,10 @@ export class TablePageComponent implements OnInit {
   }
 
   private _genVirtualData() {
+    const sevenRandomDates = Array.from(
+      { length: 7 },
+      () => new Date(Math.round(Math.random() * 1e12))
+    );
     let c = 0.0;
     for (let i = 0; i <= 1000; i++) {
       this.dataVirtual.push({
@@ -372,7 +388,8 @@ export class TablePageComponent implements OnInit {
         b: 'b' + (i % 5),
         c,
         d: new Date(new Date().valueOf() - Math.random() * 1e12),
-        e: Math.random() > 0.5
+        e: Math.random() > 0.5,
+        f: sevenRandomDates[i % 7]
       });
 
       c = parseFloat((c += 0.1).toFixed(1));

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -347,12 +347,14 @@ export class TablePageComponent implements OnInit {
 
   selCols: { [key: string]: any }[] = [];
 
-  dataVirtual: { a: string; b: string; c: number }[] = [];
+  dataVirtual: { a: string; b: string; c: number; d: Date; e: boolean }[] = [];
 
   colsVirtual = [
-    { field: 'a', header: 'A' },
-    { field: 'b', header: 'B' },
-    { field: 'c', header: 'C' }
+    { field: 'a', header: 'String' },
+    { field: 'b', header: 'String (only 5 distinct values)' },
+    { field: 'c', header: 'Number' },
+    { field: 'd', header: 'Date' },
+    { field: 'e', header: 'Boolean' }
   ];
 
   componentData = ComponentData;
@@ -365,7 +367,13 @@ export class TablePageComponent implements OnInit {
   private _genVirtualData() {
     let c = 0.0;
     for (let i = 0; i <= 1000; i++) {
-      this.dataVirtual.push({ a: 'a' + i, b: 'b' + i, c });
+      this.dataVirtual.push({
+        a: 'a' + i,
+        b: 'b' + (i % 5),
+        c,
+        d: new Date(new Date().valueOf() - Math.random() * 1e12),
+        e: Math.random() > 0.5
+      });
 
       c = parseFloat((c += 0.1).toFixed(1));
     }

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -55,6 +55,21 @@ export class TablePageComponent implements OnInit {
 
   isRemoveBtnVisible = false;
 
+  renderAsHTML = true;
+
+  dataWithHTML = [
+    {
+      a: '<h1>hello</h1>',
+      b: '<h2>world</2>',
+      c: '<a href="https://www.github.com">link to github</a>'
+    },
+    {
+      a: 'this is sanitized <script>console.log("pwned")</script>',
+      b: '<img src="/assets/ui_logo.svg" width="100" />',
+      c: '<code>null === undefined</code>'
+    }
+  ];
+
   data = [
     {
       a: 'a1',

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -360,12 +360,13 @@ export class TablePageComponent implements OnInit {
     { field: 'a', header: 'String' },
     { field: 'b', header: 'String (only 5 distinct values)' },
     { field: 'c', header: 'Number' },
-    { field: 'd', header: 'Date' },
+    { field: 'd', header: 'Date', dateFormat: 'dd. MM. yyyy' },
     { field: 'e', header: 'Boolean' },
     {
       field: 'f',
       header: 'Date but with category filter',
-      filterType: 'category'
+      filterType: 'category',
+      dateFormat: 'yyyy/MM/dd HH:mm:ss'
     }
   ];
 

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
@@ -262,9 +262,15 @@
       </ng-container>
       <ng-container *ngIf="!bodyTemplate">
         <ng-container *ngIf="columns.length > 0">
-          <td *ngFor="let col of columns">
-            {{ rowData[col[colFieldName]] }}
-          </td>
+          @if (renderDataAsHTML) {
+            <td
+              *ngFor="let col of columns"
+              [innerHTML]="rowData[col[colFieldName]]"></td>
+          } @else {
+            <td *ngFor="let col of columns">
+              {{ rowData[col[colFieldName]] }}
+            </td>
+          }
         </ng-container>
       </ng-container>
       <td

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
@@ -206,9 +206,10 @@
               [cpsTColSortable]="col[colFieldName]"
               [cpsTColFilter]="col[colFieldName]"
               [filterType]="
-                autoColumnFilterType
+                col[colFilterTypeName] ??
+                (autoColumnFilterType
                   ? (data | cpsDetectFilterType: col[colFieldName])
-                  : 'text'
+                  : 'text')
               ">
               {{ col[colHeaderName] }}
             </th>
@@ -226,9 +227,10 @@
               *ngFor="let col of columns"
               [cpsTColFilter]="col[colFieldName]"
               [filterType]="
-                autoColumnFilterType
+                col[colFilterTypeName] ??
+                (autoColumnFilterType
                   ? (data | cpsDetectFilterType: col[colFieldName])
-                  : 'text'
+                  : 'text')
               ">
               {{ col[colHeaderName] }}
             </th>

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
@@ -299,7 +299,11 @@
               [innerHTML]="rowData[col[colFieldName]]"></td>
           } @else {
             <td *ngFor="let col of columns">
-              {{ rowData[col[colFieldName]] }}
+              {{
+                col[colDateFormatName]
+                  ? (rowData[col[colFieldName]] | date: col[colDateFormatName])
+                  : rowData[col[colFieldName]]
+              }}
             </td>
           }
         </ng-container>

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.html
@@ -200,14 +200,43 @@
       </ng-container>
       <ng-container *ngIf="!headerTemplate && columns.length > 0">
         <ng-container *ngIf="sortable">
-          <th *ngFor="let col of columns" [cpsTColSortable]="col[colFieldName]">
-            {{ col[colHeaderName] }}
-          </th>
+          @if (filterableByColumns) {
+            <th
+              *ngFor="let col of columns"
+              [cpsTColSortable]="col[colFieldName]"
+              [cpsTColFilter]="col[colFieldName]"
+              [filterType]="
+                autoColumnFilterType
+                  ? (data | cpsDetectFilterType: col[colFieldName])
+                  : 'text'
+              ">
+              {{ col[colHeaderName] }}
+            </th>
+          } @else {
+            <th
+              *ngFor="let col of columns"
+              [cpsTColSortable]="col[colFieldName]">
+              {{ col[colHeaderName] }}
+            </th>
+          }
         </ng-container>
         <ng-container *ngIf="!sortable">
-          <th *ngFor="let col of columns">
-            {{ col[colHeaderName] }}
-          </th>
+          @if (filterableByColumns) {
+            <th
+              *ngFor="let col of columns"
+              [cpsTColFilter]="col[colFieldName]"
+              [filterType]="
+                autoColumnFilterType
+                  ? (data | cpsDetectFilterType: col[colFieldName])
+                  : 'text'
+              ">
+              {{ col[colHeaderName] }}
+            </th>
+          } @else {
+            <th *ngFor="let col of columns">
+              {{ col[colHeaderName] }}
+            </th>
+          }
         </ng-container>
       </ng-container>
       <th

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -125,6 +125,12 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() colFilterTypeName = 'filterType';
 
   /**
+   * A key used to retrieve the date format from columns.
+   * @group Props
+   */
+  @Input() colDateFormatName = 'dateFormat';
+
+  /**
    * Determines whether the table should have alternating stripes.
    * @group Props
    */

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -212,7 +212,7 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
 
   /**
    * If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.
-   * Only applied when filterableByColumns is true.
+   * Note: This setting only takes effect if 'filterableByColumns' is true.
    * @group Props
    */
   @Input() autoColumnFilterType = true;

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -119,6 +119,12 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() colFieldName = 'field';
 
   /**
+   * A key used to retrieve the filter type from columns.
+   * @group Props
+   */
+  @Input() colFilterTypeName = 'filterType';
+
+  /**
    * Determines whether the table should have alternating stripes.
    * @group Props
    */

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -29,6 +29,8 @@ import { CpsTableColumnSortableDirective } from './directives/cps-table-column-s
 import { TableUnsortDirective } from './directives/internal/table-unsort.directive';
 import { convertSize } from '../../utils/internal/size-utils';
 import { isEqual } from 'lodash-es';
+import { CpsTableColumnFilterDirective } from './directives/cps-table-column-filter.directive';
+import { CpsDetectFilterTypePipe } from './pipes/cps-detect-filter-type.pipe';
 
 // import jsPDF from 'jspdf';
 // import 'jspdf-autotable';
@@ -81,7 +83,9 @@ export type CpsTableSortMode = 'single' | 'multiple';
     CpsMenuComponent,
     CpsLoaderComponent,
     TableRowMenuComponent,
-    CpsTableColumnSortableDirective
+    CpsTableColumnSortableDirective,
+    CpsTableColumnFilterDirective,
+    CpsDetectFilterTypePipe
   ],
   templateUrl: './cps-table.component.html',
   styleUrls: ['./cps-table.component.scss'],
@@ -199,6 +203,19 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
    * @group Props
    */
   @Input() sortable = false;
+
+  /**
+   * Enable filtering on all columns.
+   * @group Props
+   */
+  @Input() filterableByColumns = false;
+
+  /**
+   * If true, automatically detect filter type based on values, otherwise sets string filter type for all columns.
+   * Only applied when filterableByColumns is true.
+   * @group Props
+   */
+  @Input() autoColumnFilterType = true;
 
   /**
    * Determines whether sorting works on single column or on multiple columns.

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -211,7 +211,7 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() filterableByColumns = false;
 
   /**
-   * If true, automatically detect filter type based on values, otherwise sets string filter type for all columns.
+   * If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.
    * Only applied when filterableByColumns is true.
    * @group Props
    */

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -477,6 +477,12 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() initialColumns: { [key: string]: any }[] = [];
 
   /**
+   * If set to true, row data are rendered using innerHTML.
+   * @group Props
+   */
+  @Input() renderDataAsHTML = false;
+
+  /**
    * An array of objects to display.
    * @default []
    * @group Props

--- a/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/cps-table.component.ts
@@ -217,7 +217,7 @@ export class CpsTableComponent implements OnInit, AfterViewChecked, OnChanges {
   @Input() filterableByColumns = false;
 
   /**
-   * If true, automatically detects filter type based on values, otherwise sets string filter type for all columns.
+   * If true, automatically detects filter type based on values, otherwise sets 'text' filter type for all columns.
    * Note: This setting only takes effect if 'filterableByColumns' is true.
    * @group Props
    */

--- a/projects/cps-ui-kit/src/lib/components/cps-table/pipes/cps-detect-filter-type.pipe.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-table/pipes/cps-detect-filter-type.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CpsColumnFilterType } from '../cps-column-filter-types';
+
+@Pipe({
+  name: 'cpsDetectFilterType',
+  standalone: true
+})
+export class CpsDetectFilterTypePipe implements PipeTransform {
+  transform(
+    data: { [key: string]: unknown }[],
+    column: string
+  ): CpsColumnFilterType {
+    if (data.every((item) => typeof item[column] === 'boolean')) {
+      return 'boolean';
+    } else if (data.every((item) => typeof item[column] === 'number')) {
+      return 'number';
+    } else if (data.every((item) => item[column] instanceof Date)) {
+      return 'date';
+    } else if (
+      data.reduce((acc, item) => acc.add(item[column]), new Set()).size < 6
+    ) {
+      return 'category';
+    }
+    return 'text';
+  }
+}

--- a/projects/cps-ui-kit/src/public-api.ts
+++ b/projects/cps-ui-kit/src/public-api.ts
@@ -19,6 +19,7 @@ export * from './lib/components/cps-table/directives/cps-table-column-filter.dir
 export * from './lib/components/cps-table/directives/cps-table-header-selectable.directive';
 export * from './lib/components/cps-table/directives/cps-table-row-selectable.directive';
 export * from './lib/components/cps-table/cps-column-filter-types';
+export * from './lib/components/cps-table/pipes/cps-detect-filter-type.pipe';
 export * from './lib/components/cps-tree-table/cps-tree-table.component';
 export * from './lib/components/cps-tree-table/directives/cps-tree-table-column-sortable.directive';
 export * from './lib/components/cps-tree-table/directives/cps-tree-table-column-filter.directive';


### PR DESCRIPTION
- new input **renderDataAsHTML**, `false` by default, if set to `true`, data are rendered using `innerHTML` instead of `{{ }}` interpolation 
- new input **filterableByColumns** - enables filtering on all columns (by default filter type is automatically detected based on data, it is possible to turn this auto detection off by setting **autoColumnFilterType** to `false`, then all filters will behave as simple text filters, or one can define type of the filter for given column by adding `filterType` property to column object)
- new input **colFilterTypeName** - defines name of the property that might contain column filter type
- new input **autoColumnFilterType** - if true, automatically detects filter type based on values, otherwise sets 'text' filter type for all columns, takes effect only if **filterableByColumns** is true
- new input **colDateFormatName** - defines name of the property that might contain date format