### PR TITLE
ci: set include-component-in-tag to false

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "last-release-sha": "2ee83e6e381113c634dfd8b25f5e12593da9aacf",
   "packages": {
     "projects/cps-ui-kit": {


### PR DESCRIPTION
Set `include-component-in-tag` to false (to not include `cps-ui-kit` in the tag, to align with our previous tags).