### PR TITLE
Update primeng version to 17.18.11 and align filter with update prime…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/lodash-es": "^4.17.12",
         "eslint-plugin-cypress": "^3.5.0",
         "lodash-es": "^4.17.21",
-        "primeng": "^17.18.7",
+        "primeng": "^17.18.11",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.3",
         "xlsx": "^0.18.5",
@@ -19935,9 +19935,9 @@
       }
     },
     "node_modules/primeng": {
-      "version": "17.18.7",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-17.18.7.tgz",
-      "integrity": "sha512-RKbUL69uTzDrVLOKxC8Qn7tyzoAUXetBsMOnNJJaomXTirC001vNTw/wzcuLxkTQpNXAOztxcKMpMTmZQMhe5Q==",
+      "version": "17.18.11",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-17.18.11.tgz",
+      "integrity": "sha512-LzV0fFZmb3GdnaRqi1+GP+RPtW0a+jztL5pH1zRWY7+7pyQ0n1YNyTXzmqVcdks/CmoyjNhutWEmexwi6vFVeA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/lodash-es": "^4.17.12",
     "eslint-plugin-cypress": "^3.5.0",
     "lodash-es": "^4.17.21",
-    "primeng": "^17.18.7",
+    "primeng": "^17.18.11",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
     "xlsx": "^0.18.5",

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
@@ -92,6 +92,7 @@
         [showRowMenu]="true"
         [showRowRemoveButton]="isRemoveBtnVisible"
         [showDataReloadBtn]="true"
+        [showGlobalFilter]="true"
         (rowsToRemove)="onRowsToRemove($event)"
         (editRowBtnClicked)="onEditRowButtonClicked()"
         (actionBtnClicked)="onActionBtnClicked()"

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
@@ -73,7 +73,7 @@ export class TreeTablePageComponent implements OnInit {
           children: [
             {
               data: {
-                name: 'angular.app',
+                name: 'angular.date',
                 size: 10,
                 modified: new Date(2020, 1, 11),
                 encrypted: true,
@@ -111,16 +111,16 @@ export class TreeTablePageComponent implements OnInit {
             },
             {
               data: {
-                name: 'cli.app',
+                name: 'cli.date_angular',
                 size: 10,
                 modified: new Date(2019, 2, 11),
                 encrypted: true,
-                importance: 'critical'
+                importance: 'date'
               }
             },
             {
               data: {
-                name: 'mobile.app',
+                name: 'date',
                 size: 50,
                 modified: new Date(2018, 9, 13),
                 encrypted: true,

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/internal/tree-table-unsort.directive.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/internal/tree-table-unsort.directive.ts
@@ -8,6 +8,15 @@ import { ObjectUtils } from 'primeng/utils';
 })
 export class TreeTableUnsortDirective {
   constructor(@Host() @Self() @Optional() public pTreeTable: TreeTable) {
+    this.sort(pTreeTable);
+    this.sortNodes(pTreeTable);
+    this.sortMultipleNodes(pTreeTable);
+    this.multisortField(pTreeTable);
+    this.filter(pTreeTable);
+    this.findFilteredNodes(pTreeTable);
+  }
+
+  sort(pTreeTable: TreeTable) {
     pTreeTable.sort = (event: any) => {
       if (pTreeTable.sortMode === 'single') {
         if (
@@ -59,7 +68,9 @@ export class TreeTableUnsortDirective {
         if (resetIndex) pTreeTable.multiSortMeta = [];
       }
     };
+  }
 
+  sortNodes(pTreeTable: TreeTable) {
     pTreeTable.sortNodes = (nodes) => {
       if (!nodes || nodes.length === 0) {
         return;
@@ -100,7 +111,9 @@ export class TreeTableUnsortDirective {
         if (node.children) pTreeTable.sortNodes(node.children);
       }
     };
+  }
 
+  sortMultipleNodes(pTreeTable: TreeTable) {
     pTreeTable.sortMultipleNodes = (nodes) => {
       if (!nodes || nodes.length === 0) {
         return;
@@ -129,7 +142,9 @@ export class TreeTableUnsortDirective {
         if (node.children) pTreeTable.sortMultipleNodes(node.children);
       }
     };
+  }
 
+  multisortField(pTreeTable: TreeTable) {
     pTreeTable.multisortField = (node1, node2, multiSortMeta, index) => {
       if (
         ObjectUtils.isEmpty(pTreeTable.multiSortMeta) ||
@@ -168,7 +183,9 @@ export class TreeTableUnsortDirective {
 
       return multiSortMeta[index].order * result;
     };
+  }
 
+  filter(pTreeTable: TreeTable) {
     pTreeTable._filter = () => {
       if (pTreeTable.lazy) {
         pTreeTable.onLazyLoad.emit(pTreeTable.createLazyLoadMetadata());
@@ -263,47 +280,44 @@ export class TreeTableUnsortDirective {
               !globalMatch &&
               globalFilterFieldsArray
             ) {
-              for (let j = 0; j < globalFilterFieldsArray.length; j++) {
-                const copyNodeForGlobal = { ...copyNode };
-                const filterField =
-                  globalFilterFieldsArray[j].field ||
-                  globalFilterFieldsArray[j];
-                const filterValue = pTreeTable.filters.global.value;
-                const filterConstraint =
-                  pTreeTable.filterService.filters[
-                    pTreeTable.filters.global
-                      .matchMode as keyof typeof pTreeTable.filterService.filters
-                  ];
-                paramsWithoutNode = {
-                  filterField,
-                  filterValue,
-                  filterConstraint,
-                  isStrictMode
-                };
+              const copyNodeForGlobal = { ...copyNode };
+              const filterField = undefined;
+              const filterValue = pTreeTable.filters.global.value;
+              const filterConstraint =
+                pTreeTable.filterService.filters[
+                  pTreeTable.filters.global
+                    .matchMode as keyof typeof pTreeTable.filterService.filters
+                ];
+              paramsWithoutNode = {
+                filterField,
+                filterValue,
+                filterConstraint,
+                isStrictMode,
+                globalFilterFieldsArray
+              };
 
-                if (
-                  (isStrictMode &&
-                    (pTreeTable.findFilteredNodes(
-                      copyNodeForGlobal,
-                      paramsWithoutNode
-                    ) ||
-                      pTreeTable.isFilterMatched(
-                        copyNodeForGlobal,
-                        paramsWithoutNode as any
-                      ))) ||
-                  (!isStrictMode &&
-                    (pTreeTable.isFilterMatched(
+              if (
+                (isStrictMode &&
+                  (pTreeTable.findFilteredNodes(
+                    copyNodeForGlobal,
+                    paramsWithoutNode
+                  ) ||
+                    pTreeTable.isFilterMatched(
                       copyNodeForGlobal,
                       paramsWithoutNode as any
-                    ) ||
-                      pTreeTable.findFilteredNodes(
-                        copyNodeForGlobal,
-                        paramsWithoutNode
-                      )))
-                ) {
-                  globalMatch = true;
-                  copyNode = copyNodeForGlobal;
-                }
+                    ))) ||
+                (!isStrictMode &&
+                  (pTreeTable.isFilterMatched(
+                    copyNodeForGlobal,
+                    paramsWithoutNode as any
+                  ) ||
+                    pTreeTable.findFilteredNodes(
+                      copyNodeForGlobal,
+                      paramsWithoutNode
+                    )))
+              ) {
+                globalMatch = true;
+                copyNode = copyNodeForGlobal;
               }
             }
 
@@ -355,7 +369,9 @@ export class TreeTableUnsortDirective {
         pTreeTable.resetScrollTop();
       }
     };
+  }
 
+  findFilteredNodes(pTreeTable: TreeTable) {
     pTreeTable.findFilteredNodes = (node, paramsWithoutNode): any => {
       if (node) {
         let matched = false;


### PR DESCRIPTION
## Fix Global Filter Issue in Tree-Table

Resolves #405 

### Description
This pull request addresses the issue where the global filter for the tree-table component was not returning all relevant results.

### Testing
1. Navigate to the **TreeTable** page.
2. In **Tree Table 3**, use the global search filter to search for a date.
3. Verify that the search returns all relevant results.
