### PR TITLE
Expose CpsCronValidationService publicly via an InjectionToken

### DIFF
--- a/api-generator/api-generator.js
+++ b/api-generator/api-generator.js
@@ -141,6 +141,9 @@ async function main() {
             const module_classes_group = module.groups.find(
               (g) => g.title === 'Classes'
             );
+            const module_tokens_group = module.groups.find(
+              (g) => g.title === 'Tokens'
+            );
             // Todo: Add support for type aliases
 
             if (isProcessable(module_components_group)) {
@@ -432,7 +435,7 @@ async function main() {
                 );
                 if (isProcessable(service_methods_group)) {
                   const methods = {
-                    description: 'Methods used in service.',
+                    description: 'Methods used in the service.',
                     values: []
                   };
 
@@ -464,6 +467,25 @@ async function main() {
                   doc[name].methods = methods;
                 }
               });
+            }
+
+            if (isProcessable(module_tokens_group)) {
+              const tokens = {
+                description: 'Injection tokens exposed by the service.',
+                values: []
+              };
+
+              module_tokens_group.children.forEach((token) => {
+                tokens.values.push({
+                  name: token.name,
+                  type: token.type ? token.type.toString() : 'InjectionToken',
+                  description:
+                    token.comment &&
+                    token.comment.summary.map((s) => s.text || '').join(' ')
+                });
+              });
+
+              doc[name].tokens = tokens;
             }
 
             if (isProcessable(module_interface_group)) {

--- a/projects/composition/src/app/api-data/cps-cron-validation.json
+++ b/projects/composition/src/app/api-data/cps-cron-validation.json
@@ -1,9 +1,9 @@
 {
     "components": {},
-    "name": "CronValidationService",
+    "name": "CpsCronValidationService",
     "description": "Service for validating 6-field cron expressions with extended features.\n\nThis service handles cron validation logic for extended cron expression formats\nthat support additional features beyond standard Unix cron for more flexible\nscheduling capabilities.\n\nFormat: minutes hours day-of-month month day-of-week year\n\nKey Features:\n- Wildcards: asterisk (any value), question mark (any value for day fields)\n- Ranges: 1-5, MON-FRI, JAN-MAR\n- Steps: asterisk/15, 5/10, 1-5/2\n- Lists: 1,3,5, MON,WED,FRI\n- Special chars: L (last), W (weekday), hash (nth occurrence)",
     "methods": {
-        "description": "Methods used in service.",
+        "description": "Methods used in the service.",
         "values": [
             {
                 "name": "isValidCron",
@@ -22,6 +22,16 @@
                 ],
                 "returnType": "boolean",
                 "description": "Validates a complete 6-field cron expression."
+            }
+        ]
+    },
+    "tokens": {
+        "description": "Injection tokens exposed by the service.",
+        "values": [
+            {
+                "name": "CPS_CRON_VALIDATION_SERVICE",
+                "type": "InjectionToken<CpsCronValidationService>",
+                "description": "Injection token for  `CpsCronValidationService` .\n\nAlways inject this token instead of  `CpsCronValidationService`  directly.\nThis allows consumer applications to override or disable cron validation by\nproviding an alternative implementation via  `providers` ."
             }
         ]
     }

--- a/projects/composition/src/app/api-data/cps-dialog.json
+++ b/projects/composition/src/app/api-data/cps-dialog.json
@@ -3,7 +3,7 @@
     "name": "CpsDialogService",
     "description": "Service for showing CpsDialog.",
     "methods": {
-        "description": "Methods used in service.",
+        "description": "Methods used in the service.",
         "values": [
             {
                 "name": "open",

--- a/projects/composition/src/app/api-data/cps-notification.json
+++ b/projects/composition/src/app/api-data/cps-notification.json
@@ -3,7 +3,7 @@
     "name": "CpsNotificationService",
     "description": "Service for showing notifications.",
     "methods": {
-        "description": "Methods used in service.",
+        "description": "Methods used in the service.",
         "values": [
             {
                 "name": "info",

--- a/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.html
+++ b/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.html
@@ -199,10 +199,12 @@
             <div>
               <table class="data-table">
                 <thead>
-                  <th>Name</th>
-                  <th>Parameters</th>
-                  <th>Return type</th>
-                  <th>Description</th>
+                  <tr>
+                    <th>Name</th>
+                    <th>Parameters</th>
+                    <th>Return type</th>
+                    <th>Description</th>
+                  </tr>
                 </thead>
                 <tbody>
                   @for (method of service.methods.values; track method) {
@@ -214,7 +216,9 @@
                         <div class="parameters">
                           @for (param of method.parameters; track param.name) {
                             <span>
-                              <strong [cpsTooltip]="param.description || ''">
+                              <strong
+                                [cpsTooltip]="param.description || ''"
+                                tabindex="0">
                                 {{ param.name }}:
                               </strong>
                               @if (param.type | detectType: TypesMap; as type) {
@@ -264,9 +268,11 @@
               <div>
                 <table class="data-table">
                   <thead>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Description</th>
+                    <tr>
+                      <th>Name</th>
+                      <th>Type</th>
+                      <th>Description</th>
+                    </tr>
                   </thead>
                   <tbody>
                     @for (token of tokens.values; track token.name) {

--- a/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.html
+++ b/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.html
@@ -187,5 +187,106 @@
       <!-- Enums -->
       <app-enums [enums]="componentData.enums"></app-enums>
     }
+    <!-- Services -->
+    @for (service of services; track service.name) {
+      <div>
+        <h1>{{ service.name }}</h1>
+        <p>{{ service.description }}</p>
+        @if (service.methods.values && service.methods.values.length > 0) {
+          <div>
+            <h2>Methods</h2>
+            <p>{{ service.methods.description }}</p>
+            <div>
+              <table class="data-table">
+                <thead>
+                  <th>Name</th>
+                  <th>Parameters</th>
+                  <th>Return type</th>
+                  <th>Description</th>
+                </thead>
+                <tbody>
+                  @for (method of service.methods.values; track method) {
+                    <tr>
+                      <td class="highlighted-bg">
+                        <span>{{ method.name }}</span>
+                      </td>
+                      <td class="highlighted-text">
+                        <div class="parameters">
+                          @for (param of method.parameters; track param.name) {
+                            <span>
+                              <strong [cpsTooltip]="param.description || ''">
+                                {{ param.name }}:
+                              </strong>
+                              @if (param.type | detectType: TypesMap; as type) {
+                                <a
+                                  [routerLink]="'/' + TypesMap[type] + '/api'"
+                                  fragment="{{ type }}">
+                                  {{ param.type }}
+                                </a>
+                              } @else {
+                                <span>{{ param.type }}</span>
+                              }
+                            </span>
+                          } @empty {
+                            null
+                          }
+                        </div>
+                      </td>
+                      <td class="highlighted-text">
+                        @if (
+                          method.returnType | detectType: TypesMap;
+                          as type
+                        ) {
+                          <a
+                            [routerLink]="'/' + TypesMap[type] + '/api'"
+                            fragment="{{ type }}">
+                            {{ method.returnType }}
+                          </a>
+                        } @else {
+                          <span>{{ method.returnType }}</span>
+                        }
+                      </td>
+                      <td class="method-description">
+                        {{ method.description }}
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          </div>
+        }
+        @if (service.tokens; as tokens) {
+          @if (tokens.values && tokens.values.length > 0) {
+            <div>
+              <h2>Tokens</h2>
+              <p>{{ tokens.description }}</p>
+              <div>
+                <table class="data-table">
+                  <thead>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Description</th>
+                  </thead>
+                  <tbody>
+                    @for (token of tokens.values; track token.name) {
+                      <tr>
+                        <td class="highlighted-bg">
+                          <span>{{ token.name }}</span>
+                        </td>
+                        <td class="highlighted-text">
+                          <span>{{ token.type }}</span>
+                        </td>
+                        <td>{{ token.description }}</td>
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          }
+        }
+      </div>
+    }
   </cps-tab>
 </cps-tab-group>

--- a/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.ts
+++ b/projects/composition/src/app/components/component-docs-viewer/component-docs-viewer.component.ts
@@ -5,7 +5,12 @@ import {
   InterfaceAPI,
   TypesAPI
 } from '../../models/component-api.model';
-import { CpsTabComponent, CpsTabGroupComponent } from 'cps-ui-kit';
+import { ServiceAPI } from '../../models/service-api.model';
+import {
+  CpsTabComponent,
+  CpsTabGroupComponent,
+  CpsTooltipDirective
+} from 'cps-ui-kit';
 import { ObjectEntriesPipe } from '../../pipes/object-entries.pipe';
 
 import TypesMap from '../../api-data/types_map.json';
@@ -24,7 +29,8 @@ import { EnumsComponent } from '../shared/enums/enums.component';
     ObjectEntriesPipe,
     RouterModule,
     DetectTypePipe,
-    EnumsComponent
+    EnumsComponent,
+    CpsTooltipDirective
   ]
 })
 export class ComponentDocsViewerComponent extends ViewerComponent {
@@ -34,6 +40,8 @@ export class ComponentDocsViewerComponent extends ViewerComponent {
     interfaces?: InterfaceAPI;
     enums?: EnumsAPI;
   };
+
+  @Input() services?: ServiceAPI[];
 
   TypesMap: Record<string, string> = TypesMap;
 

--- a/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
+++ b/projects/composition/src/app/components/service-docs-viewer/service-docs-viewer.component.html
@@ -38,7 +38,9 @@
                         <div class="parameters">
                           @for (param of method.parameters; track param.name) {
                             <span>
-                              <strong [cpsTooltip]="param.description || ''">
+                              <strong
+                                [cpsTooltip]="param.description || ''"
+                                tabindex="0">
                                 {{ param.name }}:
                               </strong>
                               @if (param.type | detectType: TypesMap; as type) {
@@ -242,7 +244,9 @@
                               track param.name
                             ) {
                               <span>
-                                <strong [cpsTooltip]="param.description || ''">
+                                <strong
+                                  [cpsTooltip]="param.description || ''"
+                                  tabindex="0">
                                   {{ param.name }}:
                                 </strong>
                                 @if (

--- a/projects/composition/src/app/models/service-api.model.ts
+++ b/projects/composition/src/app/models/service-api.model.ts
@@ -16,6 +16,17 @@ export interface MethodAPI {
   returnType: string;
 }
 
+export interface TokenAPI {
+  name: string;
+  type: string;
+  description: string;
+}
+
+export interface TokensAPI {
+  description: string;
+  values: TokenAPI[];
+}
+
 export interface ServiceAPI {
   name: string;
   description: string;
@@ -23,6 +34,7 @@ export interface ServiceAPI {
     description: string;
     values: MethodAPI[];
   };
+  tokens?: TokensAPI;
   types?: TypesAPI;
   interfaces?: InterfaceAPI;
   classes?: ClassesAPI;

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.html
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.html
@@ -1,4 +1,6 @@
-<app-component-docs-viewer [componentData]="componentData">
+<app-component-docs-viewer
+  [componentData]="componentData"
+  [services]="serviceData">
   <!-- Example of component's usage -->
   <cps-scheduler
     label="Frequency"

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CpsSchedulerComponent } from 'cps-ui-kit';
 import ComponentData from '../../api-data/cps-scheduler.json';
+import ServiceData from '../../api-data/cps-cron-validation.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
 
 @Component({
@@ -12,6 +13,7 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
 })
 export class SchedulerPageComponent {
   componentData = ComponentData;
+  serviceData = [ServiceData];
 
   cronExpression = '30 9 ? 7/4 WED#5 *';
   timeZone = 'UTC';

--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
@@ -18,7 +18,7 @@ import {
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
-import { CronValidationService } from '../../services/cron-validation.service';
+import { CPS_CRON_VALIDATION_SERVICE } from '../../services/cps-cron-validation/cps-cron-validation.service';
 import { CpsAutocompleteComponent } from '../cps-autocomplete/cps-autocomplete.component';
 import {
   CpsButtonToggleComponent,
@@ -186,7 +186,7 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
 
   private readonly _fb = inject(FormBuilder);
   private readonly _cdr = inject(ChangeDetectorRef);
-  private readonly _cronValidationService = inject(CronValidationService);
+  private readonly _cronValidationService = inject(CPS_CRON_VALIDATION_SERVICE);
 
   activeScheduleType = 'Not set';
   selectOptions = this._getSelectOptions();

--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.ts
@@ -423,7 +423,9 @@ export class CpsSchedulerComponent implements OnInit, OnChanges {
    * @returns boolean - True if the cron expression is valid
    */
   private _isValidCron(cron: string): boolean {
-    return this._cronValidationService.isValidCron(cron, this.showNotSet);
+    return (
+      this._cronValidationService?.isValidCron(cron, this.showNotSet) ?? true
+    );
   }
 
   private _validateAdvancedExpr(

--- a/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.spec.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
-import { CronValidationService } from './cron-validation.service';
+import {
+  CpsCronValidationService,
+  CPS_CRON_VALIDATION_SERVICE
+} from './cps-cron-validation.service';
 
-describe('CronValidationService', () => {
-  let service: CronValidationService;
+describe('CpsCronValidationService', () => {
+  let service: CpsCronValidationService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(CronValidationService);
+    service = TestBed.inject(CpsCronValidationService);
   });
 
   it('should be created', () => {
@@ -271,6 +274,39 @@ describe('CronValidationService', () => {
     it('should validate reporting schedules', () => {
       expect(service.isValidCron('0 8 1,15 * ? *')).toBe(true); // Bi-monthly
       expect(service.isValidCron('0 8 ? * MON#1 *')).toBe(true); // First Monday
+    });
+  });
+
+  describe('CPS_CRON_VALIDATION_SERVICE token', () => {
+    afterEach(() => {
+      TestBed.resetTestingModule();
+    });
+
+    it('should provide CpsCronValidationService by default', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const tokenService = TestBed.inject(CPS_CRON_VALIDATION_SERVICE);
+      expect(tokenService).toBeInstanceOf(CpsCronValidationService);
+    });
+
+    it('should allow overriding with a custom implementation', () => {
+      const customService = { isValidCron: () => true };
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: CPS_CRON_VALIDATION_SERVICE, useValue: customService }
+        ]
+      });
+      const tokenService = TestBed.inject(CPS_CRON_VALIDATION_SERVICE);
+      expect(tokenService.isValidCron('')).toBe(true);
+    });
+
+    it('should delegate isValidCron to the underlying service', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({});
+      const tokenService = TestBed.inject(CPS_CRON_VALIDATION_SERVICE);
+      expect(tokenService.isValidCron('0 12 * * ? *')).toBe(true);
+      expect(tokenService.isValidCron('invalid')).toBe(false);
     });
   });
 });

--- a/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.ts
@@ -492,10 +492,17 @@ export class CpsCronValidationService {
  * // Override with a custom implementation
  * providers: [{ provide: CPS_CRON_VALIDATION_SERVICE, useClass: MyCustomCronValidationService }]
  *
+ * @example
+ * // Disable cron validation entirely
+ * providers: [{ provide: CPS_CRON_VALIDATION_SERVICE, useValue: null }]
+ *
  * @group Tokens
  */
 export const CPS_CRON_VALIDATION_SERVICE =
-  new InjectionToken<CpsCronValidationService>('CPS_CRON_VALIDATION_SERVICE', {
-    providedIn: 'root',
-    factory: () => inject(CpsCronValidationService)
-  });
+  new InjectionToken<CpsCronValidationService | null>(
+    'CPS_CRON_VALIDATION_SERVICE',
+    {
+      providedIn: 'root',
+      factory: () => inject(CpsCronValidationService)
+    }
+  );

--- a/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 
 /**
  * Service for validating 6-field cron expressions with extended features.
@@ -21,7 +21,7 @@ import { Injectable } from '@angular/core';
 @Injectable({
   providedIn: 'root'
 })
-export class CronValidationService {
+export class CpsCronValidationService {
   /**
    * Validates a complete 6-field cron expression.
    *
@@ -41,7 +41,7 @@ export class CronValidationService {
       return false;
     }
 
-    return this.validateCronFields(parts);
+    return this._validateCronFields(parts);
   }
 
   /**
@@ -67,29 +67,30 @@ export class CronValidationService {
    * @param parts - Array of 6 cron field strings [minutes, hours, dayOfMonth, month, dayOfWeek, year]
    * @returns boolean - True if all fields are valid and follow extended cron rules
    */
-  private validateCronFields(parts: string[]): boolean {
+  private _validateCronFields(parts: string[]): boolean {
     const [minutes, hours, dayOfMonth, month, dayOfWeek, year] = parts;
 
     // Validate minutes (0-59) - use enhanced validation
-    if (!this.validateComplexField(minutes, 0, 59, 'minutes')) return false;
+    if (!this._validateComplexField(minutes, 0, 59, 'minutes')) return false;
 
     // Validate hours (0-23) - use enhanced validation
-    if (!this.validateComplexField(hours, 0, 23, 'hours')) return false;
+    if (!this._validateComplexField(hours, 0, 23, 'hours')) return false;
 
     // Validate day of month (1-31 or wildcards)
-    if (!this.validateDayOfMonth(dayOfMonth)) return false;
+    if (!this._validateDayOfMonth(dayOfMonth)) return false;
 
     // Validate month (1-12 or JAN-DEC) - use enhanced validation
-    if (!this.validateMonth(month)) return false;
+    if (!this._validateMonth(month)) return false;
 
     // Validate day of week (1-7 or SUN-SAT) - enhanced method will handle this
-    if (!this.validateDayOfWeek(dayOfWeek)) return false;
+    if (!this._validateDayOfWeek(dayOfWeek)) return false;
 
     // Validate year (1970-2199) - use enhanced validation
-    if (!this.validateComplexField(year, 1970, 2199, 'year')) return false;
+    if (!this._validateComplexField(year, 1970, 2199, 'year')) return false;
 
     // Validate mutual exclusivity of day-of-month and day-of-week
-    if (!this.validateDayMutualExclusivity(dayOfMonth, dayOfWeek)) return false;
+    if (!this._validateDayMutualExclusivity(dayOfMonth, dayOfWeek))
+      return false;
 
     return true;
   }
@@ -114,7 +115,7 @@ export class CronValidationService {
    * @param type - The cron field type ('minutes', 'hours', 'dayOfMonth', 'month', 'dayOfWeek', 'year')
    * @returns boolean - True if the field is valid according to EventBridge Scheduler rules
    */
-  private validateComplexField(
+  private _validateComplexField(
     field: string,
     min: number,
     max: number,
@@ -133,7 +134,7 @@ export class CronValidationService {
       return field.split(',').every((val) => {
         const trimmedVal = val.trim();
         // Recursively validate each part of the list
-        return this.validateComplexField(trimmedVal, min, max, type);
+        return this._validateComplexField(trimmedVal, min, max, type);
       });
     }
 
@@ -142,26 +143,26 @@ export class CronValidationService {
     if (field.includes('-') && field.includes('/')) {
       const [range, step] = field.split('/');
       const [start, end] = range.split('-');
-      return this.validateRangeWithStep(start, end, step, min, max, type);
+      return this._validateRangeWithStep(start, end, step, min, max, type);
     }
 
     // Handle simple range patterns: "1-5" (values from 1 to 5), "MON-FRI" (Monday to Friday)
     // Extended cron supports both numeric and named ranges for time-based scheduling
     if (field.includes('-')) {
       const [start, end] = field.split('-');
-      return this.validateSimpleRange(start, end, min, max, type);
+      return this._validateSimpleRange(start, end, min, max, type);
     }
 
     // Handle step patterns from start: "5/10" (every 10th value starting from 5)
     // Extended cron uses this for interval-based scheduling from a specific starting point
     if (field.includes('/')) {
       const [start, step] = field.split('/');
-      return this.validateStepField(start, step, min, max, type);
+      return this._validateStepField(start, step, min, max, type);
     }
 
     // Handle single values and special characters (L, W, #)
     // These provide advanced scheduling capabilities like "last day of month" or "3rd Tuesday"
-    return this.validateSingleValue(field, min, max, type);
+    return this._validateSingleValue(field, min, max, type);
   }
 
   /**
@@ -184,7 +185,7 @@ export class CronValidationService {
    * @param type - The cron field type for context-specific validation
    * @returns boolean - True if the value is valid for EventBridge Scheduler
    */
-  private validateSingleValue(
+  private _validateSingleValue(
     value: string,
     min: number,
     max: number,
@@ -208,22 +209,22 @@ export class CronValidationService {
       // 'MONL' = last Monday of month (last occurrence)
       if (value.endsWith('L')) {
         const day = value.slice(0, -1);
-        return this.isValidDayOfWeek(day);
+        return this._isValidDayOfWeek(day);
       }
       // '3#2' = 3rd Tuesday of month (3=Tuesday, 2=second occurrence)
       if (value.includes('#')) {
         const [day, week] = value.split('#');
         return (
-          this.isValidDayOfWeek(day) && Number(week) >= 1 && Number(week) <= 5
+          this._isValidDayOfWeek(day) && Number(week) >= 1 && Number(week) <= 5
         );
       }
       // Standard day names: SUN, MON, TUE, etc.
-      if (this.isValidDayOfWeek(value)) return true;
+      if (this._isValidDayOfWeek(value)) return true;
     }
 
     // Handle month names (JAN, FEB, MAR, etc.) for month field
     // Extended cron allows both numeric (1-12) and named month values
-    if (type === 'month' && this.isValidMonthName(value)) return true;
+    if (type === 'month' && this._isValidMonthName(value)) return true;
 
     // Validate numeric values within the specified range
     // This covers standard numeric scheduling (minutes: 0-59, hours: 0-23, etc.)
@@ -248,7 +249,7 @@ export class CronValidationService {
    * @param type - Field type for context-aware validation (dayOfWeek gets special handling)
    * @returns boolean - True if the range-step pattern is valid for EventBridge
    */
-  private validateRangeWithStep(
+  private _validateRangeWithStep(
     start: string,
     end: string,
     step: string,
@@ -261,20 +262,20 @@ export class CronValidationService {
     if (isNaN(stepNum) || stepNum <= 0) return false;
 
     // Special handling for day-of-week ranges (supports named days like MON-FRI)
-    // Extended cron allows both numeric (1-7) and named (SUN-SAT) day ranges
+    // Extended cron allows both numeric (1-7) and named day ranges
     if (type === 'dayOfWeek') {
-      return this.isValidDayOfWeek(start) && this.isValidDayOfWeek(end);
+      return this._isValidDayOfWeek(start) && this._isValidDayOfWeek(end);
     }
 
     // Special handling for month ranges (supports named months like JAN-DEC)
-    // Extended cron allows both numeric (1-12) and named (JAN-DEC) month ranges
+    // Extended cron allows both numeric (1-12) and named month ranges
     if (type === 'month') {
       const startValid =
-        this.isValidMonthName(start) ||
-        this.validateSingleValue(start, min, max, type);
+        this._isValidMonthName(start) ||
+        this._validateSingleValue(start, min, max, type);
       const endValid =
-        this.isValidMonthName(end) ||
-        this.validateSingleValue(end, min, max, type);
+        this._isValidMonthName(end) ||
+        this._validateSingleValue(end, min, max, type);
       return startValid && endValid;
     }
 
@@ -310,7 +311,7 @@ export class CronValidationService {
    * @param type - Field type for validation context (affects named value handling)
    * @returns boolean - True if the range pattern is valid for EventBridge
    */
-  private validateSimpleRange(
+  private _validateSimpleRange(
     start: string,
     end: string,
     min: number,
@@ -320,18 +321,18 @@ export class CronValidationService {
     // Handle day-of-week ranges with named values (MON-FRI, SUN-SAT, etc.)
     // Extended cron supports both numeric (1-7) and named day ranges
     if (type === 'dayOfWeek') {
-      return this.isValidDayOfWeek(start) && this.isValidDayOfWeek(end);
+      return this._isValidDayOfWeek(start) && this._isValidDayOfWeek(end);
     }
 
     // Handle month ranges with named values (JAN-DEC, etc.)
     // Extended cron allows both numeric (1-12) and named month ranges
     if (type === 'month') {
       const startValid =
-        this.isValidMonthName(start) ||
-        this.validateSingleValue(start, min, max, type);
+        this._isValidMonthName(start) ||
+        this._validateSingleValue(start, min, max, type);
       const endValid =
-        this.isValidMonthName(end) ||
-        this.validateSingleValue(end, min, max, type);
+        this._isValidMonthName(end) ||
+        this._validateSingleValue(end, min, max, type);
       return startValid && endValid;
     }
 
@@ -367,7 +368,7 @@ export class CronValidationService {
    * @param type - Field type for validation context
    * @returns boolean - True if the step pattern is valid for EventBridge
    */
-  private validateStepField(
+  private _validateStepField(
     start: string,
     step: string,
     min: number,
@@ -385,7 +386,7 @@ export class CronValidationService {
     // Handle named day values for day-of-week step patterns
     // Extended cron supports patterns like "MON/2" (every 2nd occurrence starting Monday)
     if (type === 'dayOfWeek') {
-      return this.isValidDayOfWeek(start);
+      return this._isValidDayOfWeek(start);
     }
 
     // Validate numeric start values - must be within field's valid range
@@ -397,21 +398,21 @@ export class CronValidationService {
   /**
    * Validates day-of-month field with special characters.
    */
-  private validateDayOfMonth(dayOfMonth: string): boolean {
-    return this.validateComplexField(dayOfMonth, 1, 31, 'dayOfMonth');
+  private _validateDayOfMonth(dayOfMonth: string): boolean {
+    return this._validateComplexField(dayOfMonth, 1, 31, 'dayOfMonth');
   }
 
   /**
    * Validates month field with support for named months.
    */
-  private validateMonth(month: string): boolean {
-    return this.validateComplexField(month, 1, 12, 'month');
+  private _validateMonth(month: string): boolean {
+    return this._validateComplexField(month, 1, 12, 'month');
   }
 
   /**
    * Validates day-of-week field with support for named days and special characters.
    */
-  private validateDayOfWeek(dayOfWeek: string): boolean {
+  private _validateDayOfWeek(dayOfWeek: string): boolean {
     // Check for multiple hash expressions in day-of-week field
     if (dayOfWeek.includes(',') && dayOfWeek.includes('#')) {
       const parts = dayOfWeek.split(',');
@@ -425,14 +426,14 @@ export class CronValidationService {
       }
     }
 
-    return this.validateComplexField(dayOfWeek, 1, 7, 'dayOfWeek');
+    return this._validateComplexField(dayOfWeek, 1, 7, 'dayOfWeek');
   }
 
   /**
    * Validates mutual exclusivity rule for day-of-month and day-of-week fields.
    * Extended cron requires that one of these fields must be a wildcard.
    */
-  private validateDayMutualExclusivity(
+  private _validateDayMutualExclusivity(
     dayOfMonth: string,
     dayOfWeek: string
   ): boolean {
@@ -446,7 +447,7 @@ export class CronValidationService {
   /**
    * Checks if a value represents a valid day of the week (numeric or named).
    */
-  private isValidDayOfWeek(day: string): boolean {
+  private _isValidDayOfWeek(day: string): boolean {
     const validDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
     if (validDays.includes(day.toUpperCase())) return true;
 
@@ -457,7 +458,7 @@ export class CronValidationService {
   /**
    * Checks if a value represents a valid month name.
    */
-  private isValidMonthName(month: string): boolean {
+  private _isValidMonthName(month: string): boolean {
     const validMonths = [
       'JAN',
       'FEB',
@@ -475,3 +476,26 @@ export class CronValidationService {
     return validMonths.includes(month.toUpperCase());
   }
 }
+
+/**
+ * Injection token for `CpsCronValidationService`.
+ *
+ * Always inject this token instead of `CpsCronValidationService` directly.
+ * This allows consumer applications to override or disable cron validation by
+ * providing an alternative implementation via `providers`.
+ *
+ * @example
+ * // Inject in a component or service
+ * private readonly cronValidation = inject(CPS_CRON_VALIDATION_SERVICE);
+ *
+ * @example
+ * // Override with a custom implementation
+ * providers: [{ provide: CPS_CRON_VALIDATION_SERVICE, useClass: MyCustomCronValidationService }]
+ *
+ * @group Tokens
+ */
+export const CPS_CRON_VALIDATION_SERVICE =
+  new InjectionToken<CpsCronValidationService>('CPS_CRON_VALIDATION_SERVICE', {
+    providedIn: 'root',
+    factory: () => inject(CpsCronValidationService)
+  });

--- a/projects/cps-ui-kit/src/public-api.ts
+++ b/projects/cps-ui-kit/src/public-api.ts
@@ -60,4 +60,6 @@ export * from './lib/services/cps-notification/cps-notification.service';
 export * from './lib/services/cps-notification/utils/cps-notification-config';
 
 export * from './lib/services/cps-theme/cps-theme.service';
+export * from './lib/services/cps-cron-validation/cps-cron-validation.service';
+
 export * from './lib/utils/colors-utils';


### PR DESCRIPTION
## Overview
1) Renamed `CronValidationService` to `CpsCronValidationService`
2) Moved it from `cps-ui-kit/src/lib/services/cron-validation.service.ts` to `cps-ui-kit/src/lib/services/cps-cron-validation/cps-cron-validation.service.ts`
3) Created `CPS_CRON_VALIDATION_SERVICE` injection token, so it can be reimplemented/disabled by consumer apps
4) Injected the token to `CpsSchedulerComponent`
5) Exposed it through `public-api.ts`
6) Added the service API to the Scheduler component page in the composition app

---

## Release notes:
- Publicly exposing CpsCronValidationService via an InjectionToken