### PR TITLE
feat: change default date format in the CpsDatepickerComponent to DD/MM/YYYY

### DIFF
--- a/.github/workflows/check_pr_title_cc.yml
+++ b/.github/workflows/check_pr_title_cc.yml
@@ -3,7 +3,7 @@ name: Check PR Title (Conventional Commits)
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
-    branches: [master]
+    branches: [master, next-major]
 
 jobs:
   check-pr-title:

--- a/projects/composition/src/app/api-data/cps-datepicker.json
+++ b/projects/composition/src/app/api-data/cps-datepicker.json
@@ -42,7 +42,7 @@
                         "optional": false,
                         "readonly": false,
                         "type": "CpsDatepickerDateFormat",
-                        "default": "MM/DD/YYYY",
+                        "default": "DD/MM/YYYY",
                         "description": "Date format for displaying and parsing the date string."
                     },
                     {

--- a/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
+++ b/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
@@ -24,7 +24,7 @@
       </cps-datepicker>
       <cps-datepicker
         label="Datepicker with restricted date range"
-        hint="This datepicker has selectable dates from 01/01/2023 to 12/31/2025"
+        hint="This datepicker has selectable dates from 01/01/2023 to 31/12/2025"
         [showTodayButton]="false"
         [value]="defaultDate"
         [clearable]="true"

--- a/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
+++ b/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
@@ -37,9 +37,9 @@
         [showTodayButton]="false">
       </cps-datepicker>
       <cps-datepicker
-        label="Datepicker with DD/MM/YYYY date format"
+        label="Datepicker with MM/DD/YYYY date format"
         [clearable]="true"
-        dateFormat="DD/MM/YYYY">
+        dateFormat="MM/DD/YYYY">
       </cps-datepicker>
       <div class="sync-val-example">
         <cps-datepicker

--- a/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.ts
@@ -92,7 +92,7 @@ export class CpsDatepickerComponent
    * Date format for displaying and parsing the date string.
    * @group Props
    */
-  @Input() dateFormat: CpsDatepickerDateFormat = 'MM/DD/YYYY';
+  @Input() dateFormat: CpsDatepickerDateFormat = 'DD/MM/YYYY';
 
   /**
    * Placeholder text. Defaults to the configured dateFormat.


### PR DESCRIPTION
## This PR targets the `next-major` branch, rather than `master`, as it is part of the next major version update.

## ⚠️ Breaking change

The default date format of `CpsDatepickerComponent` has changed from `MM/DD/YYYY` to `DD/MM/YYYY`.

If you want to preserve the previous behavior, explicitly specify the date format:

```html
<cps-datepicker
  dateFormat="MM/DD/YYYY"
  ...>
</cps-datepicker>
```


## Release notes:
- Change default date format in the CpsDatepickerComponent to DD/MM/YYYY