### PR TITLE
fix: prevent chip removal from closing autocomplete/select dropdown

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -464,6 +464,44 @@ describe('CpsAutocompleteComponent', () => {
     expect(component.filteredOptions.length).toBe(3);
   });
 
+  describe('Chip Removal', () => {
+    beforeEach(() => {
+      window.HTMLElement.prototype.scrollIntoView = jest.fn();
+      fixture.componentRef.setInput('multiple', true);
+      component.value = [component.options[0], component.options[1]];
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+    });
+
+    it('should prevent default on chip close button mousedown so the box does not lose focus', () => {
+      const closeBtn = fixture.debugElement.query(
+        By.css('.cps-chip-close-btn')
+      );
+      const event = new MouseEvent('mousedown', { cancelable: true });
+      closeBtn.nativeElement.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should keep the dropdown open and remove the value when a chip close button is clicked', fakeAsync(() => {
+      component.onBoxClick();
+      tick();
+      fixture.detectChanges();
+      expect(component.isOpened).toBe(true);
+
+      const closeBtn = fixture.debugElement.query(
+        By.css('.cps-chip-close-btn')
+      );
+      closeBtn.nativeElement.click();
+      fixture.detectChanges();
+      tick();
+
+      expect(component.isOpened).toBe(true);
+      expect(component.value).not.toContainEqual(component.options[0]);
+      expect(component.value).toContainEqual(component.options[1]);
+      discardPeriodicTasks();
+    }));
+  });
+
   describe('aria-label', () => {
     it('should set aria-label from ariaLabel input', () => {
       fixture.componentRef.setInput('ariaLabel', 'Search options');

--- a/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.html
@@ -12,6 +12,7 @@
       class="cps-chip-close-btn"
       [disabled]="disabled"
       [attr.aria-label]="closeButtonAriaLabel"
+      (mousedown)="$event.preventDefault()"
       (click)="onCloseClick($event)"
       (keydown.enter)="$event.stopPropagation()">
       <cps-icon icon="close-x" size="xsmall" color="text-darkest"></cps-icon>

--- a/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.spec.ts
@@ -455,6 +455,40 @@ describe('CpsSelectComponent', () => {
     });
   });
 
+  describe('Chip Removal', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('multiple', true);
+      component.writeValue([OPTIONS[0], OPTIONS[1]]);
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+    });
+
+    it('should prevent default on chip close button mousedown so the box does not lose focus', () => {
+      const closeBtn = fixture.debugElement.query(
+        By.css('.cps-chip-close-btn')
+      );
+      const event = new MouseEvent('mousedown', { cancelable: true });
+      closeBtn.nativeElement.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should keep the dropdown open and remove the value when a chip close button is clicked', () => {
+      component.onBoxClick();
+      fixture.detectChanges();
+      expect(component.isOpened).toBe(true);
+
+      const closeBtn = fixture.debugElement.query(
+        By.css('.cps-chip-close-btn')
+      );
+      closeBtn.nativeElement.click();
+      fixture.detectChanges();
+
+      expect(component.isOpened).toBe(true);
+      expect(component.value).not.toContainEqual(OPTIONS[0]);
+      expect(component.value).toContainEqual(OPTIONS[1]);
+    });
+  });
+
   describe('onBeforeOptionsHidden', () => {
     it('should close dropdown on SCROLL', () => {
       component.onBoxClick();


### PR DESCRIPTION
## Summary
- Removing a selected chip via its close button was closing the open dropdown panel in `cps-autocomplete` and `cps-select` (multiple mode). This happened because the browser's default mousedown-focus behavior on the chip's close `<button>` blurred the input/container before the click registered, triggering the existing blur-close handler.
- Added `(mousedown)="$event.preventDefault()"` to the close button in `cps-chip.component.html`, the same guard already used elsewhere in these components (clear icon, chevron, option rows) to prevent this exact focus-shift side effect.

---

## Release notes:
- fix: prevent chip removal from closing autocomplete/select dropdown