### PR TITLE
fix: tree autocomplete and tree select with virtual scroll fails to reopen dropdown when no value is selected

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
@@ -400,13 +400,15 @@ describe('CpsBaseTreeDropdownComponent', () => {
       const elementViewChild = {
         nativeElement: { style: {} as Record<string, string> }
       };
+      const scrollerStyle = {} as Record<string, string>;
       (component as any).treeList = {
-        scroller: { style: {}, elementViewChild }
+        scroller: { style: scrollerStyle, elementViewChild }
       };
 
       (component as any)._setTreeListHeight('7.5rem');
 
       expect(elementViewChild.nativeElement.style.height).toBe('7.5rem');
+      expect(scrollerStyle.height).toBeUndefined();
     });
 
     it('recalcVirtualListHeight should apply the computed height to elementViewChild', () => {
@@ -428,7 +430,9 @@ describe('CpsBaseTreeDropdownComponent', () => {
 
       component.recalcVirtualListHeight();
 
-      expect(elementViewChild.nativeElement.style.height).toBe('7.5rem');
+      expect(elementViewChild.nativeElement.style.height).toBe(
+        `${component.virtualListHeightRem}rem`
+      );
     });
   });
 

--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
@@ -395,6 +395,43 @@ describe('CpsBaseTreeDropdownComponent', () => {
     });
   });
 
+  describe('Virtual scroll list height', () => {
+    it('should set the height on scroller.elementViewChild, not scroller.style', () => {
+      const elementViewChild = {
+        nativeElement: { style: {} as Record<string, string> }
+      };
+      (component as any).treeList = {
+        scroller: { style: {}, elementViewChild }
+      };
+
+      (component as any)._setTreeListHeight('7.5rem');
+
+      expect(elementViewChild.nativeElement.style.height).toBe('7.5rem');
+    });
+
+    it('recalcVirtualListHeight should apply the computed height to elementViewChild', () => {
+      fixture.componentRef.setInput('virtualScroll', true);
+      fixture.detectChanges();
+
+      const elementViewChild = {
+        nativeElement: { style: {} as Record<string, string> }
+      };
+      (component as any).treeList = {
+        serializedValue: [{}, {}, {}],
+        scroller: {
+          style: {},
+          elementViewChild,
+          calculateOptions: jest.fn(),
+          cd: { detectChanges: jest.fn() }
+        }
+      };
+
+      component.recalcVirtualListHeight();
+
+      expect(elementViewChild.nativeElement.style.height).toBe('7.5rem');
+    });
+  });
+
   describe('Focus / Blur', () => {
     it('should emit focused on onFocus', () => {
       jest.spyOn(component.focused, 'emit');

--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
@@ -803,8 +803,10 @@ export class CpsBaseTreeDropdownComponent
   }
 
   private _setTreeListHeight(height: string) {
-    if (this.treeList?.scroller?.style)
-      this.treeList.scroller.style.height = height;
+    const scrollerEl = this.treeList?.scroller?.elementViewChild?.nativeElement;
+    if (scrollerEl) {
+      scrollerEl.style.height = height;
+    }
   }
 
   private _nodeToggled(elem: HTMLElement, key?: string) {

--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
@@ -804,7 +804,7 @@ export class CpsBaseTreeDropdownComponent
 
   private _setTreeListHeight(height: string) {
     const scrollerEl = this.treeList?.scroller?.elementViewChild?.nativeElement;
-    if (scrollerEl) {
+    if (scrollerEl?.style) {
       scrollerEl.style.height = height;
     }
   }


### PR DESCRIPTION
## Issue
With `[virtualScroll]="true"` and no selected value, `cps-tree-autocomplete` (and `cps-tree-select`, which shares the same base) opened correctly the first time, but after closing and reopening, the dropdown appeared to do nothing - the chevron icon still rotated correctly (isOpened was true, the panel was technically rendered), but no options were visible.

## Root cause
`CpsBaseTreeDropdownComponent._setTreeListHeight()` set the virtual scroll list's height via `this.treeList.scroller.style.height = height;`.

`scroller.style` is PrimeNG Scroller's `@Input() style` property - an object that isn't wired to any element actually affecting layout. The DOM node that controls the real, visible scroll viewport height is `scroller.elementViewChild.nativeElement`, a different node entirely. Writing to `scroller.style` was a no-op for layout purposes.

On first open, PrimeNG's own internal sizing (`Scroller.setSize()`, driven by an internal `setTimeout(1)` measurement) happened to land on a correct height by chance. On reopen, that same internal measurement raced against layout and settled on `0px`, and since our own height fix was writing to the wrong property, nothing corrected it - leaving the dropdown panel rendered but visually collapsed to zero height.

## Fix
`_setTreeListHeight()` now writes to `scroller.elementViewChild.nativeElement.style.height` instead, which is the element that actually clips/sizes the virtual scroll viewport.

---

## Release notes:
- fix: tree autocomplete with virtual scroll fails to reopen dropdown when no value is selected
- fix: tree select with virtual scroll fails to reopen dropdown when no value is selected