### PR TITLE
Integrate `CpsRootFontSizeService` into components

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
@@ -203,7 +203,7 @@
         aria-orientation="vertical"
         [attr.aria-multiselectable]="!!multiple"
         class="cps-autocomplete-options"
-        [style.width.rem]="autocompleteBoxWidthRem">
+        [style.width.px]="autocompleteBoxWidthPx">
         @if (loading && showLoadingMessage) {
           <div
             class="cps-autocomplete-options-loading"
@@ -262,7 +262,7 @@
               [delay]="0"
               [scrollHeight]="virtualListHeightRem + 'rem'"
               [options]="{ numToleratedItems: numToleratedItems }"
-              [itemSize]="virtualScrollItemSizePx">
+              [itemSize]="virtualScrollItemSizePx()">
               <ng-template pTemplate="item" let-item let-options="options">
                 <ng-container
                   *ngTemplateOutlet="

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -1,4 +1,4 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -15,8 +15,9 @@ import { CpsMenuHideReason } from '../cps-menu/cps-menu.component';
 import { CpsAutocompleteComponent } from './cps-autocomplete.component';
 import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 
+const mockFontSize = signal(16);
 const mockRootFontSizeService = {
-  fontSize: () => 16
+  fontSize: mockFontSize.asReadonly()
 };
 
 describe('CpsAutocompleteComponent', () => {
@@ -55,8 +56,17 @@ describe('CpsAutocompleteComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    mockFontSize.set(16);
+  });
+
   it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should update virtualScrollItemSizePx when root font size changes', () => {
+    mockFontSize.set(20);
+    expect(component.virtualScrollItemSizePx()).toBe(20 * 2.75);
   });
 
   it('should display the label when provided', () => {

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -13,6 +13,11 @@ import { CheckOptionSelectedPipe } from '../../pipes/internal/check-option-selec
 import { LabelByValuePipe } from '../../pipes/internal/label-by-value.pipe';
 import { CpsMenuHideReason } from '../cps-menu/cps-menu.component';
 import { CpsAutocompleteComponent } from './cps-autocomplete.component';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
+
+const mockRootFontSizeService = {
+  fontSize: () => 16
+};
 
 describe('CpsAutocompleteComponent', () => {
   let component: CpsAutocompleteComponent;
@@ -26,7 +31,14 @@ describe('CpsAutocompleteComponent', () => {
         CpsAutocompleteComponent,
         NoopAnimationsModule
       ],
-      providers: [LabelByValuePipe, CheckOptionSelectedPipe],
+      providers: [
+        LabelByValuePipe,
+        CheckOptionSelectedPipe,
+        {
+          provide: CPS_ROOT_FONT_SIZE_SERVICE,
+          useValue: mockRootFontSizeService
+        }
+      ],
       schemas: [NO_ERRORS_SCHEMA] // Ignore unknown elements and attributes
     }).compileComponents();
   });

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  computed,
   ElementRef,
   EventEmitter,
   inject,
@@ -47,7 +48,6 @@ import {
 } from '../cps-menu/cps-menu.component';
 import { Scroller, ScrollerModule } from 'primeng/scroller';
 
-const DEFAULT_VIRTUAL_SCROLL_ITEM_SIZE_PX = 44;
 const VIRTUAL_SCROLL_ITEM_SIZE_REM = 2.75;
 const VIRTUAL_SCROLL_MAX_VISIBLE_ITEMS = 5.5;
 
@@ -428,11 +428,16 @@ export class CpsAutocompleteComponent
   activeSingle = false;
   optionHighlightedIndex = -1;
 
-  virtualScrollItemSizePx = DEFAULT_VIRTUAL_SCROLL_ITEM_SIZE_PX;
+  readonly virtualScrollItemSizePx = computed(
+    () =>
+      (this._cpsRootFontSizeService?.fontSize() ?? 16) *
+      VIRTUAL_SCROLL_ITEM_SIZE_REM
+  );
+
   virtualListHeightRem =
     VIRTUAL_SCROLL_ITEM_SIZE_REM * VIRTUAL_SCROLL_MAX_VISIBLE_ITEMS;
 
-  autocompleteBoxWidthRem = 0;
+  autocompleteBoxWidthPx = 0;
   resizeObserver: ResizeObserver;
 
   isTimePickerField = false;
@@ -447,9 +452,6 @@ export class CpsAutocompleteComponent
   );
 
   private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
-  private get _rootFontSizePx(): number {
-    return this._cpsRootFontSizeService?.fontSize() ?? 16;
-  }
 
   private _inputChangeSubject$ = new Subject<string>();
   private _destroy$ = new Subject<void>();
@@ -468,19 +470,14 @@ export class CpsAutocompleteComponent
     this.resizeObserver = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         if (entry?.target)
-          this.autocompleteBoxWidthRem = this._pxToRem(
-            (entry.target as any).offsetWidth
-          );
+          this.autocompleteBoxWidthPx = (entry.target as any).offsetWidth;
       });
     });
   }
 
   ngOnInit() {
-    this.virtualScrollItemSizePx =
-      this._rootFontSizePx * VIRTUAL_SCROLL_ITEM_SIZE_REM;
     this.virtualListHeightRem =
       VIRTUAL_SCROLL_ITEM_SIZE_REM * VIRTUAL_SCROLL_MAX_VISIBLE_ITEMS;
-    this.cvtWidth = convertSize(this.width);
     if (this.multiple && !this._value) {
       this._value = [];
     }
@@ -508,6 +505,9 @@ export class CpsAutocompleteComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    if (changes.width) {
+      this.cvtWidth = convertSize(this.width);
+    }
     if (changes.options) {
       this.filteredOptions = this.options;
       this.recalcVirtualListHeight();
@@ -840,6 +840,7 @@ export class CpsAutocompleteComponent
     this.virtualListHeightRem =
       VIRTUAL_SCROLL_ITEM_SIZE_REM *
       Math.min(currentLen, VIRTUAL_SCROLL_MAX_VISIBLE_ITEMS);
+    this.virtualList?.setSpacerSize();
   }
 
   isEmptyValue(): boolean {
@@ -1120,8 +1121,8 @@ export class CpsAutocompleteComponent
       return;
     }
 
-    const itemTop = index * this.virtualScrollItemSizePx;
-    const itemBottom = itemTop + this.virtualScrollItemSizePx;
+    const itemTop = index * this.virtualScrollItemSizePx();
+    const itemBottom = itemTop + this.virtualScrollItemSizePx();
 
     const viewportTop = scrollerEl.scrollTop;
     const viewportBottom = viewportTop + scrollerEl.clientHeight;
@@ -1193,9 +1194,5 @@ export class CpsAutocompleteComponent
     setTimeout(() => {
       this.focusInput();
     }, 0);
-  }
-
-  private _pxToRem(px: number): number {
-    return px / this._rootFontSizePx;
   }
 }

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -1,11 +1,11 @@
-import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
-  Inject,
+  inject,
   Input,
   OnChanges,
   OnDestroy,
@@ -14,7 +14,6 @@ import {
   Output,
   Self,
   ViewChild,
-  PLATFORM_ID,
   type SimpleChanges
 } from '@angular/core';
 import {
@@ -25,6 +24,7 @@ import {
 } from '@angular/forms';
 import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 import { convertSize } from '../../utils/internal/size-utils';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 import {
   generateUniqueId,
   getComputedLabel
@@ -446,7 +446,10 @@ export class CpsAutocompleteComponent
     'cps-autocomplete-option'
   );
 
-  private _rootFontSizePx = 16;
+  private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
+  private get _rootFontSizePx(): number {
+    return this._cpsRootFontSizeService?.fontSize() ?? 16;
+  }
 
   private _inputChangeSubject$ = new Subject<string>();
   private _destroy$ = new Subject<void>();
@@ -456,8 +459,6 @@ export class CpsAutocompleteComponent
 
   constructor(
     @Self() @Optional() private _control: NgControl,
-    @Inject(DOCUMENT) private document: Document,
-    @Inject(PLATFORM_ID) private platformId: object,
     private cdRef: ChangeDetectorRef,
     private _labelByValue: LabelByValuePipe
   ) {
@@ -475,11 +476,6 @@ export class CpsAutocompleteComponent
   }
 
   ngOnInit() {
-    if (isPlatformBrowser(this.platformId)) {
-      this._rootFontSizePx = parseFloat(
-        getComputedStyle(this.document.documentElement).fontSize || '16'
-      );
-    }
     this.virtualScrollItemSizePx =
       this._rootFontSizePx * VIRTUAL_SCROLL_ITEM_SIZE_REM;
     this.virtualListHeightRem =

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.spec.ts
@@ -1,13 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SimpleChange } from '@angular/core';
+import { signal, SimpleChange } from '@angular/core';
 import {
   CpsButtonToggleComponent,
   CpsButtonToggleOption
 } from './cps-button-toggle.component';
 import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 
+const mockFontSize = signal(16);
+
 const mockRootFontSizeService = {
-  fontSize: () => 16
+  fontSize: mockFontSize.asReadonly()
 };
 
 const OPTIONS: CpsButtonToggleOption[] = [
@@ -35,6 +37,10 @@ describe('CpsButtonToggleComponent', () => {
     component = fixture.componentInstance;
     fixture.componentRef.setInput('options', OPTIONS);
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    mockFontSize.set(16);
   });
 
   it('should create', () => {
@@ -353,12 +359,12 @@ describe('CpsButtonToggleComponent', () => {
     it('should not modify largestButtonWidthRem when equalWidths is false', () => {
       component.largestButtonWidthRem = 5;
       fixture.componentRef.setInput('equalWidths', false);
-      (component as any)._setEqualWidths();
+      (component as any)._setEqualWidths(16);
       expect(component.largestButtonWidthRem).toBe(5);
     });
 
     it('should set largestButtonWidthRem to padding baseline when all option labels have offsetWidth=0', () => {
-      (component as any)._setEqualWidths();
+      (component as any)._setEqualWidths(16);
       expect(component.largestButtonWidthRem).toBeCloseTo(1.625);
     });
 
@@ -366,7 +372,7 @@ describe('CpsButtonToggleComponent', () => {
       fixture.componentRef.setInput('options', [
         { value: 'a', icon: 'home', label: 'Home' }
       ]);
-      (component as any)._setEqualWidths();
+      (component as any)._setEqualWidths(16);
       expect(component.largestButtonWidthRem).toBeCloseTo(3.125);
     });
 
@@ -374,7 +380,7 @@ describe('CpsButtonToggleComponent', () => {
       fixture.componentRef.setInput('options', [
         { value: 'a', icon: 'home', ariaLabel: 'Home' }
       ]);
-      (component as any)._setEqualWidths();
+      (component as any)._setEqualWidths(16);
       expect(component.largestButtonWidthRem).toBeCloseTo(2.625);
     });
 
@@ -383,8 +389,16 @@ describe('CpsButtonToggleComponent', () => {
         { value: 'a', label: 'Alpha' },
         { value: 'b', icon: 'home', label: 'Beta' }
       ]);
-      (component as any)._setEqualWidths();
+      (component as any)._setEqualWidths(16);
       expect(component.largestButtonWidthRem).toBeCloseTo(3.125);
+    });
+
+    it('should recalculate equal widths when root font size signal changes', async () => {
+      const spy = jest.spyOn(component as any, '_setEqualWidths');
+      mockFontSize.set(20);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(spy).toHaveBeenCalledWith(20);
     });
   });
 });

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.spec.ts
@@ -1,0 +1,390 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import {
+  CpsButtonToggleComponent,
+  CpsButtonToggleOption
+} from './cps-button-toggle.component';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
+
+const mockRootFontSizeService = {
+  fontSize: () => 16
+};
+
+const OPTIONS: CpsButtonToggleOption[] = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+  { value: 'c', label: 'Gamma' }
+];
+
+describe('CpsButtonToggleComponent', () => {
+  let component: CpsButtonToggleComponent;
+  let fixture: ComponentFixture<CpsButtonToggleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CpsButtonToggleComponent],
+      providers: [
+        {
+          provide: CPS_ROOT_FONT_SIZE_SERVICE,
+          useValue: mockRootFontSizeService
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CpsButtonToggleComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('options', OPTIONS);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('default values', () => {
+    it('should have correct default input values', () => {
+      expect(component.label).toBe('');
+      expect(component.ariaLabel).toBe('');
+      expect(component.multiple).toBe(false);
+      expect(component.disabled).toBe(false);
+      expect(component.mandatory).toBe(true);
+      expect(component.equalWidths).toBe(true);
+      expect(component.optionTooltipPosition).toBe('bottom');
+      expect(component.infoTooltip).toBe('');
+      expect(component.infoTooltipClass).toBe('cps-tooltip-content');
+      expect(component.infoTooltipMaxWidth).toBe('100%');
+      expect(component.infoTooltipPersistent).toBe(false);
+      expect(component.infoTooltipPosition).toBe('top');
+      expect(component.value).toBeUndefined();
+    });
+  });
+
+  describe('template', () => {
+    it('should render one button per option', () => {
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      expect(buttons.length).toBe(OPTIONS.length);
+    });
+
+    it('should show label element when label is set', () => {
+      fixture.componentRef.setInput('label', 'My Toggle');
+      fixture.detectChanges();
+      const label = fixture.nativeElement.querySelector(
+        '.cps-btn-toggle-label span'
+      );
+      expect(label?.textContent?.trim()).toBe('My Toggle');
+    });
+
+    it('should not show label element when label is empty', () => {
+      const label = fixture.nativeElement.querySelector(
+        '.cps-btn-toggle-label'
+      );
+      expect(label).toBeNull();
+    });
+
+    it('should set aria-label on role=group from ariaLabel', () => {
+      fixture.componentRef.setInput('ariaLabel', 'Toggle group');
+      fixture.detectChanges();
+      const group = fixture.nativeElement.querySelector('[role="group"]');
+      expect(group.getAttribute('aria-label')).toBe('Toggle group');
+    });
+
+    it('should prefer ariaLabel over label for role=group aria-label', () => {
+      fixture.componentRef.setInput('label', 'My Label');
+      fixture.componentRef.setInput('ariaLabel', 'Aria Label');
+      fixture.detectChanges();
+      const group = fixture.nativeElement.querySelector('[role="group"]');
+      expect(group.getAttribute('aria-label')).toBe('Aria Label');
+    });
+
+    it('should fall back to label for role=group aria-label when ariaLabel is empty', () => {
+      fixture.componentRef.setInput('label', 'My Label');
+      fixture.detectChanges();
+      const group = fixture.nativeElement.querySelector('[role="group"]');
+      expect(group.getAttribute('aria-label')).toBe('My Label');
+    });
+
+    it('should mark selected option with aria-pressed="true"', () => {
+      fixture.componentRef.setInput('value', 'b');
+      fixture.detectChanges();
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      expect(buttons[0].getAttribute('aria-pressed')).toBe('false');
+      expect(buttons[1].getAttribute('aria-pressed')).toBe('true');
+      expect(buttons[2].getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('should disable all buttons when component is disabled', () => {
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      buttons.forEach((btn: HTMLButtonElement) => {
+        expect(btn.disabled).toBe(true);
+      });
+    });
+
+    it('should disable only the matching button when option.disabled is true', () => {
+      fixture.componentRef.setInput('options', [
+        { value: 'a', label: 'Alpha', disabled: true },
+        { value: 'b', label: 'Beta' }
+      ]);
+      fixture.detectChanges();
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      expect(buttons[0].disabled).toBe(true);
+      expect(buttons[1].disabled).toBe(false);
+    });
+  });
+
+  describe('updateValueOnClick - single select', () => {
+    it('should update value when clicking an option', () => {
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      buttons[1].click();
+      expect(component.value).toBe('b');
+    });
+
+    it('should emit valueChanged when clicking an option', () => {
+      jest.spyOn(component.valueChanged, 'emit');
+      const buttons = fixture.nativeElement.querySelectorAll(
+        'button.cps-btn-toggle-content-option'
+      );
+      buttons[0].click();
+      expect(component.valueChanged.emit).toHaveBeenCalledWith('a');
+    });
+
+    it('should not change value when component is disabled', () => {
+      fixture.componentRef.setInput('value', 'a');
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+      component.updateValueOnClick('b');
+      expect(component.value).toBe('a');
+    });
+
+    it('should keep value when clicking same option and mandatory is true', () => {
+      fixture.componentRef.setInput('value', 'a');
+      fixture.detectChanges();
+      component.updateValueOnClick('a');
+      expect(component.value).toBe('a');
+    });
+
+    it('should deselect when clicking same option and mandatory is false', () => {
+      fixture.componentRef.setInput('mandatory', false);
+      fixture.componentRef.setInput('value', 'a');
+      fixture.detectChanges();
+      component.updateValueOnClick('a');
+      expect(component.value).toBeUndefined();
+    });
+
+    it('should select a different option when mandatory is false', () => {
+      fixture.componentRef.setInput('mandatory', false);
+      fixture.componentRef.setInput('value', 'a');
+      fixture.detectChanges();
+      component.updateValueOnClick('b');
+      expect(component.value).toBe('b');
+    });
+  });
+
+  describe('updateValueOnClick - multiple select', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('multiple', true);
+      fixture.detectChanges();
+    });
+
+    it('should add values to selection', () => {
+      component.updateValueOnClick('a');
+      component.updateValueOnClick('b');
+      expect(component.value).toEqual(['a', 'b']);
+    });
+
+    it('should remove a value from selection', () => {
+      fixture.componentRef.setInput('value', ['a', 'b']);
+      fixture.detectChanges();
+      component.updateValueOnClick('a');
+      expect(component.value).toEqual(['b']);
+    });
+
+    it('should not remove last selected value when mandatory is true', () => {
+      fixture.componentRef.setInput('value', ['a']);
+      fixture.detectChanges();
+      component.updateValueOnClick('a');
+      expect(component.value).toEqual(['a']);
+    });
+
+    it('should remove last selected value when mandatory is false', () => {
+      fixture.componentRef.setInput('mandatory', false);
+      fixture.componentRef.setInput('value', ['a']);
+      fixture.detectChanges();
+      component.updateValueOnClick('a');
+      expect(component.value).toEqual([]);
+    });
+
+    it('should preserve options order in selection', () => {
+      component.updateValueOnClick('c');
+      component.updateValueOnClick('a');
+      expect(component.value).toEqual(['a', 'c']);
+    });
+
+    it('should emit valueChanged with array value', () => {
+      jest.spyOn(component.valueChanged, 'emit');
+      component.updateValueOnClick('b');
+      expect(component.valueChanged.emit).toHaveBeenCalledWith(['b']);
+    });
+
+    it('should initialize value to [] when multiple is true and no value is set', () => {
+      const newFixture = TestBed.createComponent(CpsButtonToggleComponent);
+      newFixture.componentRef.setInput('multiple', true);
+      newFixture.componentRef.setInput('options', OPTIONS);
+      newFixture.detectChanges();
+      expect(newFixture.componentInstance.value).toEqual([]);
+      newFixture.destroy();
+    });
+  });
+
+  describe('ControlValueAccessor', () => {
+    it('should call registered onChange when value changes', () => {
+      const fn = jest.fn();
+      component.registerOnChange(fn);
+      component.updateValueOnClick('b');
+      expect(fn).toHaveBeenCalledWith('b');
+    });
+
+    it('should call registered onTouched', () => {
+      const fn = jest.fn();
+      component.registerOnTouched(fn);
+      component.onTouched();
+      expect(fn).toHaveBeenCalled();
+    });
+
+    it('should write value via writeValue', () => {
+      component.writeValue('c');
+      expect(component.value).toBe('c');
+    });
+
+    it('should not throw on setDisabledState', () => {
+      expect(() => component.setDisabledState(true)).not.toThrow();
+    });
+  });
+
+  describe('accessibility warnings', () => {
+    it('should log error when neither label nor ariaLabel is provided on the component', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      component.ngOnChanges({
+        label: new SimpleChange('My Label', '', false),
+        ariaLabel: new SimpleChange('', '', false)
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ariaLabel')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should not log error when label is set', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      fixture.componentRef.setInput('label', 'My Label');
+      fixture.detectChanges();
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should not log error when ariaLabel is set', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      fixture.componentRef.setInput('ariaLabel', 'Accessible label');
+      fixture.detectChanges();
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should log error when an option has no label and no ariaLabel', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const badOptions = [{ value: 'x' }];
+      component.options = badOptions;
+      component.ngOnChanges({
+        options: new SimpleChange(OPTIONS, badOptions, false)
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ariaLabel')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should not log error when all options have labels', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const goodOptions = [{ value: 'x', label: 'X' }];
+      component.options = goodOptions;
+      component.ngOnChanges({
+        options: new SimpleChange(OPTIONS, goodOptions, false)
+      });
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should not log error when options use ariaLabel instead of label', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const ariaOptions = [{ value: 'x', ariaLabel: 'X' }];
+      component.options = ariaOptions;
+      component.ngOnChanges({
+        options: new SimpleChange(OPTIONS, ariaOptions, false)
+      });
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('equal widths', () => {
+    it('should not modify largestButtonWidthRem when equalWidths is false', () => {
+      component.largestButtonWidthRem = 5;
+      fixture.componentRef.setInput('equalWidths', false);
+      (component as any)._setEqualWidths();
+      expect(component.largestButtonWidthRem).toBe(5);
+    });
+
+    it('should set largestButtonWidthRem to padding baseline when all option labels have offsetWidth=0', () => {
+      (component as any)._setEqualWidths();
+      expect(component.largestButtonWidthRem).toBeCloseTo(1.625);
+    });
+
+    it('should add icon width and margin for options with both icon and label', () => {
+      fixture.componentRef.setInput('options', [
+        { value: 'a', icon: 'home', label: 'Home' }
+      ]);
+      (component as any)._setEqualWidths();
+      expect(component.largestButtonWidthRem).toBeCloseTo(3.125);
+    });
+
+    it('should add icon width without margin for icon-only options', () => {
+      fixture.componentRef.setInput('options', [
+        { value: 'a', icon: 'home', ariaLabel: 'Home' }
+      ]);
+      (component as any)._setEqualWidths();
+      expect(component.largestButtonWidthRem).toBeCloseTo(2.625);
+    });
+
+    it('should use the maximum width across all options', () => {
+      fixture.componentRef.setInput('options', [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', icon: 'home', label: 'Beta' }
+      ]);
+      (component as any)._setEqualWidths();
+      expect(component.largestButtonWidthRem).toBeCloseTo(3.125);
+    });
+  });
+});

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, DOCUMENT } from '@angular/common';
 import {
-  ChangeDetectorRef,
   Component,
+  effect,
   EventEmitter,
   inject,
   Inject,
@@ -161,32 +161,31 @@ export class CpsButtonToggleComponent
   largestButtonWidthRem = 0;
 
   private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
-  private get _rootFontSizePx(): number {
-    return this._cpsRootFontSizeService?.fontSize() ?? 16;
-  }
 
   constructor(
     @Self() @Optional() private _control: NgControl,
     @Inject(DOCUMENT) private document: Document,
-    private renderer: Renderer2,
-    private cdr: ChangeDetectorRef
+    private renderer: Renderer2
   ) {
     if (this._control) {
       this._control.valueAccessor = this;
     }
+
+    effect(() => {
+      const rootFontSizePx = this._cpsRootFontSizeService?.fontSize() || 16;
+      if (this.document?.fonts?.ready) {
+        this.document.fonts.ready.then(() => {
+          this._setEqualWidths(this._cpsRootFontSizeService?.fontSize() || 16);
+        });
+      } else {
+        this._setEqualWidths(rootFontSizePx);
+      }
+    });
   }
 
   ngOnInit() {
     if (this.multiple && !this._value) {
       this._value = [];
-    }
-    if (this.document?.fonts?.ready) {
-      this.document.fonts.ready.then(() => {
-        this._setEqualWidths();
-        this.cdr.markForCheck();
-      });
-    } else {
-      this._setEqualWidths();
     }
   }
 
@@ -268,7 +267,7 @@ export class CpsButtonToggleComponent
     this.valueChanged.emit(value);
   }
 
-  private _setEqualWidths() {
+  private _setEqualWidths(rootFontSizePx: number) {
     if (!this.equalWidths) return;
 
     const hiddenSpan = this.renderer.createElement('span');
@@ -290,7 +289,7 @@ export class CpsButtonToggleComponent
       const label = opt.label || '';
       this.renderer.setProperty(hiddenSpan, 'textContent', label);
 
-      const textWidthRem = this._pxToRem(hiddenSpan.offsetWidth || 0);
+      const textWidthRem = (hiddenSpan.offsetWidth || 0) / rootFontSizePx;
       let totalWidthRem = textWidthRem + 1.625; // padding: 2×0.75rem + borders: 2×0.0625rem = 1.625rem
       if (opt.icon) {
         totalWidthRem += 1; // icon width: 1rem (cps-icon 'small' size)
@@ -306,9 +305,5 @@ export class CpsButtonToggleComponent
     });
 
     this.renderer.removeChild(this.document.body, hiddenSpan);
-  }
-
-  private _pxToRem(px: number): number {
-    return px / this._rootFontSizePx;
   }
 }

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
@@ -1,8 +1,9 @@
-import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  inject,
   Inject,
   Input,
   OnChanges,
@@ -11,11 +12,11 @@ import {
   Output,
   Renderer2,
   Self,
-  PLATFORM_ID,
   type SimpleChanges
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { isEqual } from 'lodash-es';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 import { CheckOptionSelectedPipe } from '../../pipes/internal/check-option-selected.pipe';
 import { CpsInfoCircleComponent } from '../cps-info-circle/cps-info-circle.component';
 import { CpsIconComponent } from '../cps-icon/cps-icon.component';
@@ -159,12 +160,14 @@ export class CpsButtonToggleComponent
 
   largestButtonWidthRem = 0;
 
-  private _rootFontSizePx = 16;
+  private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
+  private get _rootFontSizePx(): number {
+    return this._cpsRootFontSizeService?.fontSize() ?? 16;
+  }
 
   constructor(
     @Self() @Optional() private _control: NgControl,
     @Inject(DOCUMENT) private document: Document,
-    @Inject(PLATFORM_ID) private platformId: object,
     private renderer: Renderer2,
     private cdr: ChangeDetectorRef
   ) {
@@ -176,11 +179,6 @@ export class CpsButtonToggleComponent
   ngOnInit() {
     if (this.multiple && !this._value) {
       this._value = [];
-    }
-    if (isPlatformBrowser(this.platformId)) {
-      this._rootFontSizePx = parseFloat(
-        getComputedStyle(this.document.documentElement).fontSize || '16'
-      );
     }
     if (this.document?.fonts?.ready) {
       this.document.fonts.ready.then(() => {

--- a/projects/cps-ui-kit/src/lib/directives/cps-tooltip/cps-tooltip.directive.spec.ts
+++ b/projects/cps-ui-kit/src/lib/directives/cps-tooltip/cps-tooltip.directive.spec.ts
@@ -7,12 +7,16 @@ import {
 import { CpsTooltipDirective } from './cps-tooltip.directive';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 
 @Component({
   template: `<div cpsTooltip="<style onload='alert(420);'></style>"></div>`,
   imports: [CpsTooltipDirective]
 })
 class MaliciousTooltipComponent {}
+const mockRootFontSizeService = {
+  fontSize: () => 16
+};
 
 @Component({
   template: `<div cpsTooltip="<h1>Legit tooltip</h1>"></div>`,
@@ -29,7 +33,13 @@ describe('CpsTooltipDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: []
+      imports: [],
+      providers: [
+        {
+          provide: CPS_ROOT_FONT_SIZE_SERVICE,
+          useValue: mockRootFontSizeService
+        }
+      ]
     }).compileComponents();
   });
 

--- a/projects/cps-ui-kit/src/lib/directives/cps-tooltip/cps-tooltip.directive.ts
+++ b/projects/cps-ui-kit/src/lib/directives/cps-tooltip/cps-tooltip.directive.ts
@@ -5,13 +5,13 @@ import {
   inject,
   input,
   OnDestroy,
-  OnInit,
   SecurityContext,
   PLATFORM_ID
 } from '@angular/core';
 import { convertSize, parseSize } from '../../utils/internal/size-utils';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { DomSanitizer } from '@angular/platform-browser';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 
 /**
  * CpsTooltipPosition is used to define the position of the tooltip.
@@ -42,7 +42,7 @@ export type CpsTooltipOpenOn = 'hover' | 'click' | 'focus';
     '(window:resize)': 'onPageResize()'
   }
 })
-export class CpsTooltipDirective implements OnInit, OnDestroy {
+export class CpsTooltipDirective implements OnDestroy {
   /**
    * Tooltip text or html to show.
    * @group Props
@@ -117,8 +117,12 @@ export class CpsTooltipDirective implements OnInit, OnDestroy {
   private _showTimeout?: ReturnType<typeof setTimeout>;
   private _hideTimeout?: ReturnType<typeof setTimeout>;
   private _ariaTarget?: HTMLElement;
-  private _rootFontSizePx = 16;
   private window: Window;
+
+  private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
+  private get _rootFontSizePx(): number {
+    return this._cpsRootFontSizeService?.fontSize() ?? 16;
+  }
 
   private _elementRef = inject(ElementRef<HTMLElement>);
   private _document = inject(DOCUMENT);
@@ -127,14 +131,6 @@ export class CpsTooltipDirective implements OnInit, OnDestroy {
 
   constructor() {
     this.window = this._document.defaultView as Window;
-  }
-
-  ngOnInit(): void {
-    if (isPlatformBrowser(this._platformId)) {
-      this._rootFontSizePx = parseFloat(
-        getComputedStyle(this._document.documentElement).fontSize || '16'
-      );
-    }
   }
 
   ngOnDestroy(): void {

--- a/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.spec.ts
@@ -11,9 +11,14 @@ import { DomHandler } from 'primeng/dom';
 import { CpsDialogComponent } from './cps-dialog.component';
 import { CpsDialogConfig } from '../../../utils/cps-dialog-config';
 import { CpsDialogRef } from '../../../utils/cps-dialog-ref';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../../../cps-root-font-size/cps-root-font-size.service';
 
 @Component({ template: '' })
 class TestChildComponent {}
+
+const mockRootFontSizeService = {
+  fontSize: () => 16
+};
 
 describe('CpsDialogComponent', () => {
   let component: CpsDialogComponent;
@@ -41,6 +46,10 @@ describe('CpsDialogComponent', () => {
       providers: [
         { provide: CpsDialogRef, useValue: mockDialogRef },
         { provide: CpsDialogConfig, useValue: config },
+        {
+          provide: CPS_ROOT_FONT_SIZE_SERVICE,
+          useValue: mockRootFontSizeService
+        },
         PrimeNG
       ]
     });

--- a/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.ts
@@ -43,6 +43,7 @@ import { CpsButtonComponent } from '../../../../../components/cps-button/cps-but
 import { CpsInfoCircleComponent } from '../../../../../components/cps-info-circle/cps-info-circle.component';
 import { CpsIconComponent } from '../../../../../components/cps-icon/cps-icon.component';
 import { CPS_FOCUS_SERVICE } from '../../../../cps-focus/cps-focus.service';
+import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../../../cps-root-font-size/cps-root-font-size.service';
 
 const showAnimation = animation([
   style({ transform: '{{transform}}', opacity: 0 }),
@@ -140,9 +141,12 @@ export class CpsDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   _resizeEnded = new EventEmitter<MouseEvent | KeyboardEvent>();
   _maximizedStateChanged = new EventEmitter<boolean>();
 
-  private _rootFontSizePx = 16;
   private _openedByKeyboard = false;
   private readonly _cpsFocusService = inject(CPS_FOCUS_SERVICE);
+  private readonly _cpsRootFontSizeService = inject(CPS_ROOT_FONT_SIZE_SERVICE);
+  private get _rootFontSizePx(): number {
+    return this._cpsRootFontSizeService?.fontSize() ?? 16;
+  }
 
   get ariaLabel(): string | null {
     if (this.config.ariaLabelledBy) return null;
@@ -232,11 +236,6 @@ export class CpsDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    if (isPlatformBrowser(this.platformId)) {
-      this._rootFontSizePx = parseFloat(
-        getComputedStyle(this.document.documentElement).fontSize || '16'
-      );
-    }
     if (
       !this.config.ariaLabel?.trim() &&
       !this.config.ariaLabelledBy?.trim() &&


### PR DESCRIPTION
Integrated `CpsRootFontSizeService` into `CpsAutocompleteComponent`, `CpsButtonToggleComponent`, `CpsDialogComponent`, and `CpsTooltipDirective`, replacing their custom logic, which also lacked support for dynamic root font size changes.

---

Release notes:
- Integrate `CpsRootFontSizeService` into components