### PR TITLE
Fix input info tooltip without label

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.html
@@ -1,9 +1,11 @@
 <div class="cps-input-container" [style.width]="cvtWidth">
-  @if (label) {
+  @if (label || infoTooltip) {
     <div
       class="cps-input-label"
       [class.cps-input-label-disabled]="disabled && !readonly">
-      <label>{{ label }}</label>
+      @if (label) {
+        <label>{{ label }}</label>
+      }
       @if (infoTooltip) {
         <cps-info-circle
           class="cps-input-label-info-circle"

--- a/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.spec.ts
@@ -131,6 +131,20 @@ describe('CpsInputComponent', () => {
       expect(hint?.textContent?.trim()).toBe('Helper text');
     });
 
+    it('should display info tooltip without label', () => {
+      fixture.componentRef.setInput('label', '');
+      fixture.componentRef.setInput('infoTooltip', 'More information');
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('label');
+      const infoTooltip = fixture.nativeElement.querySelector(
+        '.cps-input-label-info-circle'
+      );
+
+      expect(label).toBeNull();
+      expect(infoTooltip).toBeTruthy();
+    });
+
     it('should change input type', () => {
       component.type = 'password';
       component.ngOnInit();


### PR DESCRIPTION
## Summary
- Render the `cps-input` label/tooltip row when either `label` or `infoTooltip` is provided.
- Keep the actual `<label>` element conditional so label-less inputs do not render an empty label.
- Add regression coverage for an `infoTooltip` without `label`.

## Verification
- `npx jest projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.spec.ts --runInBand`
- `npx eslint projects/cps-ui-kit/src/lib/components/cps-input/cps-input.component.spec.ts --quiet`
- `git diff --check`

Fixes #416