### PR TITLE
Add code examples for chip

### DIFF
--- a/projects/composition/src/app/pages/chip-page/chip-page.component.html
+++ b/projects/composition/src/app/pages/chip-page/chip-page.component.html
@@ -1,18 +1,31 @@
 <app-component-docs-viewer [componentData]="componentData">
-  <!-- Example of component's usage -->
-  <div class="chips-group">
-    <cps-chip label="Basic chip"></cps-chip>
-    <cps-chip label="Left icon chip" icon="checked"></cps-chip>
-    <cps-chip
-      label="Right icon chip"
-      icon="checked"
-      iconPosition="after"></cps-chip>
-    <cps-chip label="Disabled chip" icon="eye" [disabled]="true"></cps-chip>
-    <cps-chip
-      label="Chip with colored icon"
-      icon="avatar"
-      iconColor="success"></cps-chip>
-    <div>
+  <app-code-example label="Basic" [htmlCode]="examples.basic.html">
+    <div class="chips-group-row">
+      <cps-chip label="Basic chip"></cps-chip>
+      <cps-chip label="Disabled chip" [disabled]="true"></cps-chip>
+    </div>
+  </app-code-example>
+
+  <app-code-example label="With icon" [htmlCode]="examples.withIcon.html">
+    <div class="chips-group-row">
+      <cps-chip label="Left icon chip" icon="checked"></cps-chip>
+      <cps-chip
+        label="Right icon chip"
+        icon="checked"
+        iconPosition="after"></cps-chip>
+      <cps-chip
+        label="Chip with colored icon"
+        icon="avatar"
+        iconColor="success"></cps-chip>
+      <cps-chip label="Disabled chip" icon="eye" [disabled]="true"></cps-chip>
+    </div>
+  </app-code-example>
+
+  <app-code-example
+    label="Closable"
+    [htmlCode]="examples.closable.html"
+    [tsCode]="examples.closable.ts">
+    <div class="chips-group-row">
       @if (!chipClosed) {
         <cps-chip
           label="Closable chip"
@@ -26,5 +39,5 @@
           size="xsmall"></cps-button>
       }
     </div>
-  </div>
+  </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/chip-page/chip-page.component.scss
+++ b/projects/composition/src/app/pages/chip-page/chip-page.component.scss
@@ -1,8 +1,7 @@
-.chips-group {
-  gap: 2rem;
+.chips-group-row {
   display: flex;
-  flex-direction: column;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  margin-bottom: 0.5rem;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
 }

--- a/projects/composition/src/app/pages/chip-page/chip-page.component.ts
+++ b/projects/composition/src/app/pages/chip-page/chip-page.component.ts
@@ -3,9 +3,16 @@ import { CpsButtonComponent, CpsChipComponent } from 'cps-ui-kit';
 
 import ComponentData from '../../api-data/cps-chip.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { chipExamples } from './chip-page.examples';
 
 @Component({
-  imports: [CpsChipComponent, CpsButtonComponent, ComponentDocsViewerComponent],
+  imports: [
+    CpsChipComponent,
+    CpsButtonComponent,
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
+  ],
   selector: 'app-chip-page',
   templateUrl: './chip-page.component.html',
   styleUrls: ['./chip-page.component.scss'],
@@ -14,6 +21,8 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
 export class ChipPageComponent {
   chipClosed = false;
   componentData = ComponentData;
+
+  readonly examples = chipExamples;
 
   onToggleChip() {
     this.chipClosed = !this.chipClosed;

--- a/projects/composition/src/app/pages/chip-page/chip-page.examples.ts
+++ b/projects/composition/src/app/pages/chip-page/chip-page.examples.ts
@@ -1,0 +1,44 @@
+export const chipExamples: Record<string, { html: string; ts?: string }> = {
+  basic: {
+    html: `
+<cps-chip label="Basic chip"></cps-chip>
+<cps-chip label="Disabled chip" [disabled]="true"></cps-chip>`
+  },
+
+  withIcon: {
+    html: `
+<!-- Icon before label (default) -->
+<cps-chip label="Left icon chip" icon="checked"></cps-chip>
+
+<!-- Icon after label -->
+<cps-chip label="Right icon chip" icon="checked" iconPosition="after"></cps-chip>
+
+<!-- Colored icon -->
+<cps-chip label="Chip with colored icon" icon="avatar" iconColor="success"></cps-chip>
+
+<!-- Disabled with icon -->
+<cps-chip label="Disabled chip" icon="eye" [disabled]="true"></cps-chip>`
+  },
+
+  closable: {
+    html: `
+@if (!chipClosed) {
+  <cps-chip
+    label="Closable chip"
+    [closable]="true"
+    (closed)="onToggleChip()"></cps-chip>
+}
+@if (chipClosed) {
+  <cps-button
+    label="Reset chip"
+    (clicked)="onToggleChip()"
+    size="xsmall"></cps-button>
+}`,
+    ts: `
+chipClosed = false;
+
+onToggleChip(): void {
+  this.chipClosed = !this.chipClosed;
+}`
+  }
+};


### PR DESCRIPTION
Adds live code examples to the Chip component's documentation page.

Closes #617 