### PR TITLE
Add zone.js ^0.16.0 to peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "primeng": "^21.1.3",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
-        "zone.js": "^0.15.1"
+        "zone.js": "~0.16.1"
       },
       "devDependencies": {
         "@angular-builders/jest": "^21.0.3",
@@ -23699,8 +23699,8 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.15.1",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "version": "0.16.1",
+      "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "primeng": "^21.1.3",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
-    "zone.js": "^0.15.1"
+    "zone.js": "~0.16.1"
   },
   "devDependencies": {
     "@angular-builders/jest": "^21.0.3",

--- a/projects/cps-ui-kit/package.json
+++ b/projects/cps-ui-kit/package.json
@@ -12,7 +12,7 @@
     "lodash-es": "^4.17.21",
     "primeng": "^21.1.3",
     "rxjs": "^7.8.2",
-    "zone.js": "^0.15.1"
+    "zone.js": "^0.15.1 || ^0.16.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Release notes:
- Add zone.js `^0.16.0` to supported peer dependency range