### PR TITLE
fix update cps-autocomplete component value

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -651,9 +651,8 @@ export class CpsAutocompleteComponent
 
   onBlur() {
     if (!this.isOpened) {
-      this._closeAndClear();
+      this._confirmInput(this.inputText || '', false);
     }
-
     this._checkErrors();
     this.blurred.emit();
   }
@@ -971,7 +970,10 @@ export class CpsAutocompleteComponent
     searchVal = searchVal.toLowerCase();
     if (!searchVal) {
       if (this.multiple) return;
-      this.updateValue(this._getEmptyValue());
+      // Only reset the value if the inputText was changed by the user
+      if (this.inputText !== this._getValueLabel()) {
+        this.updateValue(this._getEmptyValue());
+      }
       this.cdRef.detectChanges();
       this._closeAndClear();
       return;


### PR DESCRIPTION
This pull request introduces the following updates to the CpsAutocompleteComponent:

onBlur Method Update:

Modified the onBlur method to call _confirmInput instead of _closeAndClear when the component is not opened. This change ensures that input confirmation logic is executed instead of simply closing and clearing the input.

Value Reset Logic Enhancement:

Enhanced the logic for resetting the value in the component. Now, the value is only reset if the inputText has been changed by the user and does not match the current value label. This prevents unnecessary value resets and ensures that the component's state remains consistent with user input.
These changes improve the component's behavior by refining input handling and ensuring more accurate state management.