### PR TITLE
fix: tree select/tree autocomplete virtual scroll rendering and scroll-to-selection on open

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.spec.ts
@@ -1,5 +1,10 @@
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -395,6 +400,99 @@ describe('CpsBaseTreeDropdownComponent', () => {
     });
   });
 
+  describe('Scroll to selection on open', () => {
+    // must run after any fixture.detectChanges() call in a test, since that
+    // re-resolves @ViewChild('treeList') and would overwrite this stub
+    const stubTreeList = () => {
+      (component as any).treeList = {
+        cd: { markForCheck: jest.fn(), detectChanges: jest.fn() },
+        updateSerializedValue: jest.fn(),
+        serializedValue: [{ node: { key: '0' } }, { node: { key: '1' } }],
+        scroller: {
+          calculateOptions: jest.fn(),
+          cd: { detectChanges: jest.fn() }
+        },
+        scrollToVirtualIndex: jest.fn()
+      };
+    };
+
+    beforeEach(() => {
+      component.writeValue(OPTIONS[0]);
+      stubTreeList();
+    });
+
+    it('should scroll the selected node into view when its element is found by key', fakeAsync(() => {
+      const scrollIntoView = jest.fn();
+      const querySelector = jest.fn().mockReturnValue({ scrollIntoView });
+      (component as any).treeContainerElement = {
+        querySelector,
+        removeEventListener: jest.fn()
+      };
+
+      component.toggleOptions(true);
+      tick();
+
+      expect(querySelector).toHaveBeenCalledWith('.key-0');
+      expect(scrollIntoView).toHaveBeenCalled();
+      expect(
+        (component as any).treeList.scrollToVirtualIndex
+      ).not.toHaveBeenCalled();
+    }));
+
+    it('should fall back to scrollToVirtualIndex when the node is not rendered and virtualScroll is on', fakeAsync(() => {
+      fixture.componentRef.setInput('virtualScroll', true);
+      fixture.detectChanges();
+      stubTreeList();
+      const querySelector = jest.fn().mockReturnValue(null);
+      (component as any).treeContainerElement = {
+        querySelector,
+        removeEventListener: jest.fn()
+      };
+
+      component.toggleOptions(true);
+      tick();
+
+      // OPTIONS[0] resolves to key '0', which is at index 0 in serializedValue -
+      // this locks in the `??` fix (findIndex returning 0 must not be discarded as "not found")
+      expect(
+        (component as any).treeList.scrollToVirtualIndex
+      ).toHaveBeenCalledWith(0);
+    }));
+
+    it('should not scroll when the node is not rendered and virtualScroll is off', fakeAsync(() => {
+      const querySelector = jest.fn().mockReturnValue(null);
+      (component as any).treeContainerElement = {
+        querySelector,
+        removeEventListener: jest.fn()
+      };
+
+      component.toggleOptions(true);
+      tick();
+
+      expect(
+        (component as any).treeList.scrollToVirtualIndex
+      ).not.toHaveBeenCalled();
+    }));
+
+    it('should use the first selected key for scrolling when multiple is enabled', fakeAsync(() => {
+      fixture.componentRef.setInput('multiple', true);
+      component.writeValue([OPTIONS[0], OPTIONS[1]]);
+      stubTreeList();
+      const scrollIntoView = jest.fn();
+      const querySelector = jest.fn().mockReturnValue({ scrollIntoView });
+      (component as any).treeContainerElement = {
+        querySelector,
+        removeEventListener: jest.fn()
+      };
+
+      component.toggleOptions(true);
+      tick();
+
+      expect(querySelector).toHaveBeenCalledWith('.key-0');
+      expect(scrollIntoView).toHaveBeenCalled();
+    }));
+  });
+
   describe('Virtual scroll list height', () => {
     it('should set the height on scroller.elementViewChild, not scroller.style', () => {
       const elementViewChild = {
@@ -433,6 +531,37 @@ describe('CpsBaseTreeDropdownComponent', () => {
       expect(elementViewChild.nativeElement.style.height).toBe(
         `${component.virtualListHeightRem}rem`
       );
+    });
+
+    it('updateOptions should refresh serializedValue and force treeList to re-check so the scroller sees fresh items', () => {
+      fixture.componentRef.setInput('virtualScroll', true);
+      fixture.detectChanges();
+
+      const updateSerializedValue = jest.fn();
+      const detectChanges = jest.fn();
+      (component as any).treeList = {
+        updateSerializedValue,
+        cd: { detectChanges }
+      };
+
+      component.updateOptions();
+
+      expect(updateSerializedValue).toHaveBeenCalled();
+      expect(detectChanges).toHaveBeenCalled();
+    });
+
+    it('updateOptions should be a no-op when virtualScroll is disabled', () => {
+      const updateSerializedValue = jest.fn();
+      const detectChanges = jest.fn();
+      (component as any).treeList = {
+        updateSerializedValue,
+        cd: { detectChanges }
+      };
+
+      component.updateOptions();
+
+      expect(updateSerializedValue).not.toHaveBeenCalled();
+      expect(detectChanges).not.toHaveBeenCalled();
     });
   });
 

--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
@@ -550,28 +550,30 @@ export class CpsBaseTreeDropdownComponent
       setTimeout(() => {
         this.updateOptions();
         this.recalcVirtualListHeight();
-        const selected = this.treeContainerElement?.querySelector(
-          '.p-highlight'
-        ) as any;
+
+        let key = '';
+        if (this.treeSelection) {
+          if (this.multiple) {
+            if (this.treeSelection.length > 0) key = this.treeSelection[0].key;
+          } else key = this.treeSelection.key;
+        }
+
+        const selected = key
+          ? (this.treeContainerElement?.querySelector(`.key-${key}`) as any)
+          : null;
         if (selected) {
           selected.scrollIntoView({
             behavior: 'instant',
             block: 'nearest',
             inline: 'center'
           });
-        } else if (this.virtualScroll && this.treeSelection) {
-          let key = '';
-          if (this.multiple) {
-            if (this.treeSelection.length > 0) key = this.treeSelection[0].key;
-          } else key = this.treeSelection.key;
-          if (key) {
-            const idx =
-              this.treeList?.serializedValue?.findIndex(
-                // https://github.com/primefaces/primeng/blob/v16.4.3/src/app/components/tree/tree.ts#L1125
-                (v: any) => v.node.key === key
-              ) || -1;
-            if (idx >= 0) this.treeList.scrollToVirtualIndex(idx);
-          }
+        } else if (this.virtualScroll && key) {
+          const idx =
+            this.treeList?.serializedValue?.findIndex(
+              // https://github.com/primefaces/primeng/blob/v16.4.3/src/app/components/tree/tree.ts#L1125
+              (v: any) => v.node.key === key
+            ) ?? -1;
+          if (idx >= 0) this.treeList.scrollToVirtualIndex(idx);
         }
       });
     }
@@ -749,6 +751,10 @@ export class CpsBaseTreeDropdownComponent
   updateOptions() {
     if (!this.virtualScroll) return;
     this.treeList?.updateSerializedValue();
+    // treeList is OnPush and serializedValue is a plain field, so its new
+    // value won't reach the scroller's items input until treeList's own
+    // view is force-checked
+    this.treeList?.cd?.detectChanges();
   }
 
   private _initContainerClickListener() {


### PR DESCRIPTION
## Description

### What
Two fixes to `cps-tree-select` / `cps-tree-autocomplete`'s dropdown, both in
`CpsBaseTreeDropdownComponent`:
1. Virtual scroll no longer renders stale rows when the dropdown is reopened after a nested
   selection.
2. Opening the dropdown now actually scrolls the selected item into view, in both virtual and
   non-virtual scroll modes.

### Why

**1. Stale virtual scroll rows on reopen.** PrimeNG's `Tree` is `OnPush`, and its
`updateSerializedValue()` reassigns the `serializedValue` field that feeds the nested `p-scroller`'s
`items` input via a plain property write — with no `markForCheck()`/`detectChanges()`. The new value
isn't pushed into the scroller until `Tree`'s own view is explicitly re-checked.
`CpsBaseTreeDropdownComponent.updateOptions()` called `updateSerializedValue()` and then immediately
triggered the virtual list height/viewport recalculation, which read the scroller's still-stale
`items`. The container ended up correctly sized (height is calculated independently, from
`treeList.serializedValue.length`) but the rendered rows lagged behind. A subsequent native `scroll`
event happens to mark the `Tree` ancestor view dirty as a side effect of Angular's event-dispatch
mechanism, which is why manual scrolling appeared to "fix" it.

**2. Scroll-to-selection never firing.** The lookup used `.querySelector('.p-highlight')` to find
the selected node's DOM element — a class from an old PrimeNG version (this repo runs
`primeng@21.x`; some code here and its comments still reference v16.4.3 behavior). That selector
never matches in the installed version, so the primary scroll path was dead code in *every* case.
Virtual scroll mode had a fallback (`scrollToVirtualIndex`), but it also silently skipped a match at
index `0` due to `` findIndex(...) || -1 `` coercing a real `0` result to `-1`.

### How
- `updateOptions()` now calls `this.treeList?.cd?.detectChanges()` immediately after
  `this.treeList?.updateSerializedValue()`, forcing `Tree`'s `OnPush` view to push the fresh
  flattened list into the scroller's `items` input before `recalcVirtualListHeight()` (and its
  callers) read scroller state. Centralized in `updateOptions()`, so it covers all existing call
  sites: `toggleOptions()`'s reopen flow, `onClickFullyExpandable()`, and
  `CpsTreeAutocompleteComponent._clearInput()`.
- `toggleOptions()`'s scroll-to-selection logic now computes the selected node's `key` up front and
  looks it up via `` `.key-${key}` `` — the same convention already stamped onto every node's
  `styleClass` and already used successfully elsewhere in this file (`_focusTreeNode`'s callers).
  Changed the virtual-scroll index fallback from `||` to `??` so a match at index `0` isn't
  discarded.

--- 

## Release notes:
- fix: tree select/tree autocomplete virtual scroll rendering and scroll-to-selection on open
