### PR TITLE
Fix change detection in TreeTable sorting

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
@@ -1343,6 +1343,7 @@ export class CpsTreeTableComponent
   onSort(event: any) {
     this.sorted.emit(event);
     setTimeout(() => {
+      this.cdRef.detectChanges();
       this._calcAutoLayoutHeaderWidths(true);
     });
   }


### PR DESCRIPTION
When using [event coalescing](https://angular.dev/api/core/NgZoneOptions#eventCoalescing), rows reordering and logic in `_calcAutoLayoutHeaderWidths` was rendered only once, causing columns to disappear. This PR introduces another change detection run that fixes this issue.

Closes #409