### PR TITLE
fix: correct horizontal scroll alignment in dropdowns on open and during arrow-key navigation

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.spec.ts
@@ -464,6 +464,67 @@ describe('CpsAutocompleteComponent', () => {
     expect(component.filteredOptions.length).toBe(3);
   });
 
+  describe('Scroll alignment', () => {
+    let scrollIntoView: jest.Mock;
+
+    beforeEach(() => {
+      scrollIntoView = jest.fn();
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    });
+
+    it('should scroll the selected option into view with inline: start when the dropdown opens', fakeAsync(() => {
+      component.writeValue(component.options[0]);
+      fixture.detectChanges();
+
+      component.onBoxClick();
+      flush();
+      fixture.detectChanges();
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'instant',
+        block: 'nearest',
+        inline: 'start'
+      });
+    }));
+
+    it('should highlight an out-of-view option with inline: nearest so horizontal scroll position is preserved', () => {
+      const parent = document.createElement('div');
+      jest
+        .spyOn(parent, 'getBoundingClientRect')
+        .mockReturnValue({ top: 0, bottom: 200 } as DOMRect);
+
+      const el = document.createElement('div');
+      parent.appendChild(el);
+      jest
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue({ top: -10, bottom: 20 } as DOMRect);
+
+      (component as any)._highlightOption(el);
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest'
+      });
+    });
+
+    it('should not scroll an already fully visible highlighted option', () => {
+      const parent = document.createElement('div');
+      jest
+        .spyOn(parent, 'getBoundingClientRect')
+        .mockReturnValue({ top: 0, bottom: 200 } as DOMRect);
+
+      const el = document.createElement('div');
+      parent.appendChild(el);
+      jest
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue({ top: 10, bottom: 40 } as DOMRect);
+
+      (component as any)._highlightOption(el);
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Chip Removal', () => {
     beforeEach(() => {
       window.HTMLElement.prototype.scrollIntoView = jest.fn();

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -1098,7 +1098,7 @@ export class CpsAutocompleteComponent
     if (elRect.top < parentRect.top || elRect.bottom > parentRect.bottom) {
       el.scrollIntoView({
         block: 'nearest',
-        inline: 'start'
+        inline: 'nearest'
       });
     }
   }

--- a/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-autocomplete/cps-autocomplete.component.ts
@@ -986,7 +986,7 @@ export class CpsAutocompleteComponent
           selected.scrollIntoView({
             behavior: 'instant',
             block: 'nearest',
-            inline: 'center'
+            inline: 'start'
           });
         } else if (this.virtualScroll && this.optionHighlightedIndex >= 0) {
           this._scrollVirtualListToIndex(this.optionHighlightedIndex);
@@ -1098,7 +1098,7 @@ export class CpsAutocompleteComponent
     if (elRect.top < parentRect.top || elRect.bottom > parentRect.bottom) {
       el.scrollIntoView({
         block: 'nearest',
-        inline: 'center'
+        inline: 'start'
       });
     }
   }

--- a/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.spec.ts
@@ -352,6 +352,67 @@ describe('CpsSelectComponent', () => {
     });
   });
 
+  describe('Scroll alignment', () => {
+    let scrollIntoView: jest.Mock;
+
+    beforeEach(() => {
+      scrollIntoView = jest.fn();
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    });
+
+    it('should scroll the selected option into view with inline: start when the dropdown opens', fakeAsync(() => {
+      component.writeValue(OPTIONS[0]);
+      fixture.detectChanges();
+
+      component.onBoxClick();
+      fixture.detectChanges();
+      tick();
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'instant',
+        block: 'nearest',
+        inline: 'start'
+      });
+    }));
+
+    it('should highlight an out-of-view option with inline: nearest so horizontal scroll position is preserved', () => {
+      const parent = document.createElement('div');
+      jest
+        .spyOn(parent, 'getBoundingClientRect')
+        .mockReturnValue({ top: 0, bottom: 200 } as DOMRect);
+
+      const el = document.createElement('div');
+      parent.appendChild(el);
+      jest
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue({ top: -10, bottom: 20 } as DOMRect);
+
+      (component as any)._highlightOption(el);
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest'
+      });
+    });
+
+    it('should not scroll an already fully visible highlighted option', () => {
+      const parent = document.createElement('div');
+      jest
+        .spyOn(parent, 'getBoundingClientRect')
+        .mockReturnValue({ top: 0, bottom: 200 } as DOMRect);
+
+      const el = document.createElement('div');
+      parent.appendChild(el);
+      jest
+        .spyOn(el, 'getBoundingClientRect')
+        .mockReturnValue({ top: 10, bottom: 40 } as DOMRect);
+
+      (component as any)._highlightOption(el);
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Clear', () => {
     beforeEach(() => {
       fixture.componentRef.setInput('clearable', true);

--- a/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
@@ -467,7 +467,7 @@ export class CpsSelectComponent
           selected.scrollIntoView({
             behavior: 'instant',
             block: 'nearest',
-            inline: 'center'
+            inline: 'start'
           });
         } else if (this.virtualScroll && this.optionHighlightedIndex >= 0) {
           this._scrollVirtualListToIndex(this.optionHighlightedIndex);
@@ -563,7 +563,7 @@ export class CpsSelectComponent
     if (elRect.top < parentRect.top || elRect.bottom > parentRect.bottom) {
       el.scrollIntoView({
         block: 'nearest',
-        inline: 'center'
+        inline: 'start'
       });
     }
   }

--- a/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-select/cps-select.component.ts
@@ -563,7 +563,7 @@ export class CpsSelectComponent
     if (elRect.top < parentRect.top || elRect.bottom > parentRect.bottom) {
       el.scrollIntoView({
         block: 'nearest',
-        inline: 'start'
+        inline: 'nearest'
       });
     }
   }

--- a/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/internal/cps-base-tree-dropdown/cps-base-tree-dropdown.component.ts
@@ -565,7 +565,7 @@ export class CpsBaseTreeDropdownComponent
           selected.scrollIntoView({
             behavior: 'instant',
             block: 'nearest',
-            inline: 'center'
+            inline: 'start'
           });
         } else if (this.virtualScroll && key) {
           const idx =


### PR DESCRIPTION
## Description

### What
Two fixes to horizontal scroll behavior in dropdowns with long, overflowing row content (e.g. a
long `optionInfo`):
1. `cps-select`, `cps-autocomplete`, `cps-tree-select`, and `cps-tree-autocomplete` no longer
   re-center the list horizontally when scrolling to reveal the selected value on open — it now
   stays at the horizontal beginning.
2. `cps-select` and `cps-autocomplete` no longer reset horizontal scroll position on every
   arrow-key-triggered vertical auto-scroll — it's now only adjusted when actually needed.

### Why

**1. Scroll-to-selection on open.** All four components used `selected.scrollIntoView({ behavior:
'instant', block: 'nearest', inline: 'center' })` to bring the selected row into view. `inline:
'center'` centers the row's *entire* bounding box horizontally — fine for rows that fit within the
viewport, but for a row wider than the viewport (because its content overflows, enabled by the
`white-space: nowrap` styling on `.virtual-row`), centering it scrolls the container away from the
start, cutting off the row's label. The virtual-scroll index-based fallback
(`scrollToVirtualIndex()` / `_scrollVirtualListToIndex()`) was unaffected, since it only manages
vertical `scrollTop`.

**2. Arrow-key highlight navigation.** `_highlightOption()` in `CpsSelectComponent` and
`CpsAutocompleteComponent` guards its `scrollIntoView()` call with a vertical-only visibility check,
but the call itself specified `inline: 'center'`. Since `scrollIntoView` applies both axes together,
every vertically-triggered auto-scroll also forced the horizontal position back to the row's center
— even when the row was already horizontally visible and no horizontal change was needed, losing
any horizontal scroll position the user had set (e.g. to read a long row).

### How
- Changed `inline: 'center'` to `inline: 'start'` in the three identical "scroll to selection on
  open" `scrollIntoView()` calls:
  - `CpsBaseTreeDropdownComponent` (shared by `cps-tree-select` and `cps-tree-autocomplete`)
  - `CpsSelectComponent`
  - `CpsAutocompleteComponent`

  `'start'` aligns the row's start edge to the scroll container's start edge, so horizontal scroll
  stays at 0 regardless of row width.
- Changed `inline: 'center'` to `inline: 'nearest'` in `_highlightOption()`'s `scrollIntoView()` call
  in both `CpsSelectComponent` and `CpsAutocompleteComponent`. `'nearest'` only repositions
  horizontally if the newly-highlighted row isn't already horizontally visible, preserving the
  user's horizontal scroll position otherwise.

--- 

## Release notes:
- fix: correct horizontal scroll alignment in dropdowns on open and during arrow-key navigation