### PR TITLE
docs: add code examples for Scheduler, Select, Sidebar Menu

### DIFF
--- a/projects/composition/src/app/components/code-example/code-example.component.html
+++ b/projects/composition/src/app/components/code-example/code-example.component.html
@@ -1,4 +1,6 @@
-<div class="code-example">
+<div
+  class="code-example"
+  [class.code-example--preview-outside]="previewOutside()">
   @if (label()) {
     <h2 class="code-example__label" [id]="instanceId + '-label'">
       {{ label() }}
@@ -11,18 +13,20 @@
       [attr.aria-labelledby]="label() ? instanceId + '-label' : null"
       [attr.aria-label]="label() ? null : 'Code example'"
       (keydown)="navigateTabs($event)">
-      <button
-        type="button"
-        role="tab"
-        class="code-example__tab"
-        [id]="instanceId + '-tab-preview'"
-        [attr.aria-selected]="activeTab() === 'preview'"
-        [attr.aria-controls]="instanceId + '-panel-preview'"
-        [tabindex]="activeTab() === 'preview' ? 0 : -1"
-        [class.code-example__tab--active]="activeTab() === 'preview'"
-        (click)="activeTab.set('preview')">
-        Preview
-      </button>
+      @if (!previewOutside()) {
+        <button
+          type="button"
+          role="tab"
+          class="code-example__tab"
+          [id]="instanceId + '-tab-preview'"
+          [attr.aria-selected]="activeTab() === 'preview'"
+          [attr.aria-controls]="instanceId + '-panel-preview'"
+          [tabindex]="activeTab() === 'preview' ? 0 : -1"
+          [class.code-example__tab--active]="activeTab() === 'preview'"
+          (click)="activeTab.set('preview')">
+          Preview
+        </button>
+      }
       @if (htmlCode()) {
         <button
           type="button"
@@ -54,13 +58,17 @@
     </div>
 
     <div
-      role="tabpanel"
+      [attr.role]="previewOutside() ? null : 'tabpanel'"
       class="code-example__preview"
-      [id]="instanceId + '-panel-preview'"
-      [attr.aria-labelledby]="instanceId + '-tab-preview'"
-      [attr.aria-hidden]="activeTab() !== 'preview'"
-      [tabindex]="previewTabIndex()"
-      [class.code-example__panel--hidden]="activeTab() !== 'preview'">
+      [attr.id]="previewOutside() ? null : instanceId + '-panel-preview'"
+      [attr.aria-labelledby]="
+        previewOutside() ? null : instanceId + '-tab-preview'
+      "
+      [attr.aria-hidden]="previewOutside() ? null : activeTab() !== 'preview'"
+      [attr.tabindex]="previewOutside() ? null : previewTabIndex()"
+      [class.code-example__panel--hidden]="
+        !previewOutside() && activeTab() !== 'preview'
+      ">
       <ng-content></ng-content>
     </div>
 

--- a/projects/composition/src/app/components/code-example/code-example.component.html
+++ b/projects/composition/src/app/components/code-example/code-example.component.html
@@ -58,6 +58,7 @@
     </div>
 
     <div
+      #previewPanel
       [attr.role]="previewOutside() ? null : 'tabpanel'"
       class="code-example__preview"
       [attr.id]="previewOutside() ? null : instanceId + '-panel-preview'"
@@ -97,7 +98,10 @@
               : ''
         }}</span>
         <pre
+          #htmlPre
           class="hljs"
+          role="group"
+          [attr.tabindex]="htmlCodeTabIndex()"
           [attr.aria-label]="
             (label() || 'Code') + ' HTML snippet'
           "><code [innerHTML]="highlightedCode()"></code></pre>
@@ -129,7 +133,10 @@
               : ''
         }}</span>
         <pre
+          #tsPre
           class="hljs"
+          role="group"
+          [attr.tabindex]="tsCodeTabIndex()"
           [attr.aria-label]="
             (label() || 'Code') + ' TypeScript snippet'
           "><code [innerHTML]="highlightedTsCode()"></code></pre>

--- a/projects/composition/src/app/components/code-example/code-example.component.scss
+++ b/projects/composition/src/app/components/code-example/code-example.component.scss
@@ -84,12 +84,65 @@
       font-size: 0.8125rem;
       line-height: 1.6;
       border-radius: inherit;
+
+      &:focus-visible {
+        outline: none;
+        box-shadow:
+          inset 0 0 0 0.0625rem var(--cps-color-calm),
+          inset 0 0 0 0.125rem var(--cps-background-color),
+          inset 0 0 0 0.1875rem var(--cps-color-calm-highlighten);
+      }
     }
 
     code {
       font-family:
         ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
         'Liberation Mono', monospace;
+    }
+
+    // The atom-one-light/dark hljs themes (loaded globally at runtime) fail
+    // WCAG AA contrast for several syntax classes against our background.
+    // Darkened/lightened variants of the same hues restore compliance.
+    ::ng-deep {
+      .hljs-comment,
+      .hljs-quote {
+        color: #71727a;
+      }
+
+      .hljs-section,
+      .hljs-name,
+      .hljs-selector-tag,
+      .hljs-deletion,
+      .hljs-subst {
+        color: #da3020;
+      }
+
+      .hljs-literal {
+        color: #017bae;
+      }
+
+      .hljs-string,
+      .hljs-regexp,
+      .hljs-addition,
+      .hljs-attribute,
+      .hljs-meta .hljs-string {
+        color: #40803f;
+      }
+
+      .hljs-symbol,
+      .hljs-bullet,
+      .hljs-link,
+      .hljs-meta,
+      .hljs-selector-id,
+      .hljs-title {
+        color: #2d6af1;
+      }
+
+      .hljs-built_in,
+      .hljs-title.class_,
+      .hljs-class .hljs-title {
+        color: #9b6a01;
+      }
     }
   }
 

--- a/projects/composition/src/app/components/code-example/code-example.component.scss
+++ b/projects/composition/src/app/components/code-example/code-example.component.scss
@@ -83,6 +83,7 @@
       overflow-x: auto;
       font-size: 0.8125rem;
       line-height: 1.6;
+      border-radius: inherit;
     }
 
     code {
@@ -97,10 +98,8 @@
     top: 0.625rem;
     right: 0.75rem;
     z-index: 1;
-
-    ::ng-deep button {
-      background-color: var(--cps-surface-elevated) !important;
-    }
+    background-color: var(--cps-surface-elevated);
+    border-radius: 0.25rem;
   }
 
   &__panel--hidden {
@@ -121,6 +120,10 @@
       margin-bottom: 1.5rem;
       background-color: transparent;
       border-radius: 0;
+
+      &:empty {
+        margin-bottom: 0;
+      }
     }
 
     .code-example__tabbar {

--- a/projects/composition/src/app/components/code-example/code-example.component.scss
+++ b/projects/composition/src/app/components/code-example/code-example.component.scss
@@ -97,9 +97,43 @@
     top: 0.625rem;
     right: 0.75rem;
     z-index: 1;
+
+    ::ng-deep button {
+      background-color: var(--cps-surface-elevated) !important;
+    }
   }
 
   &__panel--hidden {
     display: none;
+  }
+
+  &--preview-outside {
+    display: flex;
+    flex-direction: column;
+
+    .code-example__card {
+      display: contents;
+    }
+
+    .code-example__preview {
+      order: 1;
+      padding: 0;
+      margin-bottom: 1.5rem;
+      background-color: transparent;
+      border-radius: 0;
+    }
+
+    .code-example__tabbar {
+      order: 2;
+      border: 0.0625rem solid var(--cps-color-line);
+      border-radius: 0.4375rem 0.4375rem 0 0;
+    }
+
+    .code-example__code {
+      order: 3;
+      border: 0.0625rem solid var(--cps-color-line);
+      border-top: none;
+      border-radius: 0 0 0.4375rem 0.4375rem;
+    }
   }
 }

--- a/projects/composition/src/app/components/code-example/code-example.component.spec.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.spec.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { CodeExampleComponent } from './code-example.component';
@@ -352,6 +353,33 @@ describe('CodeExampleComponent', () => {
       const pres = fixture.debugElement.queryAll(By.css('pre.hljs'));
       expect(pres[0].nativeElement.tabIndex).toBe(-1);
       expect(pres[1].nativeElement.tabIndex).toBe(-1);
+    });
+  });
+
+  describe('SSR', () => {
+    afterEach(() => {
+      delete (globalThis as any).ResizeObserver;
+    });
+
+    it('does not create a ResizeObserver on the server', () => {
+      const observerCtor = jest.fn(() => ({
+        observe: jest.fn(),
+        disconnect: jest.fn()
+      }));
+      (globalThis as any).ResizeObserver = observerCtor;
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [CodeExampleComponent],
+        providers: [{ provide: PLATFORM_ID, useValue: 'server' }]
+      });
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('tsCode', 'const x = 1;');
+      fixture.detectChanges();
+
+      expect(observerCtor).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/composition/src/app/components/code-example/code-example.component.spec.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.spec.ts
@@ -342,34 +342,16 @@ describe('CodeExampleComponent', () => {
       expect(previewPanel.nativeElement.tabIndex).toBe(-1);
     });
 
-    it('preview tabpanel has tabindex 0 when isPreviewNonInteractive is true', () => {
+    it('code tabpanel pre elements default to tabindex -1 when not scrollable', () => {
       fixture = TestBed.createComponent(CodeExampleComponent);
       component = fixture.componentInstance;
       fixture.componentRef.setInput('htmlCode', '<div></div>');
-      fixture.componentRef.setInput('isPreviewNonInteractive', true);
+      fixture.componentRef.setInput('tsCode', 'const x = 1;');
       fixture.detectChanges();
 
-      const previewPanel = fixture.debugElement.query(
-        By.css('[id*="-panel-preview"]')
-      );
-      expect(previewPanel.nativeElement.tabIndex).toBe(0);
-    });
-
-    it('preview tabpanel tabindex updates reactively when input changes', () => {
-      fixture = TestBed.createComponent(CodeExampleComponent);
-      component = fixture.componentInstance;
-      fixture.componentRef.setInput('htmlCode', '<div></div>');
-      fixture.componentRef.setInput('isPreviewNonInteractive', false);
-      fixture.detectChanges();
-
-      const previewPanel = fixture.debugElement.query(
-        By.css('[id*="-panel-preview"]')
-      );
-      expect(previewPanel.nativeElement.tabIndex).toBe(-1);
-
-      fixture.componentRef.setInput('isPreviewNonInteractive', true);
-      fixture.detectChanges();
-      expect(previewPanel.nativeElement.tabIndex).toBe(0);
+      const pres = fixture.debugElement.queryAll(By.css('pre.hljs'));
+      expect(pres[0].nativeElement.tabIndex).toBe(-1);
+      expect(pres[1].nativeElement.tabIndex).toBe(-1);
     });
   });
 });

--- a/projects/composition/src/app/components/code-example/code-example.component.spec.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.spec.ts
@@ -250,6 +250,85 @@ describe('CodeExampleComponent', () => {
     });
   });
 
+  describe('previewOutside', () => {
+    it('does not render a Preview tab', () => {
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('tsCode', 'const x = 1;');
+      fixture.componentRef.setInput('previewOutside', true);
+      fixture.detectChanges();
+
+      const tabs = fixture.debugElement.queryAll(By.css('[role="tab"]'));
+      expect(tabs.length).toBe(2);
+      expect(tabs[0].nativeElement.textContent.trim()).toBe('HTML');
+      expect(tabs[1].nativeElement.textContent.trim()).toBe('TS');
+    });
+
+    it('never hides the preview panel, regardless of the active tab', () => {
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('tsCode', 'const x = 1;');
+      fixture.componentRef.setInput('previewOutside', true);
+      fixture.detectChanges();
+      component.activeTab.set('ts');
+      fixture.detectChanges();
+
+      const previewPanel = fixture.debugElement.query(
+        By.css('.code-example__preview')
+      );
+      expect(previewPanel).not.toBeNull();
+      expect(
+        previewPanel.nativeElement.classList.contains(
+          'code-example__panel--hidden'
+        )
+      ).toBe(false);
+      expect(previewPanel.nativeElement.getAttribute('aria-hidden')).toBe(null);
+    });
+
+    it('does not render tab-related ARIA attributes on the preview panel', () => {
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('previewOutside', true);
+      fixture.detectChanges();
+
+      const previewPanel = fixture.debugElement.query(
+        By.css('.code-example__preview')
+      );
+      expect(previewPanel.nativeElement.getAttribute('role')).toBe(null);
+      expect(previewPanel.nativeElement.getAttribute('id')).toBe(null);
+      expect(previewPanel.nativeElement.getAttribute('aria-labelledby')).toBe(
+        null
+      );
+    });
+
+    it('renders the host with the preview-outside modifier class', () => {
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('previewOutside', true);
+      fixture.detectChanges();
+
+      const host = fixture.debugElement.query(By.css('.code-example'));
+      expect(
+        host.nativeElement.classList.contains('code-example--preview-outside')
+      ).toBe(true);
+    });
+
+    it('defaults active tab to the first available tab instead of preview', () => {
+      fixture = TestBed.createComponent(CodeExampleComponent);
+      component = fixture.componentInstance;
+      fixture.componentRef.setInput('htmlCode', '<div></div>');
+      fixture.componentRef.setInput('tsCode', 'const x = 1;');
+      fixture.componentRef.setInput('previewOutside', true);
+      fixture.detectChanges();
+
+      expect(component.activeTab()).toBe('html');
+    });
+  });
+
   describe('tabindex', () => {
     it('preview tabpanel has tabindex -1 by default (interactive content)', () => {
       fixture = TestBed.createComponent(CodeExampleComponent);

--- a/projects/composition/src/app/components/code-example/code-example.component.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.ts
@@ -5,7 +5,11 @@ import {
   inject,
   signal,
   ChangeDetectionStrategy,
-  computed
+  computed,
+  viewChild,
+  ElementRef,
+  type Signal,
+  type WritableSignal
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { CpsButtonComponent } from 'cps-ui-kit';
@@ -31,7 +35,6 @@ export class CodeExampleComponent {
   htmlCode = input<string | undefined>();
   tsCode = input<string | undefined>();
   label = input('');
-  isPreviewNonInteractive = input(false);
   previewOutside = input(false);
 
   private sanitizer = inject(DomSanitizer);
@@ -43,9 +46,23 @@ export class CodeExampleComponent {
   highlightedCode = signal<SafeHtml>('');
   highlightedTsCode = signal<SafeHtml>('');
   tabs = signal<TabId[]>(['preview']);
-  previewTabIndex = computed(() => (this.isPreviewNonInteractive() ? 0 : -1));
+
+  private previewEl = viewChild<ElementRef<HTMLElement>>('previewPanel');
+  private htmlPreEl = viewChild<ElementRef<HTMLElement>>('htmlPre');
+  private tsPreEl = viewChild<ElementRef<HTMLElement>>('tsPre');
+  private previewScrollable = signal(false);
+  private htmlCodeScrollable = signal(false);
+  private tsCodeScrollable = signal(false);
+  // Only focusable when its content actually overflows and needs scrolling.
+  previewTabIndex = computed(() => (this.previewScrollable() ? 0 : -1));
+  htmlCodeTabIndex = computed(() => (this.htmlCodeScrollable() ? 0 : -1));
+  tsCodeTabIndex = computed(() => (this.tsCodeScrollable() ? 0 : -1));
 
   constructor() {
+    this._observeScrollable(this.previewEl, this.previewScrollable);
+    this._observeScrollable(this.htmlPreEl, this.htmlCodeScrollable);
+    this._observeScrollable(this.tsPreEl, this.tsCodeScrollable);
+
     effect(() => {
       const htmlCode = this.htmlCode();
       const tsCode = this.tsCode();
@@ -81,6 +98,29 @@ export class CodeExampleComponent {
       if (!this.tabs().includes(this.activeTab())) {
         this.activeTab.set(availableTabs[0] ?? 'preview');
       }
+    });
+  }
+
+  private _observeScrollable(
+    elRef: Signal<ElementRef<HTMLElement> | undefined>,
+    scrollable: WritableSignal<boolean>
+  ): void {
+    effect((onCleanup) => {
+      const el = elRef()?.nativeElement;
+      if (!el) {
+        scrollable.set(false);
+        return;
+      }
+
+      const update = () =>
+        scrollable.set(
+          el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight
+        );
+      update();
+
+      const observer = new ResizeObserver(update);
+      observer.observe(el);
+      onCleanup(() => observer.disconnect());
     });
   }
 

--- a/projects/composition/src/app/components/code-example/code-example.component.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.ts
@@ -32,6 +32,7 @@ export class CodeExampleComponent {
   tsCode = input<string | undefined>();
   label = input('');
   isPreviewNonInteractive = input(false);
+  previewOutside = input(false);
 
   private sanitizer = inject(DomSanitizer);
 
@@ -55,7 +56,7 @@ export class CodeExampleComponent {
         );
       }
 
-      const availableTabs: TabId[] = ['preview'];
+      const availableTabs: TabId[] = this.previewOutside() ? [] : ['preview'];
 
       if (htmlCode) {
         const htmlResult = hljs.highlight(htmlCode.trim(), { language: 'xml' });
@@ -78,7 +79,7 @@ export class CodeExampleComponent {
       this.tabs.set(availableTabs);
 
       if (!this.tabs().includes(this.activeTab())) {
-        this.activeTab.set('preview');
+        this.activeTab.set(availableTabs[0] ?? 'preview');
       }
     });
   }

--- a/projects/composition/src/app/components/code-example/code-example.component.ts
+++ b/projects/composition/src/app/components/code-example/code-example.component.ts
@@ -8,9 +8,11 @@ import {
   computed,
   viewChild,
   ElementRef,
+  PLATFORM_ID,
   type Signal,
   type WritableSignal
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { CpsButtonComponent } from 'cps-ui-kit';
 import hljs from 'highlight.js/lib/core';
@@ -38,6 +40,7 @@ export class CodeExampleComponent {
   previewOutside = input(false);
 
   private sanitizer = inject(DomSanitizer);
+  private platformId = inject(PLATFORM_ID);
 
   instanceId = `code-example-${++CodeExampleComponent.instanceCount}`;
   activeTab = signal<TabId>('preview');
@@ -105,6 +108,10 @@ export class CodeExampleComponent {
     elRef: Signal<ElementRef<HTMLElement> | undefined>,
     scrollable: WritableSignal<boolean>
   ): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
     effect((onCleanup) => {
       const el = elRef()?.nativeElement;
       if (!el) {
@@ -112,10 +119,7 @@ export class CodeExampleComponent {
         return;
       }
 
-      const update = () =>
-        scrollable.set(
-          el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight
-        );
+      const update = () => scrollable.set(el.scrollWidth > el.clientWidth);
       update();
 
       const observer = new ResizeObserver(update);

--- a/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
+++ b/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
@@ -25,8 +25,7 @@
   <app-code-example
     label="Disabled"
     [htmlCode]="examples.disabled.html"
-    [tsCode]="examples.disabled.ts"
-    [isPreviewNonInteractive]="true">
+    [tsCode]="examples.disabled.ts">
     <cps-button-toggle
       label="Disabled button toggles"
       [options]="options"

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.html
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.html
@@ -2,7 +2,10 @@
   [componentData]="componentData"
   [services]="serviceData">
   <!-- Example of component's usage -->
-  <div class="scheduler-wrapper">
+  <app-code-example
+    label="Basic usage"
+    [htmlCode]="examples.basicUsage.html"
+    [tsCode]="examples.basicUsage.ts">
     <cps-scheduler
       label="Frequency"
       [disabled]="false"
@@ -15,5 +18,5 @@
       [showNotSet]="true"
       [showTimeZone]="true"
       infoTooltip="Provide frequency"></cps-scheduler>
-  </div>
+  </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.scss
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.scss
@@ -1,5 +1,0 @@
-.scheduler-wrapper {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-  margin-bottom: 0.5rem;
-}

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
@@ -3,10 +3,16 @@ import { CpsSchedulerComponent } from 'cps-ui-kit';
 import ComponentData from '../../api-data/cps-scheduler.json';
 import ServiceData from '../../api-data/cps-cron-validation.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { schedulerExamples } from './scheduler-page.examples';
 
 @Component({
   selector: 'app-scheduler-page',
-  imports: [CpsSchedulerComponent, ComponentDocsViewerComponent],
+  imports: [
+    CpsSchedulerComponent,
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
+  ],
   templateUrl: './scheduler-page.component.html',
   styleUrl: './scheduler-page.component.scss',
   host: { class: 'composition-page' }
@@ -14,6 +20,7 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
 export class SchedulerPageComponent {
   componentData = ComponentData;
   serviceData = [ServiceData];
+  readonly examples = schedulerExamples;
 
   cronExpression = '30 9 ? 7/4 WED#5 *';
   timeZone = 'UTC';

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.component.ts
@@ -14,7 +14,6 @@ import { schedulerExamples } from './scheduler-page.examples';
     CodeExampleComponent
   ],
   templateUrl: './scheduler-page.component.html',
-  styleUrl: './scheduler-page.component.scss',
   host: { class: 'composition-page' }
 })
 export class SchedulerPageComponent {

--- a/projects/composition/src/app/pages/scheduler-page/scheduler-page.examples.ts
+++ b/projects/composition/src/app/pages/scheduler-page/scheduler-page.examples.ts
@@ -1,0 +1,29 @@
+export const schedulerExamples: Record<string, { html: string; ts?: string }> =
+  {
+    basicUsage: {
+      html: `
+<cps-scheduler
+  label="Frequency"
+  [disabled]="false"
+  [(cron)]="cronExpression"
+  (cronChange)="onCronExpressionChanged($event)"
+  [(timeZone)]="timeZone"
+  (timeZoneChange)="onTimezoneChanged($event)"
+  [showAdvanced]="true"
+  [use24HourTime]="true"
+  [showNotSet]="true"
+  [showTimeZone]="true"
+  infoTooltip="Provide frequency"></cps-scheduler>`,
+      ts: `
+cronExpression = '30 9 ? 7/4 WED#5 *';
+timeZone = 'UTC';
+
+onCronExpressionChanged(cron: string) {
+  console.log('CRON expression', cron);
+}
+
+onTimezoneChanged(tz: string) {
+  console.log('Time zone', tz);
+}`
+    }
+  };

--- a/projects/composition/src/app/pages/select-page/select-page.component.html
+++ b/projects/composition/src/app/pages/select-page/select-page.component.html
@@ -1,7 +1,10 @@
 <app-component-docs-viewer [componentData]="componentData">
   <!-- Example of component's usage -->
-  <form [formGroup]="form">
-    <div class="selects-group">
+  <app-code-example
+    label="Required single select with a tooltip"
+    [htmlCode]="examples.requiredSelect.html"
+    [tsCode]="examples.requiredSelect.ts">
+    <form [formGroup]="form">
       <cps-select
         label="Required single select with a tooltip"
         [options]="options"
@@ -12,118 +15,177 @@
         [clearable]="true"
         formControlName="requiredSelect">
       </cps-select>
+    </form>
+  </app-code-example>
+
+  <app-code-example
+    label="Loading select"
+    [htmlCode]="examples.loadingSelect.html"
+    [tsCode]="examples.loadingSelect.ts">
+    <cps-select
+      label="Loading select"
+      [loading]="true"
+      [options]="options"
+      optionLabel="name"
+      hint="This select is currently in a loading state">
+    </cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Disabled select"
+    [htmlCode]="examples.disabledSelect.html">
+    <cps-select
+      label="Disabled select"
+      [disabled]="true"
+      hint="This select is disabled">
+    </cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Multiple select"
+    [htmlCode]="examples.multipleSelect.html"
+    [tsCode]="examples.multipleSelect.ts">
+    <cps-select
+      label="Multiple select"
+      [options]="options"
+      optionLabel="name"
+      optionValue="data"
+      optionInfo="info"
+      placeholder="Select a city"
+      [clearable]="false"
+      [multiple]="true"
+      [chips]="false"
+      [returnObject]="false"
+      [value]="[{ code: 'CPT' }]"
+      hint="This select is not clearable"></cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Multiple select with virtual scroll, chips and persistent clear icon"
+    [htmlCode]="examples.virtualScrollSelect.html"
+    [tsCode]="examples.virtualScrollSelect.ts">
+    <cps-select
+      label="Multiple select with virtual scroll, chips and persistent clear icon"
+      hint="This select doesn't have Select All option"
+      [selectAll]="false"
+      [virtualScroll]="true"
+      [options]="options"
+      optionLabel="name"
+      optionInfo="info"
+      placeholder="Select a city"
+      [clearable]="true"
+      [multiple]="true"
+      [persistentClear]="true"
+      [value]="[options[0], options[4]]"></cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Multiple select with non-closable chips"
+    [htmlCode]="examples.nonClosableChipsSelect.html"
+    [tsCode]="examples.nonClosableChipsSelect.ts">
+    <cps-select
+      label="Multiple select with non-closable chips"
+      [returnObject]="false"
+      [options]="options"
+      optionLabel="name"
+      optionValue="data"
+      optionInfo="info"
+      placeholder="Select a city"
+      hint="This select doesn't have a chevron icon"
+      [showChevron]="false"
+      [clearable]="true"
+      [multiple]="true"
+      [closableChips]="false"
+      [value]="[options[0].data, options[4].data]"></cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Multiple select with prefix icon"
+    [htmlCode]="examples.prefixIconSelect.html"
+    [tsCode]="examples.prefixIconSelect.ts">
+    <cps-select
+      label="Multiple select with prefix icon"
+      [options]="options"
+      optionLabel="name"
+      optionInfo="info"
+      placeholder="Select a city"
+      [clearable]="true"
+      [multiple]="true"
+      [chips]="false"
+      prefixIcon="plus"
+      [value]="[options[5]]">
+    </cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Single select with options icons"
+    [htmlCode]="examples.iconsSelect.html"
+    [tsCode]="examples.iconsSelect.ts">
+    <cps-select
+      label="Single select with options icons"
+      [options]="statusOptions"
+      optionLabel="name"
+      optionIconColor="color"
+      placeholder="Select a status">
+    </cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Two-way binding"
+    [htmlCode]="examples.twoWayBindingSelect.html"
+    [tsCode]="examples.twoWayBindingSelect.ts">
+    <div class="sync-val-example">
       <cps-select
-        label="Loading select"
-        [loading]="true"
-        [options]="options"
-        optionLabel="name"
-        hint="This select is currently in a loading state">
-      </cps-select>
-      <cps-select
-        label="Disabled select"
-        [disabled]="true"
-        hint="This select is disabled">
-      </cps-select>
-      <cps-select
-        label="Multiple select"
-        [options]="options"
-        optionLabel="name"
-        optionValue="data"
-        optionInfo="info"
-        placeholder="Select a city"
-        [clearable]="false"
-        [multiple]="true"
-        [chips]="false"
+        width="31.25rem"
+        label="Multiple select with two-way binding and keeping initial items order"
         [returnObject]="false"
-        [value]="[{ code: 'CPT' }]"
-        hint="This select is not clearable"></cps-select>
-      <cps-select
-        label="Multiple select with virtual scroll, chips and persistent clear icon"
-        hint="This select doesn't have Select All option"
-        [selectAll]="false"
-        [virtualScroll]="true"
-        [options]="options"
-        optionLabel="name"
-        optionInfo="info"
-        placeholder="Select a city"
-        [clearable]="true"
-        [multiple]="true"
-        [persistentClear]="true"
-        [value]="[options[0], options[4]]"></cps-select>
-      <cps-select
-        label="Multiple select with non-closable chips"
-        [returnObject]="false"
-        [options]="options"
-        optionLabel="name"
-        optionValue="data"
-        optionInfo="info"
-        placeholder="Select a city"
-        hint="This select doesn't have a chevron icon"
-        [showChevron]="false"
+        [options]="syncOptions"
+        [keepInitialOrder]="true"
+        optionLabel="title"
+        optionValue="val"
+        optionInfo="ticker"
+        placeholder="Select a company"
+        hint="This select has a fixed width of 31.25rem"
         [clearable]="true"
         [multiple]="true"
         [closableChips]="false"
-        [value]="[options[0].data, options[4].data]"></cps-select>
-      <cps-select
-        label="Multiple select with prefix icon"
-        [options]="options"
-        optionLabel="name"
-        optionInfo="info"
-        placeholder="Select a city"
-        [clearable]="true"
-        [multiple]="true"
-        [chips]="false"
-        prefixIcon="plus"
-        [value]="[options[5]]">
-      </cps-select>
-      <cps-select
-        label="Single select with options icons"
-        [options]="statusOptions"
-        optionLabel="name"
-        optionIconColor="color"
-        placeholder="Select a status">
-      </cps-select>
-      <div class="sync-val-example">
-        <cps-select
-          width="31.25rem"
-          label="Multiple select with two-way binding and keeping initial items order"
-          [returnObject]="false"
-          [options]="syncOptions"
-          [keepInitialOrder]="true"
-          optionLabel="title"
-          optionValue="val"
-          optionInfo="ticker"
-          placeholder="Select a company"
-          hint="This select has a fixed width of 31.25rem"
-          [clearable]="true"
-          [multiple]="true"
-          [closableChips]="false"
-          [(ngModel)]="syncVal"
-          [ngModelOptions]="{ standalone: true }"></cps-select>
-        <span class="sync-val">{{ syncVal }}</span>
-      </div>
-      <cps-select
-        label="Underlined select"
-        [options]="options"
-        optionLabel="name"
-        optionInfo="info"
-        placeholder="Select a city"
-        [clearable]="true"
-        [multiple]="true"
-        [chips]="false"
-        appearance="underlined">
-      </cps-select>
-      <cps-select
-        label="Borderless select"
-        [options]="options"
-        optionLabel="name"
-        optionInfo="info"
-        placeholder="Select a city"
-        [clearable]="true"
-        [multiple]="true"
-        [chips]="false"
-        appearance="borderless">
-      </cps-select>
+        [(ngModel)]="syncVal"
+        [ngModelOptions]="{ standalone: true }"></cps-select>
+      <span class="sync-val">{{ syncVal }}</span>
     </div>
-  </form>
+  </app-code-example>
+
+  <app-code-example
+    label="Underlined select"
+    [htmlCode]="examples.underlinedSelect.html"
+    [tsCode]="examples.underlinedSelect.ts">
+    <cps-select
+      label="Underlined select"
+      [options]="options"
+      optionLabel="name"
+      optionInfo="info"
+      placeholder="Select a city"
+      [clearable]="true"
+      [multiple]="true"
+      [chips]="false"
+      appearance="underlined">
+    </cps-select>
+  </app-code-example>
+
+  <app-code-example
+    label="Borderless select"
+    [htmlCode]="examples.borderlessSelect.html"
+    [tsCode]="examples.borderlessSelect.ts">
+    <cps-select
+      label="Borderless select"
+      [options]="options"
+      optionLabel="name"
+      optionInfo="info"
+      placeholder="Select a city"
+      [clearable]="true"
+      [multiple]="true"
+      [chips]="false"
+      appearance="borderless">
+    </cps-select>
+  </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/select-page/select-page.component.scss
+++ b/projects/composition/src/app/pages/select-page/select-page.component.scss
@@ -1,9 +1,3 @@
-.selects-group {
-  gap: 1.5rem;
-  display: flex;
-  flex-direction: column;
-}
-
 .sync-val-example {
   display: flex;
   align-items: center;

--- a/projects/composition/src/app/pages/select-page/select-page.component.ts
+++ b/projects/composition/src/app/pages/select-page/select-page.component.ts
@@ -59,7 +59,7 @@ export class SelectPageComponent implements OnInit {
   ];
 
   form!: UntypedFormGroup;
-  syncVal: any = [];
+  syncVal: string[] = [];
   componentData = ComponentData;
 
   // eslint-disable-next-line no-useless-constructor

--- a/projects/composition/src/app/pages/select-page/select-page.component.ts
+++ b/projects/composition/src/app/pages/select-page/select-page.component.ts
@@ -10,13 +10,16 @@ import { CpsSelectComponent } from 'cps-ui-kit';
 
 import ComponentData from '../../api-data/cps-select.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { selectExamples } from './select-page.examples';
 
 @Component({
   imports: [
     CpsSelectComponent,
     FormsModule,
     ReactiveFormsModule,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   selector: 'app-select-page',
   templateUrl: './select-page.component.html',
@@ -24,6 +27,7 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
   host: { class: 'composition-page' }
 })
 export class SelectPageComponent implements OnInit {
+  readonly examples = selectExamples;
   options = [
     { name: 'New York', data: { code: 'NY' } },
     { name: 'Prague', data: { code: 'PRG' }, info: 'Prague info' },

--- a/projects/composition/src/app/pages/select-page/select-page.examples.ts
+++ b/projects/composition/src/app/pages/select-page/select-page.examples.ts
@@ -183,7 +183,7 @@ syncOptions = [
   { title: 'Netflix', val: 'NFLX', ticker: 'NFLX' },
   { title: 'Tesla', val: 'TSLA', ticker: 'TSLA' }
 ];
-syncVal: any = [];`
+syncVal: string[] = [];`
   },
 
   underlinedSelect: {

--- a/projects/composition/src/app/pages/select-page/select-page.examples.ts
+++ b/projects/composition/src/app/pages/select-page/select-page.examples.ts
@@ -1,0 +1,220 @@
+const citiesOptionsTs = `
+options = [
+  { name: 'New York', data: { code: 'NY' } },
+  { name: 'Prague', data: { code: 'PRG' }, info: 'Prague info' },
+  { name: 'Capetown', data: { code: 'CPT' }, info: 'Capetown info' },
+  { name: 'Rome', data: { code: 'RM' } },
+  { name: 'London', data: { code: 'LDN' }, info: 'London info' },
+  { name: 'Istanbul', data: { code: 'IST' } },
+  { name: 'Paris', data: { code: 'PRS' } },
+  { name: 'Tokyo', data: { code: 'TOK' } },
+  { name: 'Oslo', data: { code: 'OSL' }, info: 'Oslo info' },
+  { name: 'Berlin', data: { code: 'BER' } }
+];`;
+
+export const selectExamples: Record<string, { html: string; ts?: string }> = {
+  requiredSelect: {
+    html: `
+<form [formGroup]="form">
+  <cps-select
+    label="Required single select with a tooltip"
+    [options]="options"
+    optionLabel="name"
+    optionInfo="info"
+    placeholder="Select a city"
+    infoTooltip="Provide any information here"
+    [clearable]="true"
+    formControlName="requiredSelect">
+  </cps-select>
+</form>`,
+    ts: `
+private readonly _formBuilder = inject(UntypedFormBuilder);
+
+${citiesOptionsTs.trim()}
+
+form!: UntypedFormGroup;
+
+ngOnInit(): void {
+  this.form = this._formBuilder.group({
+    requiredSelect: [this.options[1], [Validators.required]]
+  });
+}`
+  },
+
+  loadingSelect: {
+    html: `
+<cps-select
+  label="Loading select"
+  [loading]="true"
+  [options]="options"
+  optionLabel="name"
+  hint="This select is currently in a loading state">
+</cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  disabledSelect: {
+    html: `
+<cps-select
+  label="Disabled select"
+  [disabled]="true"
+  hint="This select is disabled">
+</cps-select>`
+  },
+
+  multipleSelect: {
+    html: `
+<cps-select
+  label="Multiple select"
+  [options]="options"
+  optionLabel="name"
+  optionValue="data"
+  optionInfo="info"
+  placeholder="Select a city"
+  [clearable]="false"
+  [multiple]="true"
+  [chips]="false"
+  [returnObject]="false"
+  [value]="[{ code: 'CPT' }]"
+  hint="This select is not clearable"></cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  virtualScrollSelect: {
+    html: `
+<cps-select
+  label="Multiple select with virtual scroll, chips and persistent clear icon"
+  hint="This select doesn't have Select All option"
+  [selectAll]="false"
+  [virtualScroll]="true"
+  [options]="options"
+  optionLabel="name"
+  optionInfo="info"
+  placeholder="Select a city"
+  [clearable]="true"
+  [multiple]="true"
+  [persistentClear]="true"
+  [value]="[options[0], options[4]]"></cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  nonClosableChipsSelect: {
+    html: `
+<cps-select
+  label="Multiple select with non-closable chips"
+  [returnObject]="false"
+  [options]="options"
+  optionLabel="name"
+  optionValue="data"
+  optionInfo="info"
+  placeholder="Select a city"
+  hint="This select doesn't have a chevron icon"
+  [showChevron]="false"
+  [clearable]="true"
+  [multiple]="true"
+  [closableChips]="false"
+  [value]="[options[0].data, options[4].data]"></cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  prefixIconSelect: {
+    html: `
+<cps-select
+  label="Multiple select with prefix icon"
+  [options]="options"
+  optionLabel="name"
+  optionInfo="info"
+  placeholder="Select a city"
+  [clearable]="true"
+  [multiple]="true"
+  [chips]="false"
+  prefixIcon="plus"
+  [value]="[options[5]]">
+</cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  iconsSelect: {
+    html: `
+<cps-select
+  label="Single select with options icons"
+  [options]="statusOptions"
+  optionLabel="name"
+  optionIconColor="color"
+  placeholder="Select a status">
+</cps-select>`,
+    ts: `
+statusOptions = [
+  { name: 'Success', icon: 'circle', color: 'success' },
+  { name: 'Pending', icon: 'circle', color: 'info' },
+  { name: 'Warning', icon: 'circle', color: 'warn' },
+  { name: 'Failed', icon: 'circle', color: 'error' }
+];`
+  },
+
+  twoWayBindingSelect: {
+    html: `
+<div class="sync-val-example">
+  <cps-select
+    width="31.25rem"
+    label="Multiple select with two-way binding and keeping initial items order"
+    [returnObject]="false"
+    [options]="syncOptions"
+    [keepInitialOrder]="true"
+    optionLabel="title"
+    optionValue="val"
+    optionInfo="ticker"
+    placeholder="Select a company"
+    hint="This select has a fixed width of 31.25rem"
+    [clearable]="true"
+    [multiple]="true"
+    [closableChips]="false"
+    [(ngModel)]="syncVal"
+    [ngModelOptions]="{ standalone: true }"></cps-select>
+  <span class="sync-val">{{ syncVal }}</span>
+</div>`,
+    ts: `
+syncOptions = [
+  { title: 'Amazon', val: 'AMZN', ticker: 'AMZN' },
+  { title: 'Apple', val: 'AAPL', ticker: 'AAPL' },
+  { title: 'Google', val: 'GOOGL', ticker: 'GOOGL' },
+  { title: 'Meta', val: 'META', ticker: 'META' },
+  { title: 'Microsoft', val: 'MSFT', ticker: 'MSFT' },
+  { title: 'Netflix', val: 'NFLX', ticker: 'NFLX' },
+  { title: 'Tesla', val: 'TSLA', ticker: 'TSLA' }
+];
+syncVal: any = [];`
+  },
+
+  underlinedSelect: {
+    html: `
+<cps-select
+  label="Underlined select"
+  [options]="options"
+  optionLabel="name"
+  optionInfo="info"
+  placeholder="Select a city"
+  [clearable]="true"
+  [multiple]="true"
+  [chips]="false"
+  appearance="underlined">
+</cps-select>`,
+    ts: citiesOptionsTs
+  },
+
+  borderlessSelect: {
+    html: `
+<cps-select
+  label="Borderless select"
+  [options]="options"
+  optionLabel="name"
+  optionInfo="info"
+  placeholder="Select a city"
+  [clearable]="true"
+  [multiple]="true"
+  [chips]="false"
+  appearance="borderless">
+</cps-select>`,
+    ts: citiesOptionsTs
+  }
+};

--- a/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.html
+++ b/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.html
@@ -5,11 +5,19 @@
     [exactRoutes]="true"
     ariaLabel="Sidebar menu example"></cps-sidebar-menu>
 
-  <div class="sidebar-menu-page-info-card">
-    <cps-icon icon="info-circle" color="info" size="normal"></cps-icon>
-    <div>
-      Provide your app urls into sidebar menu items or into nested menu items to
-      navigate to your routes
+  <div class="sidebar-menu-page-side">
+    <div class="sidebar-menu-page-info-card">
+      <cps-icon icon="info-circle" color="info" size="normal"></cps-icon>
+      <div>
+        Provide your app urls into sidebar menu items or into nested menu items
+        to navigate to your routes
+      </div>
     </div>
+
+    <app-code-example
+      [htmlCode]="examples.basicUsage.html"
+      [tsCode]="examples.basicUsage.ts"
+      [previewOutside]="true">
+    </app-code-example>
   </div>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.scss
+++ b/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.scss
@@ -8,6 +8,7 @@
   .sidebar-menu-page-side {
     display: flex;
     flex-direction: column;
+    gap: 1.5rem;
     flex: 1;
     min-width: 0;
     margin: 1.5rem 1.5rem 1.5rem 1.5rem;

--- a/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.scss
+++ b/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.scss
@@ -5,12 +5,20 @@
   }
   padding: 0 1.5rem 0 1.5rem;
 
+  .sidebar-menu-page-side {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    margin: 1.5rem 1.5rem 1.5rem 1.5rem;
+    overflow-y: auto;
+  }
+
   .sidebar-menu-page-info-card {
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
     padding: 1rem 1.25rem;
-    margin: 1.5rem 0 0 1.5rem;
     border-radius: 0.5rem;
     border-left: 0.25rem solid var(--cps-color-info);
     background: var(--cps-color-info-highlighten);

--- a/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.ts
+++ b/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.component.ts
@@ -7,19 +7,23 @@ import {
 
 import ComponentData from '../../api-data/cps-sidebar-menu.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { sidebarMenuExamples } from './sidebar-menu-page.examples';
 
 @Component({
   selector: 'app-sidebar-menu-page',
   imports: [
     CpsSidebarMenuComponent,
     CpsIconComponent,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   templateUrl: './sidebar-menu-page.component.html',
   styleUrls: ['./sidebar-menu-page.component.scss'],
   host: { class: 'composition-page' }
 })
 export class SidebarMenuPageComponent {
+  readonly examples = sidebarMenuExamples;
   items: CpsSidebarMenuItem[] = [
     {
       title: 'Dashboard',

--- a/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.examples.ts
+++ b/projects/composition/src/app/pages/sidebar-menu-page/sidebar-menu-page.examples.ts
@@ -1,0 +1,60 @@
+export const sidebarMenuExamples: Record<
+  string,
+  { html: string; ts?: string }
+> = {
+  basicUsage: {
+    html: `
+<cps-sidebar-menu
+  [items]="items"
+  [exactRoutes]="true"
+  ariaLabel="Sidebar menu example"></cps-sidebar-menu>`,
+    ts: `
+items: CpsSidebarMenuItem[] = [
+  {
+    title: 'Dashboard',
+    icon: 'grid',
+    url: '/'
+  },
+  {
+    title: 'Favourites',
+    icon: 'star',
+    url: '/sidebar-menu/examples'
+  },
+  {
+    title: 'Categories disabled',
+    icon: 'book',
+    url: '/',
+    disabled: true
+  },
+  {
+    title: 'Access menu',
+    icon: 'access-lock',
+    items: [
+      { title: 'Requests', desc: 'Apply for access', url: '/' },
+      {
+        title: 'Approval',
+        desc: 'Approve or reject access requests',
+        url: '/'
+      }
+    ]
+  },
+  {
+    title: 'Community menu',
+    icon: 'users',
+    items: [{ title: 'Questions', desc: 'See all questions', url: '/' }]
+  },
+  {
+    title: 'Bookmarks menu disabled',
+    icon: 'bookmark',
+    disabled: true,
+    items: [
+      {
+        title: 'Disabled cat',
+        desc: 'This is not visible',
+        url: '/'
+      }
+    ]
+  }
+];`
+  }
+};


### PR DESCRIPTION
Adds live code examples to the Scheduler, Select and Sidebar Menu components' documentation pages.

Closes #735 
Closes #736 
Closes #737 