### PR TITLE
Use focus-ring mixin for autocomplete component

### DIFF
--- a/projects/composition/src/app/pages/autocomplete-page/autocomplete-page.component.scss
+++ b/projects/composition/src/app/pages/autocomplete-page/autocomplete-page.component.scss
@@ -1,5 +1,5 @@
 .autocompletes-group {
-  gap: 24px;
+  gap: 1.5rem;
   display: flex;
   flex-direction: column;
 }
@@ -8,6 +8,6 @@
   display: flex;
   align-items: center;
   .sync-val {
-    margin-left: 24px;
+    margin-left: 1.5rem;
   }
 }

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
@@ -28,6 +28,7 @@
     (keydown)="onContainerKeyDown($event)"
     class="cps-autocomplete-container"
     [class.active]="isActive"
+    [class.keyboard-focused]="isKeyboardFocused"
     [ngClass]="{
       'persistent-clear': persistentClear,
       borderless: appearance === 'borderless',

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.scss
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.scss
@@ -55,6 +55,14 @@ $hover-transition-duration: 0.2s;
           border-bottom: 0.0625rem solid $autocomplete-border-color !important;
         }
       }
+
+      &.keyboard-focused {
+        @include focus-ring(0, -0.0625rem, 0.25rem);
+        &::before,
+        &::after {
+          pointer-events: none;
+        }
+      }
     }
 
     &.active {

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -503,4 +503,72 @@ describe('CpsAutocompleteComponent', () => {
       );
     });
   });
+
+  describe('keyboard focus ring', () => {
+    it('should set isKeyboardFocused to true when focused via keyboard', () => {
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(true);
+    });
+
+    it('should not set isKeyboardFocused when focus follows a mouse box click', () => {
+      component.onBoxClick();
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(false);
+    });
+
+    it('should reset isKeyboardFocused on blur', () => {
+      component.isKeyboardFocused = true;
+      component.onBlur();
+      expect(component.isKeyboardFocused).toBe(false);
+    });
+
+    it('should allow next keyboard focus to show ring after blur resets mouse state', () => {
+      component.onBoxClick();
+      component.onBlur();
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(true);
+    });
+
+    it('should reset isKeyboardFocused when the box is clicked via mouse', () => {
+      component.isKeyboardFocused = true;
+      component.onBoxClick();
+      expect(component.isKeyboardFocused).toBe(false);
+    });
+
+    it('should reset isKeyboardFocused when an option is clicked', () => {
+      component.isKeyboardFocused = true;
+      component.onOptionClick(component.options[0]);
+      expect(component.isKeyboardFocused).toBe(false);
+    });
+
+    it('should set isKeyboardFocused to true when arrow-down is pressed', () => {
+      component.onContainerKeyDown({ keyCode: 40 });
+      expect(component.isKeyboardFocused).toBe(true);
+    });
+
+    it('should set isKeyboardFocused to true when Enter is pressed in the dropdown', () => {
+      jest.spyOn(component, 'select').mockImplementation(() => {});
+      component.onContainerKeyDown({ keyCode: 13 });
+      expect(component.isKeyboardFocused).toBe(true);
+    });
+
+    it('should not change isKeyboardFocused when Tab is pressed in the container', () => {
+      component.isKeyboardFocused = false;
+      component.onContainerKeyDown({ keyCode: 9 });
+      expect(component.isKeyboardFocused).toBe(false);
+
+      component.isKeyboardFocused = true;
+      component.onContainerKeyDown({ keyCode: 9 });
+      expect(component.isKeyboardFocused).toBe(true);
+    });
+
+    it('should apply keyboard-focused class to container when isKeyboardFocused is true', () => {
+      component.isKeyboardFocused = true;
+      fixture.detectChanges();
+      const container = fixture.debugElement.query(
+        By.css('.cps-autocomplete-container.keyboard-focused')
+      );
+      expect(container).toBeTruthy();
+    });
+  });
 });

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -4,6 +4,7 @@ import {
   TestBed,
   discardPeriodicTasks,
   fakeAsync,
+  flush,
   tick
 } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -510,11 +511,45 @@ describe('CpsAutocompleteComponent', () => {
       expect(component.isKeyboardFocused).toBe(true);
     });
 
-    it('should not set isKeyboardFocused when focus follows a mouse box click', () => {
+    it('should not set isKeyboardFocused when focus follows a mouse box click', fakeAsync(() => {
       component.onBoxClick();
       component.onFocus();
       expect(component.isKeyboardFocused).toBe(false);
-    });
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('should set isKeyboardFocused when chevron is activated via keyboard', fakeAsync(() => {
+      component.onChevronClick(new KeyboardEvent('keydown', { key: 'Enter' }));
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(true);
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('should not set isKeyboardFocused when clear is triggered by mouse', fakeAsync(() => {
+      fixture.componentRef.setInput('openOnClear', false);
+      component.value = component.options[0];
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      component.clear(new MouseEvent('click'));
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(false);
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('should set isKeyboardFocused when clear is triggered by keyboard', fakeAsync(() => {
+      fixture.componentRef.setInput('openOnClear', false);
+      component.value = component.options[0];
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      component.clear(new KeyboardEvent('keydown', { key: 'Enter' }));
+      component.onFocus();
+      expect(component.isKeyboardFocused).toBe(true);
+      flush();
+      discardPeriodicTasks();
+    }));
 
     it('should reset isKeyboardFocused on blur', () => {
       component.isKeyboardFocused = true;
@@ -522,18 +557,22 @@ describe('CpsAutocompleteComponent', () => {
       expect(component.isKeyboardFocused).toBe(false);
     });
 
-    it('should allow next keyboard focus to show ring after blur resets mouse state', () => {
+    it('should allow next keyboard focus to show ring after blur resets mouse state', fakeAsync(() => {
       component.onBoxClick();
       component.onBlur();
       component.onFocus();
       expect(component.isKeyboardFocused).toBe(true);
-    });
+      flush();
+      discardPeriodicTasks();
+    }));
 
-    it('should reset isKeyboardFocused when the box is clicked via mouse', () => {
+    it('should reset isKeyboardFocused when the box is clicked via mouse', fakeAsync(() => {
       component.isKeyboardFocused = true;
       component.onBoxClick();
       expect(component.isKeyboardFocused).toBe(false);
-    });
+      flush();
+      discardPeriodicTasks();
+    }));
 
     it('should reset isKeyboardFocused when an option is clicked', () => {
       component.isKeyboardFocused = true;

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -547,7 +547,6 @@ describe('CpsAutocompleteComponent', () => {
     });
 
     it('should set isKeyboardFocused to true when Enter is pressed in the dropdown', () => {
-      jest.spyOn(component, 'select').mockImplementation(() => {});
       component.onContainerKeyDown({ keyCode: 13 });
       expect(component.isKeyboardFocused).toBe(true);
     });

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -422,6 +422,7 @@ export class CpsAutocompleteComponent
   cvtWidth = '';
   isOpened = false;
   isActive = false;
+  isKeyboardFocused = false;
   inputText = '';
   inputTextDebounced = '';
   filteredOptions: any[] = [];
@@ -458,6 +459,7 @@ export class CpsAutocompleteComponent
   private _inputChangeSubject$ = new Subject<string>();
   private _destroy$ = new Subject<void>();
 
+  private _mouseActivated = false;
   private _options: any[] = [];
   private _optionIds = new WeakMap<object, string>();
 
@@ -607,6 +609,8 @@ export class CpsAutocompleteComponent
   }
 
   onOptionClick(option: any) {
+    this.isKeyboardFocused = false;
+    this._mouseActivated = true;
     this._clickOption(option);
   }
 
@@ -713,6 +717,8 @@ export class CpsAutocompleteComponent
 
   onBlur() {
     this.isActive = false;
+    this.isKeyboardFocused = false;
+    this._mouseActivated = false;
 
     this._confirmInput(this.inputText || '', false);
 
@@ -727,7 +733,9 @@ export class CpsAutocompleteComponent
   onFocus() {
     if (!this.disabled) {
       this.isActive = true;
+      this.isKeyboardFocused = !this._mouseActivated;
     }
+    this._mouseActivated = false;
 
     if (!this.multiple) {
       this.activeSingle = true;
@@ -755,6 +763,8 @@ export class CpsAutocompleteComponent
   }
 
   onBoxClick() {
+    this._mouseActivated = true;
+    this.isKeyboardFocused = false;
     const wasOpened = this.isOpened;
     if (!this.multiple) {
       this.activeSingle = true;
@@ -772,6 +782,9 @@ export class CpsAutocompleteComponent
 
   onContainerKeyDown(event: any) {
     const code = event.keyCode;
+    if ([13, 38, 40].includes(code)) {
+      this.isKeyboardFocused = true;
+    }
     // enter
     if (code === 13) {
       let idx = this.optionHighlightedIndex;

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -706,9 +706,13 @@ export class CpsAutocompleteComponent
     this.clearInput();
     this._dehighlightOption();
     if (hadValue) {
+      this._mouseActivated = !(event instanceof KeyboardEvent);
       setTimeout(() => {
         this.focusInput();
       }, 0);
+    }
+    if (!(event instanceof KeyboardEvent)) {
+      this.isKeyboardFocused = false;
     }
   }
 
@@ -762,9 +766,11 @@ export class CpsAutocompleteComponent
     this._closeAndClear();
   }
 
-  onBoxClick() {
-    this._mouseActivated = true;
-    this.isKeyboardFocused = false;
+  onBoxClick(fromKeyboard = false) {
+    this._mouseActivated = !fromKeyboard;
+    if (!fromKeyboard) {
+      this.isKeyboardFocused = false;
+    }
     const wasOpened = this.isOpened;
     if (!this.multiple) {
       this.activeSingle = true;
@@ -846,7 +852,7 @@ export class CpsAutocompleteComponent
     if (this.isOpened) {
       this._closeAndClear();
     } else {
-      this.onBoxClick();
+      this.onBoxClick(event instanceof KeyboardEvent);
     }
   }
 


### PR DESCRIPTION
## Overview
The focused state of the autocomplete component was previously indicated by borders only. 
This PR addresses the focus management gap by implementing an always-visible focus ring for keyboard navigation, resolving an issue that was especially noticeable in components with `borderless` and `underlined`, where the active state was not clearly visible due to the absence of borders.

---

## Release notes:
- Use focus-ring mixin for autocomplete component