### PR TITLE
Delete html and body styles overrides

### DIFF
--- a/projects/composition/src/styles.scss
+++ b/projects/composition/src/styles.scss
@@ -7,12 +7,18 @@
   box-sizing: border-box;
 }
 
+* {
+  scrollbar-width: thin;
+}
+
 html,
 body {
   height: 100%;
   margin: 0;
   font-family: 'Source Sans Pro', sans-serif;
   font-size: 100%;
+  background: var(--cps-background-color);
+  color: var(--cps-text-primary);
 }
 
 .composition-page {

--- a/projects/cps-ui-kit/styles/styles.scss
+++ b/projects/cps-ui-kit/styles/styles.scss
@@ -20,18 +20,6 @@
   top: -9999px;
 }
 
-/* Custom scrollbar */
-* {
-  scrollbar-width: thin;
-}
-
-html,
-body {
-  font-family: 'Source Sans Pro', sans-serif;
-  background: var(--cps-background-color);
-  color: var(--cps-text-primary);
-}
-
 // Theme transition hook used by CpsThemeService
 .cps-theme-transition,
 .cps-theme-transition *,


### PR DESCRIPTION
Applying 
```
html,
body {
  font-family: 'Source Sans Pro', sans-serif;
  background: var(--cps-background-color);
  color: var(--cps-text-primary);
}
```
is a fairly serious issue that was missed during the PR https://github.com/AbsaOSS/cps-shared-ui/pull/516 review. The component library should not be globally overriding `html` and `body` styles. Instead, it should only expose CSS custom properties, leaving it up to the consuming app to decide how to apply them. This is a clear violation of the library boundary.

---

Release notes:
- Delete html and body styles overrides