### PR TITLE
Fix docs publish trigger for UI kit assets

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -10,7 +10,7 @@ on:
       - 'angular.json'
       - 'tsconfig.generator.json'
       - 'api-generator/**'
-      - 'projects/cps-ui-kit/src/**'
+      - 'projects/cps-ui-kit/**'
       - 'projects/composition/**'
       - '.github/**'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Expand the documentation publish workflow path filter from `projects/cps-ui-kit/src/**` to `projects/cps-ui-kit/**`.
- Ensure UI kit asset-only changes, including `projects/cps-ui-kit/assets/icons.svg`, trigger documentation rebuild and publish.

## Verification
- `git diff --check`

Fixes #415