### PR TITLE
Refactor file extension comparison logic to be case-insensitive

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CpsFileUploadComponent } from './cps-file-upload.component';
+
+describe('CpsFileUploadComponent', () => {
+  let component: CpsFileUploadComponent;
+  let fixture: ComponentFixture<CpsFileUploadComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [CpsFileUploadComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CpsFileUploadComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should upload a file', async () => {
+    fixture.autoDetectChanges();
+    const file = new File([''], 'testFile.JPG', { type: 'image/jpeg' });
+    component.extensions = ['.jpg'];
+    const fileUploadInput: HTMLInputElement =
+      fixture.nativeElement.querySelector('input[type="file"]');
+    // Create a mock DataTransfer object
+    const dataTransfer = {
+      files: [file],
+      items: {
+        add: (item: File) => {
+          dataTransfer.files.push(item);
+        }
+      }
+    };
+
+    // Simulate file upload
+    Object.defineProperty(fileUploadInput, 'files', {
+      value: dataTransfer.files,
+      writable: false
+    });
+    fileUploadInput.dispatchEvent(new Event('change'));
+    await fixture.whenStable();
+
+    expect(fileUploadInput.files && fileUploadInput.files[0]).toBe(file);
+  });
+
+  it('should convert extensions to lowercase and format them correctly', () => {
+    component.extensions = ['.JPG', 'PNG', 'gif'];
+    component.updateExtensionsString();
+
+    expect(component.extensions).toEqual(['.jpg', '.png', '.gif']);
+    expect(component.extensionsString).toBe('.jpg, .png, .gif');
+    expect(component.extensionsStringAsterisks).toBe('*.jpg, *.png, *.gif');
+  });
+});

--- a/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.ts
@@ -124,7 +124,7 @@ export class CpsFileUploadComponent implements OnInit, OnChanges {
 
   updateExtensionsString(): void {
     this.extensions = this.extensions.map((ext) =>
-      ext.startsWith('.') ? ext : '.' + ext
+      ext.startsWith('.') ? ext.toLowerCase() : '.' + ext.toLowerCase()
     );
     this.extensionsString = this.extensions.join(', ');
     this.extensionsStringAsterisks = this.extensions
@@ -186,9 +186,9 @@ export class CpsFileUploadComponent implements OnInit, OnChanges {
     if (!file) return false;
 
     if (this.extensions.length < 1) return true;
-
+    const fileNameLowerCase = file.name.toLowerCase();
     for (const ext of this.extensions) {
-      if (file.name.endsWith(ext)) return true;
+      if (fileNameLowerCase.endsWith(ext)) return true;
     }
 
     return false;


### PR DESCRIPTION
# Make File Upload Extension Case Insensitive and Handle Mixed Case

## Description

This pull request addresses the issue where file uploads were case-sensitive, causing inconsistencies and errors when users uploaded files with mixed-case extensions. The changes ensure that file extensions are treated in a case-insensitive manner, improving the user experience and reducing potential upload errors.

## Changes

- **File Upload Handling**: Updated the file upload logic to normalize file extensions to lowercase before processing.
- **Validation Logic**: Modified the validation logic to compare file extensions in a case-insensitive manner.
- **Unit Tests**: Added unit tests to cover various cases of file extensions, including mixed-case scenarios.