### PR TITLE
Roll back to v21.17.0

### DIFF
--- a/projects/cps-ui-kit/package.json
+++ b/projects/cps-ui-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cps-ui-kit",
-  "version": "21.18.0",
+  "version": "21.17.0",
   "peerDependencies": {
     "@angular/common": "^21.2.6",
     "@angular/core": "^21.2.6",


### PR DESCRIPTION
Reverting to version 21.17.0 to publish the package to npm because the previous npm auth token had expired.