### PR TITLE
fix: resolve NG0956 track-by-identity warning in cps-autocomplete

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
@@ -79,7 +79,7 @@
                   aria-label="Selected options">
                   @for (
                     val of value;
-                    track returnObject ? val[optionValue] : val;
+                    track returnObject ? (val?.[optionValue] ?? val) : val;
                     let last = $last
                   ) {
                     <div
@@ -118,7 +118,7 @@
                   aria-label="Selected options">
                   @for (
                     val of value;
-                    track returnObject ? val[optionValue] : val;
+                    track returnObject ? (val?.[optionValue] ?? val) : val;
                     let last = $last
                   ) {
                     <cps-chip
@@ -284,7 +284,7 @@
           } @else {
             @for (
               item of filteredOptions;
-              track item[optionValue];
+              track item?.[optionValue] ?? item;
               let itemIndex = $index
             ) {
               <ng-container

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.html
@@ -77,7 +77,11 @@
                   role="list"
                   tabindex="-1"
                   aria-label="Selected options">
-                  @for (val of value; track val; let last = $last) {
+                  @for (
+                    val of value;
+                    track returnObject ? val[optionValue] : val;
+                    let last = $last
+                  ) {
                     <div
                       class="text-group-item"
                       role="listitem"
@@ -112,7 +116,11 @@
                   role="list"
                   tabindex="-1"
                   aria-label="Selected options">
-                  @for (val of value; track val; let last = $last) {
+                  @for (
+                    val of value;
+                    track returnObject ? val[optionValue] : val;
+                    let last = $last
+                  ) {
                     <cps-chip
                       role="listitem"
                       closeButtonAriaLabel="Remove"
@@ -274,7 +282,11 @@
               </ng-template>
             </p-virtualscroller>
           } @else {
-            @for (item of filteredOptions; track item; let itemIndex = $index) {
+            @for (
+              item of filteredOptions;
+              track item[optionValue];
+              let itemIndex = $index
+            ) {
               <ng-container
                 *ngTemplateOutlet="
                   itemTemplate;


### PR DESCRIPTION
## Summary
- `cps-autocomplete`'s dropdown option list and selected-value chip lists used Angular's `@for` with identity-based tracking (`track item` / `track val`), which triggers `NG0956` and unnecessary DOM re-creation whenever `options`/`value` are updated with a new array of equivalent objects (a common pattern, e.g. re-fetched options or reassigned selection).
- Updated the three `@for` loops in `cps-autocomplete.component.html` to track by the configured `optionValue` field, falling back to the raw item/value when that field isn't present:
  - Dropdown options: `track item[optionValue] ?? item` (options are always full option objects, independent of `returnObject`).
  - Selected-value chips (text mode and `cps-chip` mode): `track returnObject ? (val[optionValue] ?? val) : val`, since `value` holds either the full option object or the extracted primitive depending on `returnObject`.
- This mirrors the existing precedent in `cps-button-toggle` (`track option.value`) for the common case, while staying correct for the documented `returnObject: true` case where `optionValue` isn't guaranteed to exist on consumer objects (selection matching in that mode already relies on deep `isEqual`, not `optionValue` - see `check-option-selected.pipe.ts` and `select()` in `cps-autocomplete.component.ts`). 

---

## Release notes:
- fix: resolve NG0956 track-by-identity warning in cps-autocomplete