### PR TITLE
Fix: Refactor CpsSchedulerComponent initialization

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
@@ -180,7 +180,9 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
   selectOptions = this._getSelectOptions();
   timeZoneOptions = timeZones.map((tz) => ({ label: tz, value: tz }));
   state: any;
-  form!: UntypedFormGroup;
+  form: UntypedFormGroup = this._fb.group({
+    advanced: ['', [this._validateAdvancedExpr]]
+  });
 
   private _isDirty = false;
   private _minutesDefault = '0/1 * 1/1 * ? *';
@@ -203,11 +205,8 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
       if (!this.cron) this.cron = this._minutesDefault;
     }
 
-    this.form = this._fb.group({
-      advanced: [
-        this.state.advanced.expression ?? '',
-        [this._validateAdvancedExpr]
-      ]
+    this.form.setValue({
+      advanced: this.state.advanced.expression ?? ''
     });
     this._handleModelChange(this.cron);
   }

--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
@@ -10,11 +10,11 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
+  FormBuilder,
   FormControl,
+  FormGroup,
   FormsModule,
   ReactiveFormsModule,
-  UntypedFormBuilder,
-  UntypedFormGroup,
   Validators
 } from '@angular/forms';
 import { timeZones } from './cps-scheduler.utils';
@@ -180,7 +180,7 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
   selectOptions = this._getSelectOptions();
   timeZoneOptions = timeZones.map((tz) => ({ label: tz, value: tz }));
   state: any;
-  form: UntypedFormGroup = this._fb.group({
+  form: FormGroup = this._fb.group({
     advanced: ['', [this._validateAdvancedExpr]]
   });
 
@@ -189,7 +189,7 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
 
   // eslint-disable-next-line no-useless-constructor
   constructor(
-    private _fb: UntypedFormBuilder,
+    private _fb: FormBuilder,
     private _cdr: ChangeDetectorRef
   ) {}
 
@@ -204,10 +204,6 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
       this.scheduleTypes.shift();
       if (!this.cron) this.cron = this._minutesDefault;
     }
-
-    this.form.setValue({
-      advanced: this.state.advanced.expression ?? ''
-    });
     this._handleModelChange(this.cron);
   }
 

--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
@@ -203,14 +203,13 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
       if (!this.cron) this.cron = this._minutesDefault;
     }
 
-    this._handleModelChange(this.cron);
-
     this.form = this._fb.group({
       advanced: [
         this.state.advanced.expression ?? '',
         [this._validateAdvancedExpr]
       ]
     });
+    this._handleModelChange(this.cron);
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
Title: Fix Uninitialized Form Control Error in CpsSchedulerComponent


## Problem
In the `CpsSchedulerComponent`, we encountered an issue where the form control was being accessed before it was initialized. This was happening when we set to 'Advanced'. The code was trying to set a value to the 'advanced' form control, but the form was not yet initialized, leading to a "Cannot read property of undefined" error.

![image](https://github.com/AbsaOSS/cps-shared-ui/assets/107909974/d1c98e5f-e948-4a0e-8fe8-884cf5a3062d)

### Error
To reproduce the error, change the cron expression value in the `SchedulerPageComponent`
![image](https://github.com/AbsaOSS/cps-shared-ui/assets/107909974/e9b389c2-6974-4a1c-a084-8e41b64f38b6)

