### PR TITLE
docs: add code examples for Expansion Panel, File Upload, Icon

### DIFF
--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.html
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.html
@@ -1,45 +1,69 @@
 <app-component-docs-viewer [componentData]="componentData">
   <!-- Example of component's usage -->
   <div class="expans-panels-group">
-    <cps-expansion-panel
-      headerTitle="Bordered panel with transparent background">
-      <div>
-        <cps-button label="Sample button"></cps-button>
-      </div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Bordered panel with transparent background"
+      [htmlCode]="examples.borderedTransparentBackground.html">
+      <cps-expansion-panel
+        headerTitle="Bordered panel with transparent background">
+        <div>
+          <cps-button label="Sample button"></cps-button>
+        </div>
+      </cps-expansion-panel>
+    </app-code-example>
 
-    <cps-expansion-panel headerTitle="Disabled panel" [disabled]="true">
-      <div>Some content</div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Disabled panel"
+      [htmlCode]="examples.disabledPanel.html">
+      <cps-expansion-panel headerTitle="Disabled panel" [disabled]="true">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
 
-    <cps-expansion-panel
-      headerTitle="Bordered panel with prefix icon and transparent background"
-      [isExpanded]="true"
-      prefixIcon="construction">
-      <div>Some content</div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Expanded panel with prefix icon"
+      [htmlCode]="examples.expandedWithPrefixIcon.html">
+      <cps-expansion-panel
+        headerTitle="Bordered panel with prefix icon and transparent background"
+        [isExpanded]="true"
+        prefixIcon="construction">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
 
-    <cps-expansion-panel
-      headerTitle="Borderless panel with white background"
-      backgroundColor="white"
-      [bordered]="false">
-      <div>Some content</div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Borderless panel with white background"
+      [htmlCode]="examples.borderlessWhiteBackground.html">
+      <cps-expansion-panel
+        headerTitle="Borderless panel with white background"
+        backgroundColor="white"
+        [bordered]="false">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
 
-    <cps-expansion-panel
-      headerTitle="Bordered panel with 0.25rem border radius without chevron"
-      [showChevron]="false"
-      backgroundColor="white"
-      borderRadius="0.25rem">
-      <div>Some content</div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Panel with radius, without chevron"
+      [htmlCode]="examples.noChevronWithRadius.html">
+      <cps-expansion-panel
+        headerTitle="Bordered panel with 0.25rem border radius without chevron"
+        [showChevron]="false"
+        backgroundColor="white"
+        borderRadius="0.25rem">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
 
-    <cps-expansion-panel
-      headerTitle="Bordered panel with 0.25rem border radius and 32rem width"
-      backgroundColor="white"
-      borderRadius="0.25rem"
-      width="32rem">
-      <div>Some content</div>
-    </cps-expansion-panel>
+    <app-code-example
+      label="Panel with custom radius and width"
+      [htmlCode]="examples.customRadiusAndWidth.html">
+      <cps-expansion-panel
+        headerTitle="Bordered panel with 0.25rem border radius and 32rem width"
+        backgroundColor="white"
+        borderRadius="0.25rem"
+        width="32rem">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
   </div>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.ts
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.ts
@@ -3,12 +3,15 @@ import { CpsButtonComponent, CpsExpansionPanelComponent } from 'cps-ui-kit';
 
 import ComponentData from '../../api-data/cps-expansion-panel.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { expansionPanelExamples } from './expansion-panel-page.examples';
 
 @Component({
   imports: [
     CpsExpansionPanelComponent,
     ComponentDocsViewerComponent,
-    CpsButtonComponent
+    CpsButtonComponent,
+    CodeExampleComponent
   ],
   selector: 'app-expansion-panel-page',
   templateUrl: './expansion-panel-page.component.html',
@@ -17,4 +20,5 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
 })
 export class ExpansionPanelPageComponent {
   componentData = ComponentData;
+  readonly examples = expansionPanelExamples;
 }

--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.examples.ts
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.examples.ts
@@ -1,0 +1,63 @@
+export const expansionPanelExamples: Record<
+  string,
+  { html: string; ts?: string }
+> = {
+  borderedTransparentBackground: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Bordered panel with transparent background">
+  <div>
+    <cps-button label="Sample button"></cps-button>
+  </div>
+</cps-expansion-panel>`
+  },
+
+  disabledPanel: {
+    html: `
+<cps-expansion-panel headerTitle="Disabled panel" [disabled]="true">
+  <div>Some content</div>
+</cps-expansion-panel>`
+  },
+
+  expandedWithPrefixIcon: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Bordered panel with prefix icon and transparent background"
+  [isExpanded]="true"
+  prefixIcon="construction">
+  <div>Some content</div>
+</cps-expansion-panel>`
+  },
+
+  borderlessWhiteBackground: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Borderless panel with white background"
+  backgroundColor="white"
+  [bordered]="false">
+  <div>Some content</div>
+</cps-expansion-panel>`
+  },
+
+  noChevronWithRadius: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Bordered panel with 0.25rem border radius without chevron"
+  [showChevron]="false"
+  backgroundColor="white"
+  borderRadius="0.25rem">
+  <div>Some content</div>
+</cps-expansion-panel>`
+  },
+
+  customRadiusAndWidth: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Bordered panel with 0.25rem border radius and 32rem width"
+  backgroundColor="white"
+  borderRadius="0.25rem"
+  width="32rem">
+  <div>Some content</div>
+</cps-expansion-panel>`
+  }
+};

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.html
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.html
@@ -1,17 +1,16 @@
 <app-component-docs-viewer [componentData]="componentData">
   <!-- Example of component's usage -->
-  <h2 class="section-title">
-    File upload component with the dependency on selected file extension
-  </h2>
-  <div class="section-body">
-    <p>
+  <app-code-example
+    label="File upload component with the dependency on selected file extension"
+    [htmlCode]="examples.dependentOnSelectedExtension.html"
+    [tsCode]="examples.dependentOnSelectedExtension.ts">
+    <div class="file-upload-with-selector">
       <cps-button-toggle
         label="File extension"
         [options]="fileUploadOptions"
         [value]="selectedFileUploadType.value"
         (valueChanged)="onFileExtensionChanged($event)">
       </cps-button-toggle>
-      <br />
       <cps-file-upload
         #fileUpload
         [extensions]="[selectedFileUploadType.value]"
@@ -22,35 +21,35 @@
         (fileUploaded)="onFileUploaded($event)"
         (uploadedFileRemoved)="onUploadedFileRemoved($event)">
       </cps-file-upload>
-    </p>
-    <cps-divider />
-  </div>
+    </div>
+  </app-code-example>
 
-  <h2 class="section-title">File upload component with extra info</h2>
-  <div class="section-body">
-    <p>
-      <cps-file-upload
-        [extensions]="['.jpg', '.png', 'pdf']"
-        [fileInfo]="fileInfo"
-        fileDesc="Pictures or PDFs"
-        ariaLabel="Upload pictures or PDFs"
-        width="31.25rem"
-        fileNameTooltipOffset="0.9375rem"
-        [fileProcessingCallback]="processUploadedFile"
-        (fileProcessingFailed)="onFileProcessingFailed($event)"
-        (fileProcessingCancelled)="onFileProcessingCancelled($event)"
-        (fileUploadFailed)="onFileUploadFailed($event)"
-        (fileUploaded)="onFileUploaded($event)"
-        (fileProcessed)="onFileProcessed($event)"
-        (uploadedFileRemoved)="onUploadedFileRemoved($event)">
-      </cps-file-upload>
-    </p>
-    <cps-divider />
-  </div>
+  <app-code-example
+    label="File upload component with extra info"
+    [htmlCode]="examples.withExtraInfo.html"
+    [tsCode]="examples.withExtraInfo.ts">
+    <cps-file-upload
+      [extensions]="['.jpg', '.png', 'pdf']"
+      [fileInfo]="fileInfo"
+      fileDesc="Pictures or PDFs"
+      ariaLabel="Upload pictures or PDFs"
+      width="31.25rem"
+      fileNameTooltipOffset="0.9375rem"
+      [fileProcessingCallback]="processUploadedFile"
+      (fileProcessingFailed)="onFileProcessingFailed($event)"
+      (fileProcessingCancelled)="onFileProcessingCancelled($event)"
+      (fileUploadFailed)="onFileUploadFailed($event)"
+      (fileUploaded)="onFileUploaded($event)"
+      (fileProcessed)="onFileProcessed($event)"
+      (uploadedFileRemoved)="onUploadedFileRemoved($event)">
+    </cps-file-upload>
+  </app-code-example>
 
-  <h2 class="section-title">Disabled file upload component</h2>
-  <div class="section-body">
-    <p>
+  <app-code-example
+    label="Disabled file upload component"
+    [htmlCode]="examples.disabledFileUpload.html"
+    [tsCode]="examples.disabledFileUpload.ts">
+    <div class="file-upload-with-toggle">
       <cps-file-upload
         [extensions]="['.jpg', '.png', 'pdf']"
         [fileInfo]="fileInfo"
@@ -66,11 +65,11 @@
         (fileProcessed)="onFileProcessed($event)"
         (uploadedFileRemoved)="onUploadedFileRemoved($event)">
       </cps-file-upload>
-    </p>
-    <cps-button
-      label="Toggle disabled"
-      (clicked)="toggleDisabled()"
-      size="small">
-    </cps-button>
-  </div>
+      <cps-button
+        label="Toggle disabled"
+        (clicked)="toggleDisabled()"
+        size="small">
+      </cps-button>
+    </div>
+  </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.scss
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.scss
@@ -1,15 +1,8 @@
 :host {
-  .section-title {
-    color: var(--cps-color-depth);
-  }
-  .section-title:first-child {
-    margin-top: 0;
-  }
-  .section-title,
-  .section-body {
-    margin-left: 0.5rem;
-  }
-  .section-body:last-child {
-    margin-bottom: 0.5rem;
+  .file-upload-with-selector,
+  .file-upload-with-toggle {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 }

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.ts
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.ts
@@ -3,13 +3,14 @@ import {
   CpsFileUploadComponent,
   CpsButtonToggleComponent,
   CpsButtonToggleOption,
-  CpsDividerComponent,
   CpsButtonComponent
 } from 'cps-ui-kit';
 import { Observable, catchError, delay, from, map, of } from 'rxjs';
 
 import ComponentData from '../../api-data/cps-file-upload.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { fileUploadExamples } from './file-upload-page.examples';
 
 @Component({
   selector: 'app-file-upload-page',
@@ -18,7 +19,7 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
     CpsButtonComponent,
     CpsFileUploadComponent,
     ComponentDocsViewerComponent,
-    CpsDividerComponent
+    CodeExampleComponent
   ],
   templateUrl: './file-upload-page.component.html',
   styleUrls: ['./file-upload-page.component.scss'],
@@ -28,6 +29,7 @@ export class FileUploadPageComponent {
   @ViewChild('fileUpload') fileUpload?: CpsFileUploadComponent;
 
   componentData = ComponentData;
+  readonly examples = fileUploadExamples;
 
   fileUploadOptions: CpsButtonToggleOption[] = [
     { label: 'JPG image', value: '.jpg' },

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.examples.ts
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.examples.ts
@@ -1,0 +1,148 @@
+const fileUploadHandlersTs = `
+fileInfo: string =
+  'The file should be a small sample file to infer the schema, which will be shown in the next step';
+
+processUploadedFile(file: File): Observable<boolean> {
+  return from(file.text()).pipe(
+    delay(3000),
+    map((fileContentsAsText) => {
+      console.log(fileContentsAsText);
+      return true;
+    }),
+    catchError((error) => {
+      console.error('Error reading file', error);
+      return of(false);
+    })
+  );
+}
+
+onFileUploaded(file: File) {
+  console.log('File uploaded', file?.name);
+}
+
+onFileUploadFailed(fileName: string) {
+  console.log('File upload failed', fileName);
+}
+
+onFileProcessed(file: File) {
+  console.log('File processed', file?.name);
+}
+
+onFileProcessingFailed(fileName: string) {
+  console.log('File processing failed', fileName);
+}
+
+onFileProcessingCancelled(fileName: string) {
+  console.log('File processing cancelled', fileName);
+}
+
+onUploadedFileRemoved(fileName: string) {
+  console.log('File removed: ', fileName);
+}`;
+
+export const fileUploadExamples: Record<string, { html: string; ts?: string }> =
+  {
+    dependentOnSelectedExtension: {
+      html: `
+<cps-button-toggle
+  label="File extension"
+  [options]="fileUploadOptions"
+  [value]="selectedFileUploadType.value"
+  (valueChanged)="onFileExtensionChanged($event)">
+</cps-button-toggle>
+<cps-file-upload
+  #fileUpload
+  [extensions]="[selectedFileUploadType.value]"
+  [fileDesc]="selectedFileUploadType!.label || ''"
+  width="25rem"
+  fileNameTooltipPosition="bottom"
+  (fileUploadFailed)="onFileUploadFailed($event)"
+  (fileUploaded)="onFileUploaded($event)"
+  (uploadedFileRemoved)="onUploadedFileRemoved($event)">
+</cps-file-upload>`,
+      ts: `
+@ViewChild('fileUpload') fileUpload?: CpsFileUploadComponent;
+
+fileUploadOptions: CpsButtonToggleOption[] = [
+  { label: 'JPG image', value: '.jpg' },
+  { label: 'PDF document', value: '.pdf' },
+  { label: 'PNG image', value: '.png' }
+];
+
+selectedFileUploadType: CpsButtonToggleOption = this.fileUploadOptions[0];
+
+onFileUploadFailed(fileName: string) {
+  console.log('File upload failed', fileName);
+}
+
+onFileUploaded(file: File) {
+  console.log('File uploaded', file?.name);
+}
+
+onUploadedFileRemoved(fileName: string) {
+  console.log('File removed: ', fileName);
+}
+
+onFileExtensionChanged(event: string) {
+  this.fileUpload?.resetState();
+  const foundSelectedItem = this.fileUploadOptions.find(
+    (item) => item.value === event
+  );
+  if (foundSelectedItem) {
+    this.selectedFileUploadType = foundSelectedItem;
+  }
+}`
+    },
+
+    withExtraInfo: {
+      html: `
+<cps-file-upload
+  [extensions]="['.jpg', '.png', 'pdf']"
+  [fileInfo]="fileInfo"
+  fileDesc="Pictures or PDFs"
+  ariaLabel="Upload pictures or PDFs"
+  width="31.25rem"
+  fileNameTooltipOffset="0.9375rem"
+  [fileProcessingCallback]="processUploadedFile"
+  (fileProcessingFailed)="onFileProcessingFailed($event)"
+  (fileProcessingCancelled)="onFileProcessingCancelled($event)"
+  (fileUploadFailed)="onFileUploadFailed($event)"
+  (fileUploaded)="onFileUploaded($event)"
+  (fileProcessed)="onFileProcessed($event)"
+  (uploadedFileRemoved)="onUploadedFileRemoved($event)">
+</cps-file-upload>`,
+      ts: fileUploadHandlersTs
+    },
+
+    disabledFileUpload: {
+      html: `
+<cps-file-upload
+  [extensions]="['.jpg', '.png', 'pdf']"
+  [fileInfo]="fileInfo"
+  fileDesc="Pictures or PDFs"
+  width="31.25rem"
+  fileNameTooltipOffset="0.9375rem"
+  [disabled]="isDisabled"
+  [fileProcessingCallback]="processUploadedFile"
+  (fileProcessingFailed)="onFileProcessingFailed($event)"
+  (fileProcessingCancelled)="onFileProcessingCancelled($event)"
+  (fileUploadFailed)="onFileUploadFailed($event)"
+  (fileUploaded)="onFileUploaded($event)"
+  (fileProcessed)="onFileProcessed($event)"
+  (uploadedFileRemoved)="onUploadedFileRemoved($event)">
+</cps-file-upload>
+<cps-button
+  label="Toggle disabled"
+  (clicked)="toggleDisabled()"
+  size="small">
+</cps-button>`,
+      ts: `
+${fileUploadHandlersTs.trim()}
+
+isDisabled = true;
+
+toggleDisabled() {
+  this.isDisabled = !this.isDisabled;
+}`
+    }
+  };

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.html
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.html
@@ -1,5 +1,13 @@
 <app-component-docs-viewer [componentData]="componentData">
   <!-- Example of component's usage -->
+  <app-code-example label="Basic usage" [htmlCode]="examples.basicUsage.html">
+    <cps-icon
+      icon="like"
+      size="normal"
+      color="var(--cps-text-primary)"></cps-icon>
+  </app-code-example>
+
+  <h2 class="section-title">Browse all icons</h2>
   <div class="search-input">
     <cps-input
       ariaLabel="Search an icon"

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.scss
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.scss
@@ -1,6 +1,11 @@
 @use '../../../../variables.scss' as vars;
 @use '../../../../../../cps-ui-kit/styles/mixins' as *;
 
+.section-title {
+  color: var(--cps-color-depth);
+  margin-top: 0;
+}
+
 .search-input {
   margin-bottom: 1.5rem;
 }

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.ts
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.ts
@@ -10,13 +10,16 @@ import {
 
 import ComponentData from '../../../api-data/cps-icon.json';
 import { ComponentDocsViewerComponent } from '../../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../../components/code-example/code-example.component';
+import { iconsExamples } from './icons-page.examples';
 
 @Component({
   imports: [
     CpsIconComponent,
     CpsInputComponent,
     FormsModule,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   selector: 'app-icons-page',
   templateUrl: './icons-page.component.html',
@@ -26,6 +29,7 @@ import { ComponentDocsViewerComponent } from '../../../components/component-docs
 export class IconsPageComponent implements OnInit {
   filteredIconsList: string[] = [];
   componentData = ComponentData;
+  readonly examples = iconsExamples;
 
   private _notificationService = inject(CpsNotificationService);
 

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
@@ -1,0 +1,6 @@
+export const iconsExamples: Record<string, { html: string; ts?: string }> = {
+  basicUsage: {
+    html: `
+<cps-icon icon="like" size="normal" color="var(--cps-text-primary)"></cps-icon>`
+  }
+};


### PR DESCRIPTION
Adds live code examples to the Expansion Panel, File Upload and Icon components's documentation pages.

Closes #723  
Closes #724 
Closes #725 