### PR TITLE
Fix button toggle navigation styling

### DIFF
--- a/projects/cps-ui-kit/package.json
+++ b/projects/cps-ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cps-ui-kit",
-  "version": "21.4.0",
+  "version": "21.4.1",
   "peerDependencies": {
     "@angular/common": "^21.2.6",
     "@angular/core": "^21.2.6",

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.scss
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.scss
@@ -68,17 +68,21 @@ $option-active-background: var(--cps-color-highlight-active);
       letter-spacing: 0.05em;
       color: $option-label-color;
       user-select: none;
-      transition: background-color 0.2s ease;
 
       &:hover {
         background: $option-hover-background;
+        transition: background-color 0.2s ease;
       }
 
       &:active {
         background: $option-active-background;
+        transition: background-color 0.2s ease;
       }
 
       &:focus-visible {
+        &:not(.is-selected):not(:active) {
+          background: $option-hover-background;
+        }
         z-index: 1;
       }
 


### PR DESCRIPTION
## Overview
1. Fixing the button toggle active state so it stays highlighted when focused via keyboard.
2. Fixing single-selection behavior: when tabbing to a non-selected button and pressing Space, it becomes selected, but the previously selected button briefly flashes the selected state.

## Release notes:
- Fix button toggle navigation styling
