### PR TITLE
docs: respect browser font size preference in composition styles

### DIFF
--- a/projects/composition/src/styles.scss
+++ b/projects/composition/src/styles.scss
@@ -12,7 +12,7 @@ body {
   height: 100%;
   margin: 0;
   font-family: 'Source Sans Pro', sans-serif;
-  font-size: 16px;
+  font-size: 100%;
 }
 
 .composition-page {


### PR DESCRIPTION
Setting `font-size: 16px` on `html, body` overrides the user's browser font size preference, breaking accessibility for users who rely on a larger default. Replaced with `font-size: 100%` so the browser default is respected and rem-based sizing scales correctly.

Closes #573