### PR TITLE
Fix a11y issues in timepicker component

### DIFF
--- a/playwright/cps-accessibility.spec.ts
+++ b/playwright/cps-accessibility.spec.ts
@@ -171,15 +171,15 @@ const components: ComponentEntry[] = [
   // { route: '/table', name: 'Table', selector: 'cps-table' },
   // { route: '/tag', name: 'Tag', selector: 'cps-tag' },
   // { route: '/textarea', name: 'Textarea', selector: 'cps-textarea' },
-  // {
-  //   route: '/timepicker',
-  //   name: 'Timepicker',
-  //   selector: ['cps-timepicker', '.cps-autocomplete-options-menu'],
-  //   setup: async (page) => {
-  //     await page.waitForSelector('cps-timepicker');
-  //     await page.locator('cps-timepicker cps-autocomplete').first().click();
-  //   }
-  // },
+  {
+    route: '/timepicker',
+    name: 'Timepicker',
+    selector: ['cps-timepicker', '.cps-autocomplete-options-menu'],
+    setup: async (page) => {
+      await page.waitForSelector('cps-timepicker');
+      await page.locator('cps-timepicker cps-autocomplete').first().click();
+    }
+  },
   {
     route: '/tooltip',
     name: 'Tooltip',

--- a/projects/composition/src/app/api-data/cps-timepicker.json
+++ b/projects/composition/src/app/api-data/cps-timepicker.json
@@ -14,6 +14,14 @@
                         "description": "Label of the timepicker."
                     },
                     {
+                        "name": "ariaLabel",
+                        "optional": false,
+                        "readonly": false,
+                        "type": "string",
+                        "default": "",
+                        "description": "Aria label for the timepicker component, used for accessibility, it takes precedence over label."
+                    },
+                    {
                         "name": "disabled",
                         "optional": false,
                         "readonly": false,

--- a/projects/composition/src/app/pages/timepicker-page/timepicker-page.component.scss
+++ b/projects/composition/src/app/pages/timepicker-page/timepicker-page.component.scss
@@ -1,5 +1,5 @@
 .timepickers-group {
-  gap: 24px;
+  gap: 1.5rem;
   display: flex;
   flex-direction: column;
 }

--- a/projects/composition/tsconfig.json
+++ b/projects/composition/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/app",
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -28,7 +28,8 @@ import { convertSize } from '../../utils/internal/size-utils';
 import { CPS_ROOT_FONT_SIZE_SERVICE } from '../../services/cps-root-font-size/cps-root-font-size.service';
 import {
   generateUniqueId,
-  getComputedLabel
+  getComputedLabel,
+  logMissingAriaLabelError
 } from '../../utils/internal/accessibility-utils';
 import {
   CpsIconComponent,
@@ -504,6 +505,12 @@ export class CpsAutocompleteComponent
         this.inputTextDebounced = this.inputText;
         this.inputChanged.emit(val);
       });
+
+    logMissingAriaLabelError(
+      'CpsAutocompleteComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -523,11 +530,12 @@ export class CpsAutocompleteComponent
     ) {
       this._toggleOptions(true);
     }
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsAutocompleteComponent: unlabeled autocomplete component must have an ariaLabel for accessibility.'
-      );
-    }
+
+    logMissingAriaLabelError(
+      'CpsAutocompleteComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngAfterViewInit(): void {

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.ts
@@ -24,6 +24,7 @@ import {
   CpsTooltipDirective,
   CpsTooltipPosition
 } from '../../directives/cps-tooltip/cps-tooltip.directive';
+import { logMissingAriaLabelError } from '../../utils/internal/accessibility-utils';
 
 /**
  * CpsButtonToggleOption is used to define the options of the CpsButtonToggleComponent.
@@ -187,14 +188,14 @@ export class CpsButtonToggleComponent
     if (this.multiple && !this._value) {
       this._value = [];
     }
+    logMissingAriaLabelError(
+      'CpsButtonToggleComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsButtonToggleComponent: unlabeled button toggle component must have an ariaLabel for accessibility.'
-      );
-    }
     if (changes.options) {
       const hasInaccessibleOption = this.options.some(
         (opt) => !opt.label?.trim() && !opt.ariaLabel?.trim()
@@ -205,6 +206,11 @@ export class CpsButtonToggleComponent
         );
       }
     }
+    logMissingAriaLabelError(
+      'CpsButtonToggleComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/projects/cps-ui-kit/src/lib/components/cps-button/cps-button.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-button/cps-button.component.ts
@@ -6,12 +6,14 @@ import {
   Inject,
   Input,
   OnChanges,
+  OnInit,
   Output
 } from '@angular/core';
 import { getCSSColor } from '../../utils/colors-utils';
 import { CpsIconComponent, IconType } from '../cps-icon/cps-icon.component';
 import { CpsProgressCircularComponent } from '../cps-progress-circular/cps-progress-circular.component';
 import { convertSize, parseSize } from '../../utils/internal/size-utils';
+import { logMissingAriaLabelError } from '../../utils/internal/accessibility-utils';
 
 /**
  * CpsButtonComponent is a button element.
@@ -23,7 +25,7 @@ import { convertSize, parseSize } from '../../utils/internal/size-utils';
   templateUrl: './cps-button.component.html',
   styleUrls: ['./cps-button.component.scss']
 })
-export class CpsButtonComponent implements OnChanges {
+export class CpsButtonComponent implements OnInit, OnChanges {
   /**
    * Color of the button.
    * @group Props
@@ -125,6 +127,10 @@ export class CpsButtonComponent implements OnChanges {
   // eslint-disable-next-line no-useless-constructor
   constructor(@Inject(DOCUMENT) private document: Document) {}
 
+  ngOnInit(): void {
+    logMissingAriaLabelError('CpsButtonComponent', this.label, this.ariaLabel);
+  }
+
   ngOnChanges(): void {
     this.buttonColor = getCSSColor(this.color, this.document);
     this.borderRadius = convertSize(this.borderRadius);
@@ -135,12 +141,8 @@ export class CpsButtonComponent implements OnChanges {
     if (this.disabled || this.loading) {
       this.enterActive = false;
     }
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsButtonComponent: icon-only or unlabeled button must have an ariaLabel for accessibility.'
-      );
-    }
     this.setClasses();
+    logMissingAriaLabelError('CpsButtonComponent', this.label, this.ariaLabel);
   }
 
   setClasses() {

--- a/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.spec.ts
@@ -181,7 +181,7 @@ describe('CpsCheckboxComponent', () => {
       fixture.componentRef.setInput('label', '');
       fixture.detectChanges();
       expect(consoleSpy).toHaveBeenCalledWith(
-        'CpsCheckboxComponent: icon-only or unlabeled checkbox must have an ariaLabel for accessibility.'
+        'CpsCheckboxComponent: unlabeled component must have an ariaLabel for accessibility.'
       );
       consoleSpy.mockRestore();
     });

--- a/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.ts
@@ -16,6 +16,7 @@ import { CpsInfoCircleComponent } from '../cps-info-circle/cps-info-circle.compo
 import { CpsTooltipPosition } from '../../directives/cps-tooltip/cps-tooltip.directive';
 import { CpsIconComponent, IconType } from '../cps-icon/cps-icon.component';
 import { getCSSColor } from '../../utils/colors-utils';
+import { logMissingAriaLabelError } from '../../utils/internal/accessibility-utils';
 
 /**
  * CpsCheckboxComponent is a checkbox element.
@@ -125,14 +126,19 @@ export class CpsCheckboxComponent
 
   ngOnInit(): void {
     this.iconColor = getCSSColor(this.iconColor, this.document);
+    logMissingAriaLabelError(
+      'CpsCheckboxComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngOnChanges(): void {
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsCheckboxComponent: icon-only or unlabeled checkbox must have an ariaLabel for accessibility.'
-      );
-    }
+    logMissingAriaLabelError(
+      'CpsCheckboxComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/projects/cps-ui-kit/src/lib/components/cps-radio-group/cps-radio-group.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-radio-group/cps-radio-group.component.ts
@@ -19,7 +19,8 @@ import { CpsRadioButtonComponent } from './cps-radio-button/cps-radio-button.com
 import { Subscription } from 'rxjs';
 import {
   generateUniqueId,
-  getComputedLabel
+  getComputedLabel,
+  logMissingAriaLabelError
 } from '../../utils/internal/accessibility-utils';
 
 /**
@@ -182,14 +183,19 @@ export class CpsRadioGroupComponent
         this._checkErrors();
       }
     );
+    logMissingAriaLabelError(
+      'CpsRadioGroupComponent',
+      this.groupLabel,
+      this.ariaLabel
+    );
   }
 
   ngOnChanges(): void {
-    if (!this.groupLabel?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsRadioGroupComponent: unlabeled radio group component must have an ariaLabel for accessibility.'
-      );
-    }
+    logMissingAriaLabelError(
+      'CpsRadioGroupComponent',
+      this.groupLabel,
+      this.ariaLabel
+    );
   }
 
   ngOnDestroy() {

--- a/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-scheduler/cps-scheduler.component.html
@@ -103,6 +103,7 @@
               </cps-select>
               day(s) at
               <cps-timepicker
+                ariaLabel="Time"
                 data-testid="daily-timepicker"
                 [disabled]="disabled || state.daily.subTab !== 'everyDays'"
                 [use24HourTime]="use24HourTime"
@@ -128,6 +129,7 @@
               ">
               Every working day at
               <cps-timepicker
+                ariaLabel="Time"
                 [disabled]="disabled || state.daily.subTab !== 'everyWeekDay'"
                 [use24HourTime]="use24HourTime"
                 [mandatoryValue]="true"
@@ -199,6 +201,7 @@
         <div class="cps-scheduler-tab-pane-row">
           at
           <cps-timepicker
+            ariaLabel="Time"
             [disabled]="disabled"
             data-testid="weekly-timepicker"
             [use24HourTime]="use24HourTime"
@@ -258,6 +261,7 @@
               </cps-select>
               month(s) at
               <cps-timepicker
+                ariaLabel="Time"
                 [disabled]="disabled || state.monthly.subTab !== 'specificDay'"
                 [use24HourTime]="use24HourTime"
                 [mandatoryValue]="true"
@@ -348,6 +352,7 @@
               </cps-select>
               at
               <cps-timepicker
+                ariaLabel="Time"
                 [disabled]="
                   disabled || state.monthly.subTab !== 'specificWeekDay'
                 "
@@ -417,6 +422,7 @@
               </cps-select>
               at
               <cps-timepicker
+                ariaLabel="Time"
                 [disabled]="
                   disabled || state.yearly.subTab !== 'specificMonthDay'
                 "
@@ -496,6 +502,7 @@
               </cps-select>
               at
               <cps-timepicker
+                ariaLabel="Time"
                 [disabled]="
                   disabled || state.yearly.subTab !== 'specificMonthWeek'
                 "

--- a/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
@@ -26,7 +26,8 @@ import { Subscription } from 'rxjs';
 import { convertSize } from '../../utils/internal/size-utils';
 import {
   generateUniqueId,
-  getComputedLabel
+  getComputedLabel,
+  logMissingAriaLabelError
 } from '../../utils/internal/accessibility-utils';
 import {
   CpsIconComponent,
@@ -399,6 +400,8 @@ export class CpsSelectComponent
     );
 
     this.recalcVirtualListHeight();
+
+    logMissingAriaLabelError('CpsSelectComponent', this.label, this.ariaLabel);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -414,11 +417,8 @@ export class CpsSelectComponent
       });
       this.recalcVirtualListHeight();
     }
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsSelectComponent: unlabeled select component must have an ariaLabel for accessibility.'
-      );
-    }
+
+    logMissingAriaLabelError('CpsSelectComponent', this.label, this.ariaLabel);
   }
 
   ngAfterViewInit(): void {

--- a/projects/cps-ui-kit/src/lib/components/cps-tab-group/cps-tab/cps-tab.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tab-group/cps-tab/cps-tab.component.ts
@@ -4,9 +4,11 @@ import {
   Component,
   Input,
   OnChanges,
+  OnInit,
   TemplateRef,
   ViewChild
 } from '@angular/core';
+import { logMissingAriaLabelError } from '../../../utils/internal/accessibility-utils';
 
 /**
  * CpsTabComponent is a tab within a tab-group.
@@ -18,7 +20,7 @@ import {
   templateUrl: './cps-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CpsTabComponent implements OnChanges {
+export class CpsTabComponent implements OnInit, OnChanges {
   /**
    * Label of the tab.
    * @group Props
@@ -83,11 +85,11 @@ export class CpsTabComponent implements OnChanges {
 
   active = false;
 
+  ngOnInit(): void {
+    logMissingAriaLabelError('CpsTabComponent', this.label, this.ariaLabel);
+  }
+
   ngOnChanges(): void {
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsTabComponent: unlabeled tab component must have an ariaLabel for accessibility.'
-      );
-    }
+    logMissingAriaLabelError('CpsTabComponent', this.label, this.ariaLabel);
   }
 }

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.html
@@ -20,9 +20,9 @@
   <div class="cps-timepicker-body">
     <cps-autocomplete
       #hoursField
-      ariaLabel="Hours"
+      [ariaLabel]="`Hours, ${ariaLabel || label}`"
       (keypress)="numberOnly($event)"
-      width="60"
+      width="3.75rem"
       [emptyOptionIndex]="mandatoryValue ? 0 : -1"
       [options]="hoursOptions"
       [withOptionsAliases]="!use24HourTime"
@@ -43,7 +43,7 @@
       #minutesField
       ariaLabel="Minutes"
       (keypress)="numberOnly($event)"
-      width="60"
+      width="3.75rem"
       [emptyOptionIndex]="mandatoryValue ? 0 : -1"
       [options]="minutesOptions"
       [hideDetails]="true"
@@ -65,7 +65,7 @@
         #secondsField
         ariaLabel="Seconds"
         (keypress)="numberOnly($event)"
-        width="60"
+        width="3.75rem"
         [emptyOptionIndex]="mandatoryValue ? 0 : -1"
         [options]="secondsOptions"
         [hideDetails]="true"

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.html
@@ -38,7 +38,7 @@
       (valueChanged)="updateHours($event)"
       [externalError]="hoursError"
       placeholder="HH"></cps-autocomplete>
-    <span class="cps-timepicker-delimiter">:</span>
+    <span aria-hidden="true" class="cps-timepicker-delimiter">:</span>
     <cps-autocomplete
       #minutesField
       ariaLabel="Minutes"
@@ -58,9 +58,7 @@
       [externalError]="minutesError"
       placeholder="MM"></cps-autocomplete>
     @if (withSeconds) {
-      <span class="cps-timepicker-delimiter">:</span>
-    }
-    @if (withSeconds) {
+      <span aria-hidden="true" class="cps-timepicker-delimiter">:</span>
       <cps-autocomplete
         #secondsField
         ariaLabel="Seconds"

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.scss
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.scss
@@ -18,7 +18,7 @@ $timepicker-delimeter-color: var(--cps-color-text-lightest);
       font-weight: 600;
 
       &-info-circle {
-        margin-left: 8px;
+        margin-left: 0.5rem;
       }
 
       &-disabled {
@@ -31,14 +31,14 @@ $timepicker-delimeter-color: var(--cps-color-text-lightest);
       flex-direction: row;
 
       .cps-timepicker-am-pm-selector {
-        margin-left: 10px;
+        margin-left: 0.625rem;
         margin-top: 0;
       }
 
       .cps-timepicker-delimiter {
         color: $timepicker-delimeter-color;
-        font-size: 24px;
-        margin: 0 10px;
+        font-size: 1.5rem;
+        margin: 0 0.625rem;
       }
     }
 

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.spec.ts
@@ -1,0 +1,616 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+
+import { CpsTimepickerComponent, CpsTime } from './cps-timepicker.component';
+
+describe('CpsTimepickerComponent', () => {
+  let component: CpsTimepickerComponent;
+  let fixture: ComponentFixture<CpsTimepickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CpsTimepickerComponent, NoopAnimationsModule],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CpsTimepickerComponent);
+    component = fixture.componentInstance;
+    component.label = 'Test';
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('label', () => {
+    it('should display the label when provided', () => {
+      const labelEl = fixture.debugElement.query(
+        By.css('.cps-timepicker-label label')
+      );
+      expect(labelEl.nativeElement.textContent.trim()).toBe('Test');
+    });
+
+    it('should not render the label element when label is empty', () => {
+      component.label = '';
+      component.ariaLabel = 'Test timepicker';
+      fixture.detectChanges();
+      const labelEl = fixture.debugElement.query(
+        By.css('.cps-timepicker-label')
+      );
+      expect(labelEl).toBeNull();
+    });
+
+    it('should apply disabled class to label when disabled is true', () => {
+      component.disabled = true;
+      fixture.detectChanges();
+      const disabledLabel = fixture.debugElement.query(
+        By.css('.cps-timepicker-label-disabled')
+      );
+      expect(disabledLabel).toBeTruthy();
+    });
+
+    it('should not apply disabled class to label when disabled is false', () => {
+      const disabledLabel = fixture.debugElement.query(
+        By.css('.cps-timepicker-label-disabled')
+      );
+      expect(disabledLabel).toBeNull();
+    });
+  });
+
+  describe('ngOnChanges', () => {
+    it('should log an error when both label and ariaLabel are empty', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      component.label = '';
+      component.ariaLabel = '';
+      component.ngOnChanges();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'CpsTimepickerComponent: unlabeled timepicker component must have an ariaLabel for accessibility.'
+      );
+    });
+
+    it('should not log an error when label is provided', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      component.label = 'Time';
+      component.ariaLabel = '';
+      component.ngOnChanges();
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not log an error when ariaLabel is provided', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      component.label = '';
+      component.ariaLabel = 'Select time';
+      component.ngOnChanges();
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should treat whitespace-only label as empty', () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      component.label = '   ';
+      component.ariaLabel = '';
+      component.ngOnChanges();
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('ngOnInit — hours options', () => {
+    type HourOption = { label: string; value: string; alias?: string };
+
+    it('should initialize 12-hour options (01–12) by default', () => {
+      expect(component.hoursOptions.length).toBe(12);
+      expect(component.hoursOptions[0].value).toBe('01');
+      expect(component.hoursOptions[11].value).toBe('12');
+    });
+
+    it('should include an alias for each 12-hour option', () => {
+      const hour12 = component.hoursOptions.find(
+        (h) => h.value === '12'
+      ) as HourOption;
+      expect(hour12?.alias).toBe('00');
+
+      const hour1 = component.hoursOptions.find(
+        (h) => h.value === '01'
+      ) as HourOption;
+      expect(hour1?.alias).toBe('13');
+    });
+
+    it('should initialize 24-hour options (00–23) when use24HourTime is true', () => {
+      component.use24HourTime = true;
+      component.ngOnInit();
+      expect(component.hoursOptions.length).toBe(24);
+      expect(component.hoursOptions[0].value).toBe('00');
+      expect(component.hoursOptions[23].value).toBe('23');
+    });
+
+    it('should not include an alias for 24-hour options', () => {
+      component.use24HourTime = true;
+      component.ngOnInit();
+      (component.hoursOptions as HourOption[]).forEach((h) =>
+        expect(h.alias).toBeUndefined()
+      );
+    });
+  });
+
+  describe('ngOnInit — minutes options', () => {
+    it('should have 60 minutes options (00–59)', () => {
+      expect(component.minutesOptions.length).toBe(60);
+      expect(component.minutesOptions[0].value).toBe('00');
+      expect(component.minutesOptions[59].value).toBe('59');
+    });
+  });
+
+  describe('ngOnInit — seconds options', () => {
+    it('should have empty secondsOptions by default', () => {
+      expect(component.secondsOptions.length).toBe(0);
+    });
+
+    it('should populate secondsOptions (00–59) when withSeconds is true', () => {
+      component.withSeconds = true;
+      component.ngOnInit();
+      expect(component.secondsOptions.length).toBe(60);
+      expect(component.secondsOptions[0].value).toBe('00');
+      expect(component.secondsOptions[59].value).toBe('59');
+    });
+  });
+
+  describe('ngAfterViewInit', () => {
+    it('should set isTimePickerField on hoursField and minutesField', () => {
+      const mockField = { isTimePickerField: false };
+      (component as any).hoursField = mockField;
+      (component as any).minutesField = { ...mockField };
+      component.ngAfterViewInit();
+      expect((component as any).hoursField.isTimePickerField).toBe(true);
+      expect((component as any).minutesField.isTimePickerField).toBe(true);
+    });
+
+    it('should set isTimePickerField on secondsField when present', () => {
+      const mockSecondsField = { isTimePickerField: false };
+      (component as any).secondsField = mockSecondsField;
+      component.ngAfterViewInit();
+      expect((component as any).secondsField.isTimePickerField).toBe(true);
+    });
+
+    it('should not throw when child fields are not present', () => {
+      (component as any).hoursField = undefined;
+      (component as any).minutesField = undefined;
+      (component as any).secondsField = undefined;
+      expect(() => component.ngAfterViewInit()).not.toThrow();
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe from statusChanges on destroy', () => {
+      const unsubscribeSpy = jest.fn();
+      (component as any)._statusChangesSubscription = {
+        unsubscribe: unsubscribeSpy
+      };
+      component.ngOnDestroy();
+      expect(unsubscribeSpy).toHaveBeenCalled();
+    });
+
+    it('should not throw when there is no subscription', () => {
+      (component as any)._statusChangesSubscription = undefined;
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+  });
+
+  describe('value setter / getter', () => {
+    it('should set and retrieve the value', () => {
+      const time: CpsTime = { hours: '10', minutes: '30' };
+      component.value = time;
+      expect(component.value).toEqual(time);
+    });
+
+    it('should accept undefined and store undefined', () => {
+      component.value = { hours: '10', minutes: '30' };
+      component.value = undefined;
+      expect(component.value).toBeUndefined();
+    });
+
+    it('should call onChange when value is set', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+      const time: CpsTime = { hours: '08', minutes: '45' };
+      component.value = time;
+      expect(onChangeSpy).toHaveBeenCalledWith(time);
+    });
+  });
+
+  describe('registerOnChange', () => {
+    it('should register a callback that is called on value change', () => {
+      const cb = jest.fn();
+      component.registerOnChange(cb);
+      component.value = { hours: '01', minutes: '00' };
+      expect(cb).toHaveBeenCalledWith({ hours: '01', minutes: '00' });
+    });
+  });
+
+  describe('registerOnTouched', () => {
+    it('should register a touched callback', () => {
+      const cb = jest.fn();
+      component.registerOnTouched(cb);
+      expect((component as any).onTouched).toBe(cb);
+    });
+  });
+
+  describe('updateHours', () => {
+    it('should update value.hours', () => {
+      component.value = { hours: '10', minutes: '30' };
+      component.updateHours('11');
+      expect(component.value?.hours).toBe('11');
+    });
+
+    it('should emit valueChanged with the updated value', () => {
+      const spy = jest.spyOn(component.valueChanged, 'emit');
+      component.value = { hours: '10', minutes: '30' };
+      component.updateHours('11');
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ hours: '11' })
+      );
+    });
+
+    it('should auto-set dayPeriod to PM when hour is 13–23 in 12-hour mode', () => {
+      component.value = { hours: '01', minutes: '00', dayPeriod: 'AM' };
+      component.updateHours('15');
+      expect(component.value?.dayPeriod).toBe('PM');
+    });
+
+    it('should not auto-set dayPeriod to PM in 24-hour mode', () => {
+      component.use24HourTime = true;
+      component.ngOnInit();
+      component.value = { hours: '10', minutes: '00' };
+      component.updateHours('15');
+      expect(component.value?.dayPeriod).toBeUndefined();
+    });
+
+    it('should initialize value when it is undefined and a non-empty hour is given', () => {
+      expect(component.value).toBeUndefined();
+      component.updateHours('10');
+      expect(component.value).toBeDefined();
+      expect(component.value?.hours).toBe('10');
+    });
+
+    it('should set hours to empty string when empty string is passed', () => {
+      component.value = { hours: '10', minutes: '30' };
+      component.updateHours('');
+      expect(component.value?.hours).toBe('');
+    });
+  });
+
+  describe('updateMinutes', () => {
+    it('should update value.minutes', () => {
+      component.value = { hours: '10', minutes: '30' };
+      component.updateMinutes('45');
+      expect(component.value?.minutes).toBe('45');
+    });
+
+    it('should emit valueChanged with the updated value', () => {
+      const spy = jest.spyOn(component.valueChanged, 'emit');
+      component.value = { hours: '10', minutes: '30' };
+      component.updateMinutes('45');
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ minutes: '45' })
+      );
+    });
+
+    it('should initialize value when it is undefined and non-empty minutes are given', () => {
+      expect(component.value).toBeUndefined();
+      component.updateMinutes('30');
+      expect(component.value).toBeDefined();
+      expect(component.value?.minutes).toBe('30');
+    });
+
+    it('should not initialize value when empty string is passed', () => {
+      expect(component.value).toBeUndefined();
+      component.updateMinutes('');
+      expect(component.value).toBeUndefined();
+    });
+  });
+
+  describe('updateSeconds', () => {
+    it('should update value.seconds', () => {
+      component.withSeconds = true;
+      component.value = { hours: '10', minutes: '30', seconds: '00' };
+      component.updateSeconds('45');
+      expect(component.value?.seconds).toBe('45');
+    });
+
+    it('should emit valueChanged with the updated value', () => {
+      const spy = jest.spyOn(component.valueChanged, 'emit');
+      component.value = { hours: '10', minutes: '30', seconds: '00' };
+      component.updateSeconds('45');
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ seconds: '45' })
+      );
+    });
+
+    it('should initialize value when it is undefined and non-empty seconds are given', () => {
+      expect(component.value).toBeUndefined();
+      component.updateSeconds('30');
+      expect(component.value).toBeDefined();
+    });
+  });
+
+  describe('updateDayPeriod', () => {
+    it('should update value.dayPeriod', () => {
+      component.value = { hours: '10', minutes: '30', dayPeriod: 'AM' };
+      component.updateDayPeriod('PM');
+      expect(component.value?.dayPeriod).toBe('PM');
+    });
+
+    it('should emit valueChanged with the updated value', () => {
+      const spy = jest.spyOn(component.valueChanged, 'emit');
+      component.value = { hours: '10', minutes: '30', dayPeriod: 'AM' };
+      component.updateDayPeriod('PM');
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ dayPeriod: 'PM' })
+      );
+    });
+
+    it('should initialize value when it is undefined and dayPeriod is provided', () => {
+      expect(component.value).toBeUndefined();
+      component.updateDayPeriod('AM');
+      expect(component.value).toBeDefined();
+    });
+  });
+
+  describe('_initValue (via update methods)', () => {
+    it('should add dayPeriod AM when use24HourTime is false and value has no dayPeriod', () => {
+      component.use24HourTime = false;
+      component.value = { hours: '10', minutes: '' };
+      delete component.value.dayPeriod;
+      component.updateMinutes('30');
+      expect(component.value?.dayPeriod).toBe('AM');
+    });
+
+    it('should add seconds empty string when withSeconds is true and value has no seconds', () => {
+      component.withSeconds = true;
+      component.value = { hours: '10', minutes: '' };
+      delete (component.value as any).seconds;
+      component.updateMinutes('30');
+      expect('seconds' in (component.value as CpsTime)).toBe(true);
+      expect(component.value?.seconds).toBe('');
+    });
+
+    it('should not overwrite existing dayPeriod when _initValue is called', () => {
+      component.use24HourTime = false;
+      component.value = { hours: '10', minutes: '00', dayPeriod: 'PM' };
+      component.updateMinutes('30');
+      expect(component.value?.dayPeriod).toBe('PM');
+    });
+  });
+
+  describe('numberOnly', () => {
+    it('should allow digit characters (0–9, codes 48–57)', () => {
+      for (let code = 48; code <= 57; code++) {
+        expect(component.numberOnly({ which: code })).toBe(true);
+      }
+    });
+
+    it('should allow control characters (code <= 31)', () => {
+      expect(component.numberOnly({ which: 8 })).toBe(true); // Backspace
+      expect(component.numberOnly({ which: 13 })).toBe(true); // Enter
+      expect(component.numberOnly({ which: 0 })).toBe(true);
+    });
+
+    it('should block non-digit printable characters', () => {
+      expect(component.numberOnly({ which: 65 })).toBe(false); // 'A'
+      expect(component.numberOnly({ which: 47 })).toBe(false); // '/'
+      expect(component.numberOnly({ which: 58 })).toBe(false); // ':'
+    });
+
+    it('should fall back to keyCode when which is 0', () => {
+      expect(component.numberOnly({ which: 0, keyCode: 50 })).toBe(true); // '2'
+      expect(component.numberOnly({ which: 0, keyCode: 65 })).toBe(false); // 'A'
+    });
+  });
+
+  describe('onFieldBlur', () => {
+    it('should emit blurred', () => {
+      const spy = jest.spyOn(component.blurred, 'emit');
+      component.onFieldBlur();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onFieldFocus', () => {
+    it('should emit focused', () => {
+      const spy = jest.spyOn(component.focused, 'emit');
+      component.onFieldFocus();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should mark the control as touched when a control is present', () => {
+      const markAsTouchedSpy = jest.fn();
+      (component as any)._control = {
+        control: { markAsTouched: markAsTouchedSpy }
+      };
+      component.onFieldFocus();
+      expect(markAsTouchedSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('hint display', () => {
+    it('should display the hint when there is no error and hideDetails is false', () => {
+      component.hint = 'Select a time';
+      component.error = '';
+      fixture.detectChanges();
+      const hintEl = fixture.debugElement.query(By.css('.cps-timepicker-hint'));
+      expect(hintEl).toBeTruthy();
+      expect(hintEl.nativeElement.textContent.trim()).toBe('Select a time');
+    });
+
+    it('should not display the hint when hideDetails is true', () => {
+      component.hint = 'Select a time';
+      component.hideDetails = true;
+      fixture.detectChanges();
+      const hintEl = fixture.debugElement.query(By.css('.cps-timepicker-hint'));
+      expect(hintEl).toBeNull();
+    });
+
+    it('should not display the hint when an error is present', () => {
+      component.hint = 'Select a time';
+      component.error = 'Time is invalid';
+      fixture.detectChanges();
+      const hintEl = fixture.debugElement.query(By.css('.cps-timepicker-hint'));
+      expect(hintEl).toBeNull();
+    });
+  });
+
+  describe('error display', () => {
+    it('should display the error when error is set and hideDetails is false', () => {
+      component.error = 'Time is invalid';
+      fixture.detectChanges();
+      const errorEl = fixture.debugElement.query(
+        By.css('.cps-timepicker-error')
+      );
+      expect(errorEl).toBeTruthy();
+      expect(errorEl.nativeElement.textContent.trim()).toBe('Time is invalid');
+    });
+
+    it('should not display the error when hideDetails is true', () => {
+      component.error = 'Time is invalid';
+      component.hideDetails = true;
+      fixture.detectChanges();
+      const errorEl = fixture.debugElement.query(
+        By.css('.cps-timepicker-error')
+      );
+      expect(errorEl).toBeNull();
+    });
+
+    it('should not display the error element when error is empty', () => {
+      component.error = '';
+      fixture.detectChanges();
+      const errorEl = fixture.debugElement.query(
+        By.css('.cps-timepicker-error')
+      );
+      expect(errorEl).toBeNull();
+    });
+  });
+
+  describe('_checkErrors', () => {
+    function mockControl(
+      options: Partial<{
+        touched: boolean;
+        errors: Record<string, unknown> | null;
+        statusChanges: Subject<string>;
+      }>
+    ) {
+      (component as any)._control = {
+        control: {
+          touched: options.touched ?? false,
+          markAsTouched: jest.fn()
+        },
+        errors: options.errors ?? null,
+        statusChanges: options.statusChanges ?? new Subject()
+      };
+    }
+
+    it('should show "Field is required" when control has required error and is touched', () => {
+      mockControl({ touched: true, errors: { required: true } });
+      component.value = undefined;
+      component.onFieldBlur();
+      expect(component.error).toBe('Field is required');
+      expect(component.hoursError).toBe('Field is required');
+      expect(component.minutesError).toBe('Field is required');
+    });
+
+    it('should show a custom string error message from the errors object', () => {
+      mockControl({
+        touched: true,
+        errors: { custom: 'Invalid time range' }
+      });
+      component.value = undefined;
+      component.onFieldBlur();
+      expect(component.error).toBe('Invalid time range');
+    });
+
+    it('should show "Unknown error" when error value is not a string', () => {
+      mockControl({ touched: true, errors: { custom: true } });
+      component.value = undefined;
+      component.onFieldBlur();
+      expect(component.error).toBe('Unknown error');
+    });
+
+    it('should clear errors when control is untouched', () => {
+      component.error = 'Field is required';
+      mockControl({ touched: false, errors: { required: true } });
+      component.onFieldBlur();
+      expect(component.error).toBe('');
+    });
+
+    it('should clear errors when control has no errors', () => {
+      component.error = 'Field is required';
+      mockControl({ touched: true, errors: null });
+      component.onFieldBlur();
+      expect(component.error).toBe('');
+    });
+
+    it('should show invalid-value errors when value exists but is incomplete', () => {
+      mockControl({ touched: false, errors: null });
+      component.value = { hours: '10', minutes: '' };
+      component.onFieldBlur();
+      expect(component.error).toBe('Time is invalid');
+      expect(component.hoursError).toBe('');
+      expect(component.minutesError).toBe('Time is invalid');
+    });
+
+    it('should show invalid-value error for missing seconds when withSeconds is true', () => {
+      mockControl({ touched: false, errors: null });
+      component.withSeconds = true;
+      component.value = { hours: '10', minutes: '30', seconds: '' };
+      component.onFieldBlur();
+      expect(component.error).toBe('Time is invalid');
+      expect(component.secondsError).toBe('Time is invalid');
+    });
+
+    it('should set secondsError to empty string when withSeconds is false and setErrors is called', () => {
+      component.withSeconds = false;
+      mockControl({ touched: true, errors: { required: true } });
+      component.value = undefined;
+      component.onFieldBlur();
+      expect(component.secondsError).toBe('');
+    });
+
+    it('should set secondsError when withSeconds is true and setErrors is called', () => {
+      component.withSeconds = true;
+      mockControl({ touched: true, errors: { required: true } });
+      component.value = undefined;
+      component.onFieldBlur();
+      expect(component.secondsError).toBe('Field is required');
+    });
+  });
+
+  describe('statusChanges subscription', () => {
+    it('should call _checkErrors when status changes', () => {
+      const statusChanges$ = new Subject<string>();
+      (component as any)._control = {
+        control: { touched: false, markAsTouched: jest.fn() },
+        errors: null,
+        statusChanges: statusChanges$
+      };
+      component.ngOnInit();
+      const checkErrorsSpy = jest.spyOn(component as any, '_checkErrors');
+      statusChanges$.next('INVALID');
+      expect(checkErrorsSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.spec.ts
@@ -76,7 +76,7 @@ describe('CpsTimepickerComponent', () => {
       component.ariaLabel = '';
       component.ngOnChanges();
       expect(consoleSpy).toHaveBeenCalledWith(
-        'CpsTimepickerComponent: unlabeled timepicker component must have an ariaLabel for accessibility.'
+        'CpsTimepickerComponent: unlabeled component must have an ariaLabel for accessibility.'
       );
     });
 

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.ts
@@ -21,6 +21,7 @@ import {
 import { CpsAutocompleteComponent } from '../cps-autocomplete/cps-autocomplete.component';
 import { CpsTooltipPosition } from '../../directives/cps-tooltip/cps-tooltip.directive';
 import { CpsInfoCircleComponent } from '../cps-info-circle/cps-info-circle.component';
+import { logMissingAriaLabelError } from '../../utils/internal/accessibility-utils';
 
 /**
  * CpsTime is used to define the time format.
@@ -218,6 +219,12 @@ export class CpsTimepickerComponent
         this._checkErrors();
       }
     );
+
+    logMissingAriaLabelError(
+      'CpsTimepickerComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngAfterViewInit(): void {
@@ -227,11 +234,11 @@ export class CpsTimepickerComponent
   }
 
   ngOnChanges(): void {
-    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
-      console.error(
-        'CpsTimepickerComponent: unlabeled timepicker component must have an ariaLabel for accessibility.'
-      );
-    }
+    logMissingAriaLabelError(
+      'CpsTimepickerComponent',
+      this.label,
+      this.ariaLabel
+    );
   }
 
   ngOnDestroy() {

--- a/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-timepicker/cps-timepicker.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
   Optional,
@@ -49,13 +50,19 @@ export interface CpsTime {
   styleUrls: ['./cps-timepicker.component.scss']
 })
 export class CpsTimepickerComponent
-  implements OnInit, AfterViewInit, OnDestroy
+  implements OnInit, OnChanges, AfterViewInit, OnDestroy
 {
   /**
    * Label of the timepicker.
    * @group Props
    */
   @Input() label = '';
+
+  /**
+   * Aria label for the timepicker component, used for accessibility, it takes precedence over label.
+   * @group Props
+   */
+  @Input() ariaLabel = '';
 
   /**
    * Determines whether the timepicker is disabled.
@@ -217,6 +224,14 @@ export class CpsTimepickerComponent
     if (this.hoursField) this.hoursField.isTimePickerField = true;
     if (this.minutesField) this.minutesField.isTimePickerField = true;
     if (this.secondsField) this.secondsField.isTimePickerField = true;
+  }
+
+  ngOnChanges(): void {
+    if (!this.label?.trim() && !this.ariaLabel?.trim()) {
+      console.error(
+        'CpsTimepickerComponent: unlabeled timepicker component must have an ariaLabel for accessibility.'
+      );
+    }
   }
 
   ngOnDestroy() {

--- a/projects/cps-ui-kit/src/lib/utils/internal/accessibility-utils.ts
+++ b/projects/cps-ui-kit/src/lib/utils/internal/accessibility-utils.ts
@@ -32,3 +32,15 @@ export const focusElement = (element?: HTMLElement): void => {
     setTimeout(() => element.focus());
   }
 };
+
+export const logMissingAriaLabelError = (
+  componentName: string,
+  label?: string,
+  ariaLabel?: string
+): void => {
+  if (!label?.trim() && !ariaLabel?.trim()) {
+    console.error(
+      `${componentName}: unlabeled component must have an ariaLabel for accessibility.`
+    );
+  }
+};

--- a/tsconfig.generator.json
+++ b/tsconfig.generator.json
@@ -3,6 +3,11 @@
   "compilerOptions": {
     "skipLibCheck": true
   },
+  "include": [
+    "projects/cps-ui-kit/src/lib/components/**/*.ts",
+    "projects/cps-ui-kit/src/lib/services/**/*.ts",
+    "projects/cps-ui-kit/src/lib/directives/**/*.ts"
+  ],
   "exclude": [
     "projects/composition/**",
     "./node_modules/**",


### PR DESCRIPTION
## Fixing accessibility issues in timepicker component

### Validation rules:
Validated using Playwright accessibility tests, Lighthouse tool, and manual checks including keyboard tab navigation and screen reader testing.

[Full doc with rules](https://absacorp-my.sharepoint.com/:fl:/g/personal/andrei_fateev_absa_africa1/IQCXaIJSyyLNQJJuhWWI0FVpAVw6yjZ-O58HNmD5WymZTnk?e=wblvWh&nav=cz0lMkZwZXJzb25hbCUyRmFuZHJlaV9mYXRlZXZfYWJzYV9hZnJpY2ExJmQ9YiFwaGhlWkZVTzcwbThrWTNkRm5vNVZING9qaXA4SjNoUGs5WHNkUEYwcGhzUEdSZVhfeE5zVG9YcmtWX2xSU3V0JmY9MDFRWEJFUEZNWE5DQkZGU1pDWlZBSkUzVUZNV0VOQVZMSiZjPSUyRiZmbHVpZD0xJmE9TG9vcEFwcCZwPSU0MGZsdWlkeCUyRmxvb3AtcGFnZS1jb250YWluZXI%3D)

---

### Playwright axe-core validation results:

## State before:
| Component  | aria-roles | button-name | color-contrast | label | tabindex |
|------------|------------|-------------|----------------|-------|----------|
| Timepicker | -          | -           | ❌              | ❌     | ❌         |

---

## State after:
| Component  | aria-roles | button-name | color-contrast | label | tabindex |
|------------|------------|-------------|----------------|-------|----------|
| Timepicker | ✅          | ✅           | ✅              | ✅     | ✅        |

---

## Checklist

- [x] Keyboard Navigation
  All interactive elements are fully operable via keyboard only, including buttons, inputs, menus, dialogs, sliders, drag-and-drop, tree views, multi-selects, and composite widgets. No traps or dead ends.

- [x] Focus Management
  Focus is visible, logical, moves in predictable order, trapped where necessary (modals/popovers), and restored after closing. Focus is perceivable in all interactive widgets.

- [x] Semantics / ARIA
  - Semantic HTML is used correctly.
  - ARIA roles, states, and properties are applied only when needed.
  - All form fields, tables, and widgets (including autocomplete, tree selects, tree tables, drag-and-drop, sliders, and multi-selects) are properly labeled and accessible.

- [x] Color / Contrast
  - Text and interactive elements meet contrast requirements (≥4.5:1 normal text, ≥3:1 large text).
  - Focus and selection indicators are visually perceivable.
  - Color is not the only indicator of state.

- [x] Screen Reader / Assistive Technology
  - All content, labels, and dynamic updates are perceivable via screen readers.
  - Live regions announce status messages, alerts, modals, notifications, and dynamic changes.
  - Interactive widgets provide proper announcements of selection and updates.

- [x] Responsive & Zoom
  - Components function correctly and remain readable at all viewport sizes and up to 200% zoom, including mobile and touch devices.
  - Prefer em/rem units over px where scaling is required.

- [x] Error Handling
  - Errors are clearly identified visually and programmatically.
  - Form inputs use aria-describedby or aria-invalid for inline messages.
  - Instructions and suggestions are accessible.

- [x] Dynamic Content / Updates
  - Status updates, alerts, notifications, and modals use live regions.
  - Updates do not disrupt focus or user control unexpectedly.

- [x] Interaction Feedback / States
  - All interactive states (hover, focus, active, disabled, drag-and-drop, reordering, multi-select) are visually perceivable.

- [x] Authentication & Sensitive Actions
  - Inputs and actions involving sensitive data provide accessible instructions, feedback, and error messages.

- [x] Predictable & Controllable UI
  - Components behave consistently and predictably.
  - Popups, modals, autocomplete suggestions, drag-and-drop, and dynamic content allow user control.

---

## Additional changes

- Updated `tsconfig.generator.json` since `npm run generate-json-api` was failing with `[error] Unable to find any entry points`. The root tsconfig has "files": [], so TypeDoc requires the tsconfig to explicitly include those files.

- Added `composition/tsconfig.json` since `cps-ui-kit` couldn't be found by TS within composition app. VSCode's language server finds "files: []" and since the component file isn't explicitly included, it treats it as an inferred project which doesn't inherit the paths mapping.

- Added the `logMissingAriaLabelError` function to the accessibility utils. It is now executed in both `ngOnInit` and `ngOnChanges` for the required components.

---

## Release notes:
- Fix a11y issues in timepicker component
