### PR TITLE
docs: add code examples for Tabs, Table, Treetable

### DIFF
--- a/projects/composition/src/app/components/code-example/code-example.component.scss
+++ b/projects/composition/src/app/components/code-example/code-example.component.scss
@@ -1,8 +1,14 @@
 @use '../../../../../cps-ui-kit/styles/mixins' as *;
 
-.code-example {
-  margin-bottom: 1.5rem;
+:host {
+  display: block;
 
+  &:not(:last-child) {
+    margin-bottom: 1.5rem;
+  }
+}
+
+.code-example {
   &__label {
     font-size: 1.125rem;
     font-weight: 600;

--- a/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.scss
+++ b/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.scss
@@ -1,5 +1,4 @@
 .datepickers-group {
-  gap: 1.5rem;
   display: flex;
   flex-direction: column;
 }

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.component.scss
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.component.scss
@@ -1,6 +1,5 @@
 .open-dlg-btns-group,
 .close-dlg-btns-group {
-  gap: 1.875rem;
   display: flex;
   flex-direction: column;
   margin-left: 0.5rem;

--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.scss
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.scss
@@ -1,5 +1,4 @@
 .expans-panels-group {
-  gap: 1.5rem;
   display: flex;
   flex-direction: column;
   min-width: max-content;

--- a/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.html
+++ b/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.html
@@ -13,110 +13,120 @@
       }
     </div>
   </ng-template>
-  <div class="tabs-elems-group">
-    <div class="tabs-elems-group-title">
-      Center-aligned tabs with slide transition, badges and disabled last tab
+  <app-code-example
+    label="Center-aligned tabs with slide transition, badges and disabled last tab"
+    [htmlCode]="examples.centerAlignedTabs.html"
+    [tsCode]="examples.centerAlignedTabs.ts">
+    <div class="tabs-elems-group">
+      <cps-tab-group
+        tabsBackground="bg-light"
+        alignment="center"
+        class="tab-example--center-aligned"
+        [selectedIndex]="selectedTabIndex"
+        (afterTabChanged)="changeTab($event)">
+        @for (tab of centerAlignedTabs; track tab.label) {
+          <cps-tab
+            [label]="tab.label"
+            [badgeValue]="tab.badgeValue"
+            [badgeTooltip]="tab.badgeTooltip"
+            [disabled]="tab.disabled">
+            <ng-container
+              [ngTemplateOutlet]="tabContent"
+              [ngTemplateOutletContext]="{
+                showCheckbox: true,
+                tabLabel: tab.label
+              }"></ng-container>
+          </cps-tab>
+        }
+      </cps-tab-group>
     </div>
-    <cps-tab-group
-      tabsBackground="bg-light"
-      alignment="center"
-      class="tab-example--center-aligned"
-      [selectedIndex]="selectedTabIndex"
-      (afterTabChanged)="changeTab($event)">
-      @for (tab of centerAlignedTabs; track tab.label) {
-        <cps-tab
-          [label]="tab.label"
-          [badgeValue]="tab.badgeValue"
-          [badgeTooltip]="tab.badgeTooltip"
-          [disabled]="tab.disabled">
-          <ng-container
-            [ngTemplateOutlet]="tabContent"
-            [ngTemplateOutletContext]="{
-              showCheckbox: true,
-              tabLabel: tab.label
-            }"></ng-container>
-        </cps-tab>
-      }
-    </cps-tab-group>
-  </div>
+  </app-code-example>
 
-  <div class="tabs-elems-group">
-    <div class="tabs-elems-group-title">
-      Left-aligned tabs with fade transition and tooltips
+  <app-code-example
+    label="Left-aligned tabs with fade transition and tooltips"
+    [htmlCode]="examples.leftAlignedTabs.html"
+    [tsCode]="examples.leftAlignedTabs.ts">
+    <div class="tabs-elems-group">
+      <cps-tab-group
+        class="tab-example--left-aligned"
+        animationType="fade"
+        tabsBackground="bg-light"
+        (afterTabChanged)="changeTab($event)">
+        @for (tab of leftAlignedTabs; track tab.label) {
+          <cps-tab [label]="tab.label" [tooltipText]="tab.tooltipText">
+            <ng-container
+              [ngTemplateOutlet]="tabContent"
+              [ngTemplateOutletContext]="{ tabLabel: tab.label }">
+            </ng-container>
+          </cps-tab>
+        }
+      </cps-tab-group>
     </div>
-    <cps-tab-group
-      class="tab-example--left-aligned"
-      animationType="fade"
-      tabsBackground="bg-light"
-      (afterTabChanged)="changeTab($event)">
-      @for (tab of leftAlignedTabs; track tab.label) {
-        <cps-tab [label]="tab.label" [tooltipText]="tab.tooltipText">
-          <ng-container
-            [ngTemplateOutlet]="tabContent"
-            [ngTemplateOutletContext]="{ tabLabel: tab.label }">
-          </ng-container>
-        </cps-tab>
-      }
-    </cps-tab-group>
-  </div>
+  </app-code-example>
 
-  <div class="tabs-elems-group">
-    <div class="tabs-elems-group-title">
-      Right-aligned tabs with icons and without auto activation
+  <app-code-example
+    label="Right-aligned tabs with icons and without auto activation"
+    [htmlCode]="examples.rightAlignedTabs.html"
+    [tsCode]="examples.rightAlignedTabs.ts">
+    <div class="tabs-elems-group">
+      <cps-tab-group
+        alignment="right"
+        [autoActivation]="false"
+        (afterTabChanged)="changeTab($event)"
+        tabsBackground="bg-light">
+        @for (tab of rightAlignedTabs; track tab.label) {
+          <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
+            <ng-container
+              [ngTemplateOutlet]="tabContent"
+              [ngTemplateOutletContext]="{ tabLabel: tab.label }">
+            </ng-container>
+          </cps-tab>
+        }
+      </cps-tab-group>
     </div>
-    <cps-tab-group
-      alignment="right"
-      [autoActivation]="false"
-      (afterTabChanged)="changeTab($event)"
-      tabsBackground="bg-light">
-      @for (tab of rightAlignedTabs; track tab.label) {
-        <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
-          <ng-container
-            [ngTemplateOutlet]="tabContent"
-            [ngTemplateOutletContext]="{ tabLabel: tab.label }">
-          </ng-container>
-        </cps-tab>
-      }
-    </cps-tab-group>
-  </div>
+  </app-code-example>
 
-  <div class="tabs-elems-group">
-    <div class="tabs-elems-group-title">
-      Stretched tabs with slide transition
+  <app-code-example
+    label="Stretched tabs with slide transition"
+    [htmlCode]="examples.stretchedTabs.html"
+    [tsCode]="examples.stretchedTabs.ts">
+    <div class="tabs-elems-group">
+      <cps-tab-group
+        tabsBackground="bg-light"
+        [stretched]="true"
+        (afterTabChanged)="changeTab($event)">
+        @for (tab of stretchedTabs; track tab.label) {
+          <cps-tab [label]="tab.label">
+            <ng-container
+              [ngTemplateOutlet]="tabContent"
+              [ngTemplateOutletContext]="{ tabLabel: tab.label }">
+            </ng-container>
+          </cps-tab>
+        }
+      </cps-tab-group>
     </div>
-    <cps-tab-group
-      tabsBackground="bg-light"
-      [stretched]="true"
-      (afterTabChanged)="changeTab($event)">
-      @for (tab of stretchedTabs; track tab.label) {
-        <cps-tab [label]="tab.label">
-          <ng-container
-            [ngTemplateOutlet]="tabContent"
-            [ngTemplateOutletContext]="{ tabLabel: tab.label }">
-          </ng-container>
-        </cps-tab>
-      }
-    </cps-tab-group>
-  </div>
+  </app-code-example>
 
-  <div class="tabs-elems-group">
-    <div class="tabs-elems-group-title">
-      Tabs styled as subtabs out of the box
+  <app-code-example
+    label="Tabs styled as subtabs"
+    [htmlCode]="examples.subTabs.html"
+    [tsCode]="examples.subTabs.ts">
+    <div class="tabs-elems-group">
+      <cps-tab-group
+        class="tab-example--left-aligned"
+        [isSubTabs]="true"
+        tabsBackground="bg-light"
+        animationType="fade"
+        (afterTabChanged)="changeTab($event)">
+        @for (tab of subTabs; track tab.label) {
+          <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
+            <ng-container
+              [ngTemplateOutlet]="tabContent"
+              [ngTemplateOutletContext]="{ tabLabel: tab.label }">
+            </ng-container>
+          </cps-tab>
+        }
+      </cps-tab-group>
     </div>
-    <cps-tab-group
-      class="tab-example--left-aligned"
-      [isSubTabs]="true"
-      tabsBackground="bg-light"
-      animationType="fade"
-      (afterTabChanged)="changeTab($event)">
-      @for (tab of subTabs; track tab.label) {
-        <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
-          <ng-container
-            [ngTemplateOutlet]="tabContent"
-            [ngTemplateOutletContext]="{ tabLabel: tab.label }">
-          </ng-container>
-        </cps-tab>
-      }
-    </cps-tab-group>
-  </div>
+  </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.scss
+++ b/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.scss
@@ -2,14 +2,6 @@
   .tabs-elems-group {
     margin-bottom: 0.25rem;
 
-    &-title {
-      font-size: 1.5rem;
-      color: var(--cps-color-depth);
-      margin-bottom: 0.75rem;
-      padding-bottom: 0.5rem;
-      font-weight: 600;
-    }
-
     ::ng-deep .tab-example--center-aligned {
       .cps-tab-content-wrap {
         margin: 0 20%;

--- a/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.ts
+++ b/projects/composition/src/app/pages/tab-group-page/tab-group-page.component.ts
@@ -6,9 +6,10 @@ import {
   CpsTabChangeEvent,
   CpsCheckboxComponent
 } from 'cps-ui-kit';
-
 import ComponentData from '../../api-data/cps-tab-group.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { tabGroupExamples } from './tab-group-page.examples';
 
 @Component({
   imports: [
@@ -16,7 +17,8 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
     CpsTabGroupComponent,
     CpsTabComponent,
     CpsCheckboxComponent,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   selector: 'app-tab-group-page',
   templateUrl: './tab-group-page.component.html',
@@ -25,6 +27,7 @@ import { ComponentDocsViewerComponent } from '../../components/component-docs-vi
 })
 export class TabGroupPageComponent {
   componentData = ComponentData;
+  readonly examples = tabGroupExamples;
   selectedTabIndex = 1;
 
   changeTab({ newIndex }: CpsTabChangeEvent) {

--- a/projects/composition/src/app/pages/tab-group-page/tab-group-page.examples.ts
+++ b/projects/composition/src/app/pages/tab-group-page/tab-group-page.examples.ts
@@ -1,0 +1,132 @@
+const changeTabTs = `
+changeTab({ newIndex }: CpsTabChangeEvent) {
+  console.log('Tab changed to: ' + newIndex);
+}`;
+
+export const tabGroupExamples: Record<string, { html: string; ts?: string }> = {
+  centerAlignedTabs: {
+    html: `
+<cps-tab-group
+  tabsBackground="bg-light"
+  alignment="center"
+  [selectedIndex]="selectedTabIndex"
+  (afterTabChanged)="changeTab($event)">
+  @for (tab of centerAlignedTabs; track tab.label) {
+    <cps-tab
+      [label]="tab.label"
+      [badgeValue]="tab.badgeValue"
+      [badgeTooltip]="tab.badgeTooltip"
+      [disabled]="tab.disabled">
+      <cps-checkbox
+        [label]="'Checkbox of ' + tab.label.toLowerCase()"></cps-checkbox>
+    </cps-tab>
+  }
+</cps-tab-group>`,
+    ts: `
+selectedTabIndex = 1;
+
+centerAlignedTabs = [
+  {
+    label: 'Tab 1',
+    badgeValue: '7',
+    badgeTooltip: 'First tab badge',
+    disabled: false
+  },
+  { label: 'Tab 2', badgeValue: '', badgeTooltip: '', disabled: false },
+  {
+    label: 'Tab 3',
+    badgeValue: '5',
+    badgeTooltip: 'Third tab badge',
+    disabled: false
+  },
+  { label: 'Tab 4', badgeValue: '', badgeTooltip: '', disabled: true }
+];
+
+${changeTabTs.trim()}`
+  },
+
+  leftAlignedTabs: {
+    html: `
+<cps-tab-group
+  animationType="fade"
+  tabsBackground="bg-light"
+  (afterTabChanged)="changeTab($event)">
+  @for (tab of leftAlignedTabs; track tab.label) {
+    <cps-tab [label]="tab.label" [tooltipText]="tab.tooltipText">
+      {{ 'Content of ' + tab.label.toLowerCase() }}
+    </cps-tab>
+  }
+</cps-tab-group>`,
+    ts: `
+leftAlignedTabs = Array.from({ length: 20 }, (_, i) => ({
+  label: \`Tab \${i + 1}\`,
+  tooltipText: \`Tooltip of tab \${i + 1}\`
+}));
+
+${changeTabTs.trim()}`
+  },
+
+  rightAlignedTabs: {
+    html: `
+<cps-tab-group
+  alignment="right"
+  [autoActivation]="false"
+  (afterTabChanged)="changeTab($event)"
+  tabsBackground="bg-light">
+  @for (tab of rightAlignedTabs; track tab.label) {
+    <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
+      {{ 'Content of ' + tab.label.toLowerCase() }}
+    </cps-tab>
+  }
+</cps-tab-group>`,
+    ts: `
+rightAlignedTabs = [
+  { label: 'Tab 1', icon: 'survivorship', id: 'tab1' },
+  { label: 'Tab 2', icon: 'kris', id: null },
+  { label: 'Tab 3', icon: 'dq', id: null }
+];
+
+${changeTabTs.trim()}`
+  },
+
+  stretchedTabs: {
+    html: `
+<cps-tab-group
+  tabsBackground="bg-light"
+  [stretched]="true"
+  (afterTabChanged)="changeTab($event)">
+  @for (tab of stretchedTabs; track tab.label) {
+    <cps-tab [label]="tab.label">
+      {{ 'Content of ' + tab.label.toLowerCase() }}
+    </cps-tab>
+  }
+</cps-tab-group>`,
+    ts: `
+stretchedTabs = [{ label: 'Tab 1' }, { label: 'Tab 2' }, { label: 'Tab 3' }];
+
+${changeTabTs.trim()}`
+  },
+
+  subTabs: {
+    html: `
+<cps-tab-group
+  [isSubTabs]="true"
+  tabsBackground="bg-light"
+  animationType="fade"
+  (afterTabChanged)="changeTab($event)">
+  @for (tab of subTabs; track tab.label) {
+    <cps-tab [label]="tab.label" [icon]="tab.icon" [attr.id]="tab.id">
+      {{ 'Content of ' + tab.label.toLowerCase() }}
+    </cps-tab>
+  }
+</cps-tab-group>`,
+    ts: `
+subTabs = [
+  { label: 'Tab 1', icon: 'avatar', id: 'tab1' },
+  { label: 'Tab 2', icon: '', id: null },
+  { label: 'Tab 3', icon: '', id: null }
+];
+
+${changeTabTs.trim()}`
+  }
+};

--- a/projects/composition/src/app/pages/table-page/table-page.component.html
+++ b/projects/composition/src/app/pages/table-page/table-page.component.html
@@ -261,7 +261,7 @@
           [showRowMenu]="true"
           [rowMenuItems]="customRowMenuItems"
           exportFilename="table_6"
-          toolbarTitle="Borderless table with export button, without highlightning on rows hover. Row menu is shown and has custom items.">
+          toolbarTitle="Borderless table with export button, without highlighting on rows hover. Row menu is shown and has custom items.">
           <ng-template #header>
             <th cpsTColSortable="a">A</th>
             <th cpsTColSortable="b">B</th>

--- a/projects/composition/src/app/pages/table-page/table-page.component.html
+++ b/projects/composition/src/app/pages/table-page/table-page.component.html
@@ -6,192 +6,303 @@
     tabsBackground="bg-light"
     (afterTabChanged)="changeTab($event)">
     <cps-tab label="Table 1">
-      <cps-table
-        [data]="data"
-        [paginator]="true"
-        sortMode="multiple"
-        toolbarTitle="Table with a paginator, multiple sorting and individual filtering">
-        <ng-template #header>
-          <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
-          <th
-            cpsTColSortable="b"
-            cpsTColFilter="b"
-            filterType="date"
-            [filterMatchModes]="dateMatchModes"
-            [filterShowOperator]="false">
-            B
-          </th>
-          <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
-          <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">D</th>
-          <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">E</th>
-        </ng-template>
+      <app-code-example
+        [htmlCode]="examples.table1.html"
+        [tsCode]="examples.table1.ts">
+        <cps-table
+          [data]="data"
+          [paginator]="true"
+          sortMode="multiple"
+          toolbarTitle="Table with a paginator, multiple sorting and individual filtering">
+          <ng-template #header>
+            <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
+            <th
+              cpsTColSortable="b"
+              cpsTColFilter="b"
+              filterType="date"
+              [filterMatchModes]="dateMatchModes"
+              [filterShowOperator]="false">
+              B
+            </th>
+            <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
+            <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">
+              D
+            </th>
+            <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">
+              E
+            </th>
+          </ng-template>
 
-        <ng-template let-item #body>
-          <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-          <td>{{ item.c | percent }}</td>
-          <td>
-            <cps-icon
-              [icon]="item.d ? 'checked' : 'close-x'"
-              [color]="
-                item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="item.d ? 'True' : 'False'">
-            </cps-icon>
-          </td>
-          <td>{{ item.e }}</td>
-        </ng-template>
-      </cps-table>
+          <ng-template let-item #body>
+            <td>{{ item.a | uppercase }}</td>
+            <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+            <td>{{ item.c | percent }}</td>
+            <td>
+              <cps-icon
+                [icon]="item.d ? 'checked' : 'close-x'"
+                [color]="
+                  item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="item.d ? 'True' : 'False'">
+              </cps-icon>
+            </td>
+            <td>{{ item.e }}</td>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 2">
-      @if (selectedTabIndex === 1) {
-        <cps-table
-          [showGlobalFilter]="true"
-          [data]="dataVirtual"
-          [columns]="colsVirtual"
-          [sortable]="true"
-          [virtualScroll]="true"
-          [showColumnsToggleBtn]="true"
-          scrollHeight="31.25rem"
-          toolbarTitle="Sortable table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled"
-          [filterableByColumns]="true"
-          [resizableColumns]="true">
-        </cps-table>
-      }
+      <app-code-example
+        [htmlCode]="examples.table2.html"
+        [tsCode]="examples.table2.ts">
+        @if (selectedTabIndex === 1) {
+          <cps-table
+            [showGlobalFilter]="true"
+            [data]="dataVirtual"
+            [columns]="colsVirtual"
+            [sortable]="true"
+            [virtualScroll]="true"
+            [showColumnsToggleBtn]="true"
+            scrollHeight="26rem"
+            toolbarTitle="Sortable table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled"
+            [filterableByColumns]="true"
+            [resizableColumns]="true">
+          </cps-table>
+        }
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 3">
-      <cps-table
-        [data]="data"
-        [reorderableRows]="true"
-        [showActionBtn]="true"
-        [showRowMenu]="true"
-        [showRowRemoveButton]="isRemoveBtnVisible"
-        (rowsToRemove)="onRowsToRemove($event)"
-        [showDataReloadBtn]="true"
-        (editRowBtnClicked)="onEditRowButtonClicked($event)"
-        (actionBtnClicked)="onActionBtnClicked()"
-        (dataReloadBtnClicked)="onReloadBtnClicked()"
-        toolbarTitle="Table with resizable columns (expand mode), draggable rows, rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
-          isRemoveBtnVisible ? 'visible' : 'hidden'
-        }}"
-        actionBtnTitle="{{
-          isRemoveBtnVisible ? 'Hide' : 'Show'
-        }} Remove buttons"
-        [resizableColumns]="true"
-        [columnResizeMode]="'expand'">
-        <ng-template #header>
-          <th cpsTColResizable>A</th>
-          <th cpsTColResizable>B</th>
-          <th cpsTColResizable>C</th>
-          <th cpsTColResizable>D</th>
-          <th cpsTColResizable>E</th>
-        </ng-template>
+      <app-code-example
+        [htmlCode]="examples.table3.html"
+        [tsCode]="examples.table3.ts">
+        <cps-table
+          [data]="data"
+          [reorderableRows]="true"
+          [showActionBtn]="true"
+          [showRowMenu]="true"
+          [showRowRemoveButton]="isRemoveBtnVisible"
+          (rowsToRemove)="onRowsToRemove($event)"
+          [showDataReloadBtn]="true"
+          (editRowBtnClicked)="onEditRowButtonClicked($event)"
+          (actionBtnClicked)="onActionBtnClicked()"
+          (dataReloadBtnClicked)="onReloadBtnClicked()"
+          toolbarTitle="Table with resizable columns (expand mode), draggable rows, rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
+            isRemoveBtnVisible ? 'visible' : 'hidden'
+          }}"
+          actionBtnTitle="{{
+            isRemoveBtnVisible ? 'Hide' : 'Show'
+          }} Remove buttons"
+          [resizableColumns]="true"
+          [columnResizeMode]="'expand'">
+          <ng-template #header>
+            <th cpsTColResizable>A</th>
+            <th cpsTColResizable>B</th>
+            <th cpsTColResizable>C</th>
+            <th cpsTColResizable>D</th>
+            <th cpsTColResizable>E</th>
+          </ng-template>
 
-        <ng-template let-item #body>
-          <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-          <td>{{ item.c | percent }}</td>
-          <td>
-            <cps-icon
-              [icon]="item.d ? 'checked' : 'close-x'"
-              [color]="
-                item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="item.d ? 'True' : 'False'">
-            </cps-icon>
-          </td>
-          <td>{{ item.e }}</td>
-        </ng-template>
-      </cps-table>
+          <ng-template let-item #body>
+            <td>{{ item.a | uppercase }}</td>
+            <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+            <td>{{ item.c | percent }}</td>
+            <td>
+              <cps-icon
+                [icon]="item.d ? 'checked' : 'close-x'"
+                [color]="
+                  item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="item.d ? 'True' : 'False'">
+              </cps-icon>
+            </td>
+            <td>{{ item.e }}</td>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 4">
-      <cps-table
-        [data]="data"
-        dataKey="a"
-        [columns]="colsWithFilterType"
-        [selectable]="true"
-        sortMode="multiple"
-        [striped]="false"
-        [showRowMenu]="true"
-        (rowsToRemove)="onRowsToRemove($event)"
-        [showColumnsToggleBtn]="true"
-        (columnsSelected)="onColumnsSelected($event)"
-        (editRowBtnClicked)="onEditRowButtonClicked($event)"
-        (rowsSelected)="onRowsSelectionChanged($event)"
-        toolbarIcon="toast-success"
-        toolbarIconColor="success"
-        toolbarTitle="Table with toolbar icon, external columns toggle, unstriped selectable and expandable rows">
-        <ng-template #header>
-          @for (scol of selCols; track scol) {
-            <th
-              [cpsTColSortable]="scol.field"
-              [cpsTColFilter]="scol.field"
-              [filterType]="scol.filterType">
-              {{ scol.header }}
-            </th>
-          }
-        </ng-template>
+      <app-code-example
+        [htmlCode]="examples.table4.html"
+        [tsCode]="examples.table4.ts">
+        <cps-table
+          [data]="data"
+          dataKey="a"
+          [columns]="colsWithFilterType"
+          [selectable]="true"
+          sortMode="multiple"
+          [striped]="false"
+          [showRowMenu]="true"
+          (rowsToRemove)="onRowsToRemove($event)"
+          [showColumnsToggleBtn]="true"
+          (columnsSelected)="onColumnsSelected($event)"
+          (editRowBtnClicked)="onEditRowButtonClicked($event)"
+          (rowsSelected)="onRowsSelectionChanged($event)"
+          toolbarIcon="toast-success"
+          toolbarIconColor="success"
+          toolbarTitle="Table with toolbar icon, external columns toggle, unstriped selectable and expandable rows">
+          <ng-template #header>
+            @for (scol of selCols; track scol) {
+              <th
+                [cpsTColSortable]="scol.field"
+                [cpsTColFilter]="scol.field"
+                [filterType]="scol.filterType">
+                {{ scol.header }}
+              </th>
+            }
+          </ng-template>
 
-        <ng-template let-item #body>
-          @for (scol of selCols; track scol) {
-            @switch (scol.field) {
-              @case ('a') {
-                <td>{{ item.a | uppercase }}</td>
-              }
-              @case ('b') {
-                <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-              }
-              @case ('c') {
-                <td>{{ item.c | percent }}</td>
-              }
-              @case ('d') {
-                <td>
-                  <cps-icon
-                    [icon]="item.d ? 'checked' : 'close-x'"
-                    [color]="
-                      item.d
-                        ? 'var(--cps-color-success)'
-                        : 'var(--cps-color-error)'
-                    "
-                    size="small"
-                    [ariaLabel]="item.d ? 'True' : 'False'">
-                  </cps-icon>
-                </td>
-              }
-              @case ('e') {
-                <td>{{ item.e }}</td>
+          <ng-template let-item #body>
+            @for (scol of selCols; track scol) {
+              @switch (scol.field) {
+                @case ('a') {
+                  <td>{{ item.a | uppercase }}</td>
+                }
+                @case ('b') {
+                  <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+                }
+                @case ('c') {
+                  <td>{{ item.c | percent }}</td>
+                }
+                @case ('d') {
+                  <td>
+                    <cps-icon
+                      [icon]="item.d ? 'checked' : 'close-x'"
+                      [color]="
+                        item.d
+                          ? 'var(--cps-color-success)'
+                          : 'var(--cps-color-error)'
+                      "
+                      size="small"
+                      [ariaLabel]="item.d ? 'True' : 'False'">
+                    </cps-icon>
+                  </td>
+                }
+                @case ('e') {
+                  <td>{{ item.e }}</td>
+                }
               }
             }
-          }
-        </ng-template>
+          </ng-template>
 
-        <ng-template let-item #rowexpansion>
-          <div class="expanded-row-contents">
-            <div>id: {{ item.f.id }}</div>
-            <div>desc: {{ item.f.desc }}</div>
-          </div>
-        </ng-template>
-      </cps-table>
+          <ng-template let-item #rowexpansion>
+            <div class="expanded-row-contents">
+              <div>id: {{ item.f.id }}</div>
+              <div>desc: {{ item.f.desc }}</div>
+            </div>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 5">
-      <cps-table
-        [data]="data"
-        [selectable]="true"
-        toolbarSize="small"
-        (rowsToRemove)="onRowsToRemove($event)"
-        scrollHeight="calc(100vh - 19.375rem)"
-        toolbarTitle="Table with nested header and small toolbar">
-        <ng-template #nestedHeader>
-          <tr>
-            <!-- MANUALLY ADD FIRST HEADER WITH CHECKBOX, SINCE THE TABLE IS SELECTABLE -->
-            <!-- FOR SIMPLE HEADER THIS IS DONE AUTOMATICALLY -->
-            <th rowspan="2" cpsTHdrSelectable></th>
-            <th colspan="2">Section 1</th>
-            <th colspan="3">Section 2</th>
-          </tr>
-          <tr>
+      <app-code-example
+        [htmlCode]="examples.table5.html"
+        [tsCode]="examples.table5.ts">
+        <cps-table
+          [data]="data"
+          [selectable]="true"
+          toolbarSize="small"
+          (rowsToRemove)="onRowsToRemove($event)"
+          scrollHeight="calc(100vh - 24.625rem)"
+          toolbarTitle="Table with nested header and small toolbar">
+          <ng-template #nestedHeader>
+            <tr>
+              <!-- MANUALLY ADD FIRST HEADER WITH CHECKBOX, SINCE THE TABLE IS SELECTABLE -->
+              <!-- FOR SIMPLE HEADER THIS IS DONE AUTOMATICALLY -->
+              <th rowspan="2" cpsTHdrSelectable></th>
+              <th colspan="2">Section 1</th>
+              <th colspan="3">Section 2</th>
+            </tr>
+            <tr>
+              <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
+              <th cpsTColSortable="b" cpsTColFilter="b" filterType="date">B</th>
+              <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">
+                C
+              </th>
+              <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">
+                D
+              </th>
+              <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">
+                E
+              </th>
+            </tr>
+          </ng-template>
+          <ng-template let-item #body>
+            <td>{{ item.a | uppercase }}</td>
+            <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+            <td>{{ item.c | percent }}</td>
+            <td>
+              <cps-icon
+                [icon]="item.d ? 'checked' : 'close-x'"
+                [color]="
+                  item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="item.d ? 'True' : 'False'">
+              </cps-icon>
+            </td>
+            <td>{{ item.e }}</td>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
+    </cps-tab>
+    <cps-tab label="Table 6">
+      <app-code-example
+        [htmlCode]="examples.table6.html"
+        [tsCode]="examples.table6.ts">
+        <cps-table
+          [data]="data"
+          [columns]="cols"
+          [rowHover]="false"
+          [bordered]="false"
+          [sortable]="true"
+          [showExportBtn]="true"
+          [showRowMenu]="true"
+          [rowMenuItems]="customRowMenuItems"
+          exportFilename="table_6"
+          toolbarTitle="Borderless table with export button, without highlightning on rows hover. Row menu is shown and has custom items.">
+          <ng-template #header>
+            <th cpsTColSortable="a">A</th>
+            <th cpsTColSortable="b">B</th>
+            <th cpsTColSortable="c">C</th>
+            <th cpsTColSortable="d">D</th>
+            <th cpsTColSortable="e">E</th>
+          </ng-template>
+
+          <ng-template let-item #body>
+            <td>{{ item.a | uppercase }}</td>
+            <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+            <td>{{ item.c | percent }}</td>
+            <td>
+              <cps-icon
+                [icon]="item.d ? 'checked' : 'close-x'"
+                [color]="
+                  item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="item.d ? 'True' : 'False'">
+              </cps-icon>
+            </td>
+            <td>{{ item.e }}</td>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
+    </cps-tab>
+    <cps-tab label="Table 7">
+      <app-code-example
+        [htmlCode]="examples.table7.html"
+        [tsCode]="examples.table7.ts">
+        <cps-table [data]="data" [size]="selSize">
+          <ng-template #toolbar>
+            <span>Table with custom toolbar and different sizes</span>
+            <cps-button-toggle
+              ariaLabel="Table size"
+              [options]="sizesOptions"
+              [(ngModel)]="selSize">
+            </cps-button-toggle>
+          </ng-template>
+          <ng-template #header>
             <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
             <th cpsTColSortable="b" cpsTColFilter="b" filterType="date">B</th>
             <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
@@ -201,133 +312,73 @@
             <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">
               E
             </th>
-          </tr>
-        </ng-template>
-        <ng-template let-item #body>
-          <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-          <td>{{ item.c | percent }}</td>
-          <td>
-            <cps-icon
-              [icon]="item.d ? 'checked' : 'close-x'"
-              [color]="
-                item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="item.d ? 'True' : 'False'">
-            </cps-icon>
-          </td>
-          <td>{{ item.e }}</td>
-        </ng-template>
-      </cps-table>
-    </cps-tab>
-    <cps-tab label="Table 6">
-      <cps-table
-        [data]="data"
-        [columns]="cols"
-        [rowHover]="false"
-        [bordered]="false"
-        [sortable]="true"
-        [showExportBtn]="true"
-        [showRowMenu]="true"
-        [rowMenuItems]="customRowMenuItems"
-        exportFilename="table_6"
-        toolbarTitle="Borderless table with export button, without highlightning on rows hover. Row menu is shown and has custom items.">
-        <ng-template #header>
-          <th cpsTColSortable="a">A</th>
-          <th cpsTColSortable="b">B</th>
-          <th cpsTColSortable="c">C</th>
-          <th cpsTColSortable="d">D</th>
-          <th cpsTColSortable="e">E</th>
-        </ng-template>
+          </ng-template>
 
-        <ng-template let-item #body>
-          <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-          <td>{{ item.c | percent }}</td>
-          <td>
-            <cps-icon
-              [icon]="item.d ? 'checked' : 'close-x'"
-              [color]="
-                item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="item.d ? 'True' : 'False'">
-            </cps-icon>
-          </td>
-          <td>{{ item.e }}</td>
-        </ng-template>
-      </cps-table>
-    </cps-tab>
-    <cps-tab label="Table 7">
-      <cps-table [data]="data" [size]="selSize">
-        <ng-template #toolbar>
-          <span>Table with custom toolbar and different sizes</span>
-          <cps-button-toggle
-            ariaLabel="Table size"
-            [options]="sizesOptions"
-            [(ngModel)]="selSize">
-          </cps-button-toggle>
-        </ng-template>
-        <ng-template #header>
-          <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
-          <th cpsTColSortable="b" cpsTColFilter="b" filterType="date">B</th>
-          <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
-          <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">D</th>
-          <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">E</th>
-        </ng-template>
-
-        <ng-template let-item #body>
-          <td>{{ item.a | uppercase }}</td>
-          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
-          <td>{{ item.c | percent }}</td>
-          <td>
-            <cps-icon
-              [icon]="item.d ? 'checked' : 'close-x'"
-              [color]="
-                item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="item.d ? 'True' : 'False'">
-            </cps-icon>
-          </td>
-          <td>{{ item.e }}</td>
-        </ng-template>
-      </cps-table>
+          <ng-template let-item #body>
+            <td>{{ item.a | uppercase }}</td>
+            <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+            <td>{{ item.c | percent }}</td>
+            <td>
+              <cps-icon
+                [icon]="item.d ? 'checked' : 'close-x'"
+                [color]="
+                  item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="item.d ? 'True' : 'False'">
+              </cps-icon>
+            </td>
+            <td>{{ item.e }}</td>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 8">
-      <cps-table [data]="[]" toolbarTitle="Empty table" emptyBodyHeight="25rem">
-        <ng-template #header>
-          <th cpsTColSortable="a">A</th>
-          <th cpsTColSortable="b">B</th>
-          <th cpsTColSortable="c">C</th>
-          <th cpsTColSortable="d">D</th>
-          <th cpsTColSortable="e">E</th>
-        </ng-template>
-      </cps-table>
+      <app-code-example [htmlCode]="examples.table8.html">
+        <cps-table
+          [data]="[]"
+          toolbarTitle="Empty table"
+          emptyBodyHeight="22rem">
+          <ng-template #header>
+            <th cpsTColSortable="a">A</th>
+            <th cpsTColSortable="b">B</th>
+            <th cpsTColSortable="c">C</th>
+            <th cpsTColSortable="d">D</th>
+            <th cpsTColSortable="e">E</th>
+          </ng-template>
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 9">
-      <cps-table
-        [data]="data"
-        [loading]="true"
-        scrollHeight="25rem"
-        [columns]="cols"
-        toolbarTitle="Table in data loading state">
-      </cps-table>
+      <app-code-example
+        [htmlCode]="examples.table9.html"
+        [tsCode]="examples.table9.ts">
+        <cps-table
+          [data]="data"
+          [loading]="true"
+          scrollHeight="25rem"
+          [columns]="cols"
+          toolbarTitle="Table in data loading state">
+        </cps-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Table 10">
-      <cps-table
-        [data]="dataWithHTML"
-        scrollHeight="25rem"
-        [columns]="colsHTML"
-        [renderDataAsHTML]="renderAsHTML"
-        [showActionBtn]="true"
-        toolbarTitle="Table containing HTML"
-        actionBtnTitle="renderAsHTML is set to {{
-          renderAsHTML ? 'true' : 'false'
-        }}"
-        (actionBtnClicked)="renderAsHTML = !renderAsHTML">
-      </cps-table>
+      <app-code-example
+        [htmlCode]="examples.table10.html"
+        [tsCode]="examples.table10.ts">
+        <cps-table
+          [data]="dataWithHTML"
+          scrollHeight="22rem"
+          [columns]="colsHTML"
+          [renderDataAsHTML]="renderAsHTML"
+          [showActionBtn]="true"
+          toolbarTitle="Table containing HTML"
+          actionBtnTitle="renderAsHTML is set to {{
+            renderAsHTML ? 'true' : 'false'
+          }}"
+          (actionBtnClicked)="renderAsHTML = !renderAsHTML">
+        </cps-table>
+      </app-code-example>
     </cps-tab>
   </cps-tab-group>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/table-page/table-page.component.scss
+++ b/projects/composition/src/app/pages/table-page/table-page.component.scss
@@ -4,7 +4,13 @@
     color: red;
   }
 
-  ::ng-deep .table-page--sub-tabs {
-    padding-top: 0.625rem;
+  ::ng-deep {
+    .table-page--sub-tabs {
+      padding-top: 0.625rem;
+    }
+
+    app-code-example {
+      margin-top: 0.0625rem;
+    }
   }
 }

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -72,7 +72,7 @@ export class TablePageComponent implements OnInit {
     {
       a: '<h1>hello</h1>',
       b: '<h2>world</h2>',
-      c: '<a href="https://www.github.com">link to github</a>'
+      c: '<a href="https://www.github.com">link to GitHub</a>'
     },
     {
       a: 'this is sanitized <script>console.log("pwned")</script>',

--- a/projects/composition/src/app/pages/table-page/table-page.component.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.component.ts
@@ -17,6 +17,8 @@ import {
   CpsIconComponent
 } from 'cps-ui-kit';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { tableExamples } from './table-page.examples';
 
 import ComponentData from '../../api-data/cps-table.json';
 import { DatePipe, PercentPipe, UpperCasePipe } from '@angular/common';
@@ -37,13 +39,16 @@ import { DatePipe, PercentPipe, UpperCasePipe } from '@angular/common';
     CpsTabComponent,
     CpsButtonToggleComponent,
     CpsIconComponent,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   templateUrl: './table-page.component.html',
   styleUrls: ['./table-page.component.scss'],
   host: { class: 'composition-page' }
 })
 export class TablePageComponent implements OnInit {
+  readonly examples = tableExamples;
+
   selectedTabIndex = 0;
 
   dateMatchModes = [

--- a/projects/composition/src/app/pages/table-page/table-page.examples.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.examples.ts
@@ -535,7 +535,7 @@ selSize: CpsTableSize = 'small';`
 
   table8: {
     html: `
-<cps-table [data]="[]" toolbarTitle="Empty table" emptyBodyHeight="25rem">
+<cps-table [data]="[]" toolbarTitle="Empty table" emptyBodyHeight="22rem">
   <ng-template #header>
     <th cpsTColSortable="a">A</th>
     <th cpsTColSortable="b">B</th>

--- a/projects/composition/src/app/pages/table-page/table-page.examples.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.examples.ts
@@ -141,7 +141,7 @@ dateMatchModes = [
   [sortable]="true"
   [virtualScroll]="true"
   [showColumnsToggleBtn]="true"
-  scrollHeight="31.25rem"
+  scrollHeight="26rem"
   toolbarTitle="Sortable table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled"
   [filterableByColumns]="true"
   [resizableColumns]="true">
@@ -367,7 +367,7 @@ onRowsSelectionChanged(rows: any) {
   [selectable]="true"
   toolbarSize="small"
   (rowsToRemove)="onRowsToRemove($event)"
-  scrollHeight="calc(100vh - 19.375rem)"
+  scrollHeight="calc(100vh - 24.625rem)"
   toolbarTitle="Table with nested header and small toolbar">
   <ng-template #nestedHeader>
     <tr>
@@ -426,7 +426,7 @@ onRowsToRemove(rows: any[]) {
   [showRowMenu]="true"
   [rowMenuItems]="customRowMenuItems"
   exportFilename="table_6"
-  toolbarTitle="Borderless table with export button, without highlightning on rows hover. Row menu is shown and has custom items.">
+  toolbarTitle="Borderless table with export button, without highlighting on rows hover. Row menu is shown and has custom items.">
   <ng-template #header>
     <th cpsTColSortable="a">A</th>
     <th cpsTColSortable="b">B</th>
@@ -571,7 +571,7 @@ cols = [
     html: `
 <cps-table
   [data]="dataWithHTML"
-  scrollHeight="25rem"
+  scrollHeight="22rem"
   [columns]="colsHTML"
   [renderDataAsHTML]="renderAsHTML"
   [showActionBtn]="true"
@@ -586,7 +586,7 @@ dataWithHTML = [
   {
     a: '<h1>hello</h1>',
     b: '<h2>world</h2>',
-    c: '<a href="https://www.github.com">link to github</a>'
+    c: '<a href="https://www.github.com">link to GitHub</a>'
   },
   {
     a: 'this is sanitized <script>console.log("pwned")</script>',

--- a/projects/composition/src/app/pages/table-page/table-page.examples.ts
+++ b/projects/composition/src/app/pages/table-page/table-page.examples.ts
@@ -1,0 +1,606 @@
+const tableDataTs = `
+data = [
+  {
+    a: 'a1',
+    b: new Date(2022, 5, 15),
+    c: 0.0,
+    d: true,
+    e: 'Panda',
+    f: { desc: 'expanded row contents', id: 1 }
+  },
+  {
+    a: 'a2',
+    b: new Date(2021, 7, 10),
+    c: 0.1,
+    d: false,
+    e: 'Elephant',
+    f: { desc: 'expanded row contents', id: 2 }
+  },
+  {
+    a: 'a3',
+    b: new Date(2023, 0, 31),
+    c: 0.2,
+    d: false,
+    e: 'Lion',
+    f: { desc: 'expanded row contents', id: 3 }
+  },
+  {
+    a: 'a4',
+    b: new Date(2022, 8, 25),
+    c: 0.3,
+    d: true,
+    e: 'Dolphin',
+    f: { desc: 'expanded row contents', id: 4 }
+  },
+  {
+    a: 'a5',
+    b: new Date(2023, 0, 31),
+    c: 0.4,
+    d: false,
+    e: 'Penguin',
+    f: { desc: 'expanded row contents', id: 5 }
+  },
+  {
+    a: 'a6',
+    b: new Date(2022, 3, 5),
+    c: 0.5,
+    d: true,
+    e: 'Panda',
+    f: { desc: 'expanded row contents', id: 6 }
+  },
+  {
+    a: 'a7',
+    b: new Date(2023, 4, 20),
+    c: 0.6,
+    d: true,
+    e: 'Lion',
+    f: { desc: 'expanded row contents', id: 7 }
+  },
+  {
+    a: 'a8',
+    b: new Date(2021, 2, 22),
+    c: 0.7,
+    d: true,
+    e: 'Elephant',
+    f: { desc: 'expanded row contents', id: 8 }
+  },
+  {
+    a: 'a9',
+    b: new Date(2023, 1, 14),
+    c: 0.8,
+    d: false,
+    e: 'Giraffe',
+    f: { desc: 'expanded row contents', id: 9 }
+  },
+  {
+    a: 'a10',
+    b: new Date(2023, 3, 7),
+    c: 0.9,
+    d: true,
+    e: 'Chimpanzee',
+    f: { desc: 'expanded row contents', id: 10 }
+  }
+  // ...more rows omitted for brevity
+];`;
+
+export const tableExamples: Record<string, { html: string; ts?: string }> = {
+  table1: {
+    html: `
+<cps-table
+  [data]="data"
+  [paginator]="true"
+  sortMode="multiple"
+  toolbarTitle="Table with a paginator, multiple sorting and individual filtering">
+  <ng-template #header>
+    <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
+    <th
+      cpsTColSortable="b"
+      cpsTColFilter="b"
+      filterType="date"
+      [filterMatchModes]="dateMatchModes"
+      [filterShowOperator]="false">
+      B
+    </th>
+    <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
+    <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">D</th>
+    <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">E</th>
+  </ng-template>
+
+  <ng-template let-item #body>
+    <td>{{ item.a | uppercase }}</td>
+    <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+    <td>{{ item.c | percent }}</td>
+    <td>
+      <cps-icon
+        [icon]="item.d ? 'checked' : 'close-x'"
+        [color]="
+          item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="item.d ? 'True' : 'False'">
+      </cps-icon>
+    </td>
+    <td>{{ item.e }}</td>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+dateMatchModes = [
+  CpsColumnFilterMatchMode.DATE_BEFORE,
+  CpsColumnFilterMatchMode.DATE_AFTER
+];`
+  },
+
+  table2: {
+    html: `
+<cps-table
+  [showGlobalFilter]="true"
+  [data]="dataVirtual"
+  [columns]="colsVirtual"
+  [sortable]="true"
+  [virtualScroll]="true"
+  [showColumnsToggleBtn]="true"
+  scrollHeight="31.25rem"
+  toolbarTitle="Sortable table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled"
+  [filterableByColumns]="true"
+  [resizableColumns]="true">
+</cps-table>`,
+    ts: `
+colsVirtual = [
+  { field: 'a', header: 'String' },
+  { field: 'b', header: 'String (only 5 distinct values)' },
+  { field: 'c', header: 'Number' },
+  { field: 'd', header: 'Date', dateFormat: 'dd. MM. yyyy' },
+  { field: 'e', header: 'Boolean' },
+  {
+    field: 'f',
+    header: 'Date but with category filter',
+    filterType: 'category',
+    dateFormat: 'yyyy/MM/dd HH:mm:ss'
+  }
+];
+
+dataVirtual: {
+  a: string;
+  b: string;
+  c: number;
+  d: Date;
+  e: boolean;
+  f: Date;
+}[] = [];
+
+ngOnInit(): void {
+  const sevenRandomDates = Array.from(
+    { length: 7 },
+    () => new Date(Math.round(Math.random() * 1e12))
+  );
+  let c = 0.0;
+  for (let i = 0; i <= 1000; i++) {
+    this.dataVirtual.push({
+      a: 'a' + i,
+      b: 'b' + (i % 5),
+      c,
+      d: new Date(new Date().valueOf() - Math.random() * 1e12),
+      e: Math.random() > 0.5,
+      f: sevenRandomDates[i % 7]
+    });
+
+    c = parseFloat((c += 0.1).toFixed(1));
+  }
+}`
+  },
+
+  table3: {
+    html: `
+<cps-table
+  [data]="data"
+  [reorderableRows]="true"
+  [showActionBtn]="true"
+  [showRowMenu]="true"
+  [showRowRemoveButton]="isRemoveBtnVisible"
+  (rowsToRemove)="onRowsToRemove($event)"
+  [showDataReloadBtn]="true"
+  (editRowBtnClicked)="onEditRowButtonClicked($event)"
+  (actionBtnClicked)="onActionBtnClicked()"
+  (dataReloadBtnClicked)="onReloadBtnClicked()"
+  toolbarTitle="Table with resizable columns (expand mode), draggable rows, rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
+    isRemoveBtnVisible ? 'visible' : 'hidden'
+  }}"
+  actionBtnTitle="{{
+    isRemoveBtnVisible ? 'Hide' : 'Show'
+  }} Remove buttons"
+  [resizableColumns]="true"
+  [columnResizeMode]="'expand'">
+  <ng-template #header>
+    <th cpsTColResizable>A</th>
+    <th cpsTColResizable>B</th>
+    <th cpsTColResizable>C</th>
+    <th cpsTColResizable>D</th>
+    <th cpsTColResizable>E</th>
+  </ng-template>
+
+  <ng-template let-item #body>
+    <td>{{ item.a | uppercase }}</td>
+    <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+    <td>{{ item.c | percent }}</td>
+    <td>
+      <cps-icon
+        [icon]="item.d ? 'checked' : 'close-x'"
+        [color]="
+          item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="item.d ? 'True' : 'False'">
+      </cps-icon>
+    </td>
+    <td>{{ item.e }}</td>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+isRemoveBtnVisible = false;
+
+onRowsToRemove(rows: any[]) {
+  this.data = this.data.filter((r) => !rows.includes(r));
+}
+
+onEditRowButtonClicked(item: any) {
+  alert(\`Edit row button clicked. Item: \${JSON.stringify(item)}\`);
+}
+
+onActionBtnClicked() {
+  this.isRemoveBtnVisible = !this.isRemoveBtnVisible;
+  const visibilityStatus = this.isRemoveBtnVisible ? 'visible' : 'hidden';
+  alert(\`'Remove' buttons are now \${visibilityStatus}\`);
+}
+
+onReloadBtnClicked() {
+  alert('Data reload button clicked');
+}`
+  },
+
+  table4: {
+    html: `
+<cps-table
+  [data]="data"
+  dataKey="a"
+  [columns]="colsWithFilterType"
+  [selectable]="true"
+  sortMode="multiple"
+  [striped]="false"
+  [showRowMenu]="true"
+  (rowsToRemove)="onRowsToRemove($event)"
+  [showColumnsToggleBtn]="true"
+  (columnsSelected)="onColumnsSelected($event)"
+  (editRowBtnClicked)="onEditRowButtonClicked($event)"
+  (rowsSelected)="onRowsSelectionChanged($event)"
+  toolbarIcon="toast-success"
+  toolbarIconColor="success"
+  toolbarTitle="Table with toolbar icon, external columns toggle, unstriped selectable and expandable rows">
+  <ng-template #header>
+    @for (scol of selCols; track scol) {
+      <th
+        [cpsTColSortable]="scol.field"
+        [cpsTColFilter]="scol.field"
+        [filterType]="scol.filterType">
+        {{ scol.header }}
+      </th>
+    }
+  </ng-template>
+
+  <ng-template let-item #body>
+    @for (scol of selCols; track scol) {
+      @switch (scol.field) {
+        @case ('a') {
+          <td>{{ item.a | uppercase }}</td>
+        }
+        @case ('b') {
+          <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+        }
+        @case ('c') {
+          <td>{{ item.c | percent }}</td>
+        }
+        @case ('d') {
+          <td>
+            <cps-icon
+              [icon]="item.d ? 'checked' : 'close-x'"
+              [color]="
+                item.d
+                  ? 'var(--cps-color-success)'
+                  : 'var(--cps-color-error)'
+              "
+              size="small"
+              [ariaLabel]="item.d ? 'True' : 'False'">
+            </cps-icon>
+          </td>
+        }
+        @case ('e') {
+          <td>{{ item.e }}</td>
+        }
+      }
+    }
+  </ng-template>
+
+  <ng-template let-item #rowexpansion>
+    <div>
+      <div>id: {{ item.f.id }}</div>
+      <div>desc: {{ item.f.desc }}</div>
+    </div>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+colsWithFilterType = [
+  { field: 'a', header: 'A', filterType: 'text' },
+  { field: 'b', header: 'B', filterType: 'date' },
+  { field: 'c', header: 'C', filterType: 'number' },
+  { field: 'd', header: 'D', filterType: 'boolean' },
+  { field: 'e', header: 'E', filterType: 'category' }
+];
+
+selCols = this.colsWithFilterType;
+
+onRowsToRemove(rows: any[]) {
+  this.data = this.data.filter((r) => !rows.includes(r));
+}
+
+onColumnsSelected(columns: any) {
+  this.selCols = columns;
+}
+
+onEditRowButtonClicked(item: any) {
+  alert(\`Edit row button clicked. Item: \${JSON.stringify(item)}\`);
+}
+
+onRowsSelectionChanged(rows: any) {
+  console.log(rows);
+}`
+  },
+
+  table5: {
+    html: `
+<cps-table
+  [data]="data"
+  [selectable]="true"
+  toolbarSize="small"
+  (rowsToRemove)="onRowsToRemove($event)"
+  scrollHeight="calc(100vh - 19.375rem)"
+  toolbarTitle="Table with nested header and small toolbar">
+  <ng-template #nestedHeader>
+    <tr>
+      <!-- MANUALLY ADD FIRST HEADER WITH CHECKBOX, SINCE THE TABLE IS SELECTABLE -->
+      <!-- FOR SIMPLE HEADER THIS IS DONE AUTOMATICALLY -->
+      <th rowspan="2" cpsTHdrSelectable></th>
+      <th colspan="2">Section 1</th>
+      <th colspan="3">Section 2</th>
+    </tr>
+    <tr>
+      <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
+      <th cpsTColSortable="b" cpsTColFilter="b" filterType="date">B</th>
+      <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
+      <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">
+        D
+      </th>
+      <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">
+        E
+      </th>
+    </tr>
+  </ng-template>
+  <ng-template let-item #body>
+    <td>{{ item.a | uppercase }}</td>
+    <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+    <td>{{ item.c | percent }}</td>
+    <td>
+      <cps-icon
+        [icon]="item.d ? 'checked' : 'close-x'"
+        [color]="
+          item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="item.d ? 'True' : 'False'">
+      </cps-icon>
+    </td>
+    <td>{{ item.e }}</td>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+onRowsToRemove(rows: any[]) {
+  this.data = this.data.filter((r) => !rows.includes(r));
+}`
+  },
+
+  table6: {
+    html: `
+<cps-table
+  [data]="data"
+  [columns]="cols"
+  [rowHover]="false"
+  [bordered]="false"
+  [sortable]="true"
+  [showExportBtn]="true"
+  [showRowMenu]="true"
+  [rowMenuItems]="customRowMenuItems"
+  exportFilename="table_6"
+  toolbarTitle="Borderless table with export button, without highlightning on rows hover. Row menu is shown and has custom items.">
+  <ng-template #header>
+    <th cpsTColSortable="a">A</th>
+    <th cpsTColSortable="b">B</th>
+    <th cpsTColSortable="c">C</th>
+    <th cpsTColSortable="d">D</th>
+    <th cpsTColSortable="e">E</th>
+  </ng-template>
+
+  <ng-template let-item #body>
+    <td>{{ item.a | uppercase }}</td>
+    <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+    <td>{{ item.c | percent }}</td>
+    <td>
+      <cps-icon
+        [icon]="item.d ? 'checked' : 'close-x'"
+        [color]="
+          item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="item.d ? 'True' : 'False'">
+      </cps-icon>
+    </td>
+    <td>{{ item.e }}</td>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+cols = [
+  { field: 'a', header: 'A' }, // text
+  { field: 'b', header: 'B' }, // date
+  { field: 'c', header: 'C' }, // number
+  { field: 'd', header: 'D' }, // boolean
+  { field: 'e', header: 'E' } // category
+];
+
+customRowMenuItems: CpsMenuItem[] = [
+  {
+    title: 'Custom menu item',
+    icon: 'heart',
+    action: (row: any) => {
+      console.log('Custom menu item clicked', row);
+    }
+  },
+  {
+    title: 'Edit row',
+    icon: 'edit',
+    action: (row: any) => {
+      this.onEditRowButtonClicked(row);
+    }
+  }
+];
+
+onEditRowButtonClicked(item: any) {
+  alert(\`Edit row button clicked. Item: \${JSON.stringify(item)}\`);
+}`
+  },
+
+  table7: {
+    html: `
+<cps-table [data]="data" [size]="selSize">
+  <ng-template #toolbar>
+    <span>Table with custom toolbar and different sizes</span>
+    <cps-button-toggle
+      ariaLabel="Table size"
+      [options]="sizesOptions"
+      [(ngModel)]="selSize">
+    </cps-button-toggle>
+  </ng-template>
+  <ng-template #header>
+    <th cpsTColSortable="a" cpsTColFilter="a" filterType="text">A</th>
+    <th cpsTColSortable="b" cpsTColFilter="b" filterType="date">B</th>
+    <th cpsTColSortable="c" cpsTColFilter="c" filterType="number">C</th>
+    <th cpsTColSortable="d" cpsTColFilter="d" filterType="boolean">D</th>
+    <th cpsTColSortable="e" cpsTColFilter="e" filterType="category">E</th>
+  </ng-template>
+
+  <ng-template let-item #body>
+    <td>{{ item.a | uppercase }}</td>
+    <td>{{ item.b | date: 'MM/dd/yyyy' }}</td>
+    <td>{{ item.c | percent }}</td>
+    <td>
+      <cps-icon
+        [icon]="item.d ? 'checked' : 'close-x'"
+        [color]="
+          item.d ? 'var(--cps-color-success)' : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="item.d ? 'True' : 'False'">
+      </cps-icon>
+    </td>
+    <td>{{ item.e }}</td>
+  </ng-template>
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+sizesOptions: CpsButtonToggleOption[] = [
+  { label: 'Small', value: 'small' },
+  { label: 'Normal', value: 'normal' },
+  { label: 'Large', value: 'large' }
+];
+
+selSize: CpsTableSize = 'small';`
+  },
+
+  table8: {
+    html: `
+<cps-table [data]="[]" toolbarTitle="Empty table" emptyBodyHeight="25rem">
+  <ng-template #header>
+    <th cpsTColSortable="a">A</th>
+    <th cpsTColSortable="b">B</th>
+    <th cpsTColSortable="c">C</th>
+    <th cpsTColSortable="d">D</th>
+    <th cpsTColSortable="e">E</th>
+  </ng-template>
+</cps-table>`
+  },
+
+  table9: {
+    html: `
+<cps-table
+  [data]="data"
+  [loading]="true"
+  scrollHeight="25rem"
+  [columns]="cols"
+  toolbarTitle="Table in data loading state">
+</cps-table>`,
+    ts: `
+${tableDataTs.trim()}
+
+cols = [
+  { field: 'a', header: 'A' },
+  { field: 'b', header: 'B' },
+  { field: 'c', header: 'C' },
+  { field: 'd', header: 'D' },
+  { field: 'e', header: 'E' }
+];`
+  },
+
+  table10: {
+    html: `
+<cps-table
+  [data]="dataWithHTML"
+  scrollHeight="25rem"
+  [columns]="colsHTML"
+  [renderDataAsHTML]="renderAsHTML"
+  [showActionBtn]="true"
+  toolbarTitle="Table containing HTML"
+  actionBtnTitle="renderAsHTML is set to {{
+    renderAsHTML ? 'true' : 'false'
+  }}"
+  (actionBtnClicked)="renderAsHTML = !renderAsHTML">
+</cps-table>`,
+    ts: `
+dataWithHTML = [
+  {
+    a: '<h1>hello</h1>',
+    b: '<h2>world</h2>',
+    c: '<a href="https://www.github.com">link to github</a>'
+  },
+  {
+    a: 'this is sanitized <script>console.log("pwned")</script>',
+    b: '<img src="./assets/ui_logo.svg" alt="CPS UI Kit logo" width="100" />',
+    c: '<code>null === undefined</code>'
+  }
+];
+
+colsHTML = [
+  { field: 'a', header: 'String' },
+  { field: 'b', header: 'String (only 5 distinct values)' },
+  { field: 'c', header: 'Number' }
+];
+
+renderAsHTML = true;`
+  }
+};

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
@@ -6,228 +6,360 @@
     tabsBackground="bg-light"
     (afterTabChanged)="changeTab($event)">
     <cps-tab label="Tree table 1">
-      <cps-tree-table
-        [data]="data"
-        [paginator]="true"
-        [scrollable]="false"
-        sortMode="multiple"
-        [resizableColumns]="true"
-        [columnResizeMode]="'expand'"
-        [showExportBtn]="true"
-        [exportFilename]="'virtual-tree-data'"
-        toolbarTitle="Tree table with a paginator, resizable columns, multiple sorting and individual filtering">
-        <ng-template #header>
-          <th
-            cpsTTColSortable="name"
-            cpsTTColFilter="name"
-            filterType="text"
-            cpsTTColResizable>
-            Name
-          </th>
-          <th
-            cpsTTColSortable="size"
-            cpsTTColFilter="size"
-            filterType="number"
-            cpsTTColResizable>
-            Size
-          </th>
-          <th
-            cpsTTColSortable="modified"
-            cpsTTColFilter="modified"
-            filterType="date"
-            cpsTTColResizable>
-            Modified
-          </th>
-          <th
-            cpsTTColSortable="encrypted"
-            cpsTTColFilter="encrypted"
-            filterType="boolean"
-            cpsTTColResizable>
-            Encrypted
-          </th>
-          <th
-            cpsTTColSortable="importance"
-            cpsTTColFilter="importance"
-            filterType="category"
-            cpsTTColResizable>
-            Importance
-          </th>
-        </ng-template>
-
-        <ng-template #body let-rowNode let-rowData="rowData">
-          <td [cpsTTRowToggler]="rowNode">
-            {{ rowData.name }}
-          </td>
-          <td>{{ rowData.size }}</td>
-          <td>{{ rowData.modified | date }}</td>
-          <td>
-            <cps-icon
-              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-              [color]="
-                rowData.encrypted
-                  ? 'var(--cps-color-success)'
-                  : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
-            </cps-icon>
-          </td>
-          <td>{{ rowData.importance }}</td>
-        </ng-template>
-      </cps-tree-table>
-    </cps-tab>
-    <cps-tab label="Tree table 2">
-      @if (selectedTabIndex === 1) {
+      <app-code-example
+        [htmlCode]="examples.treeTable1.html"
+        [tsCode]="examples.treeTable1.ts">
         <cps-tree-table
-          [showGlobalFilter]="true"
-          [data]="dataVirtual"
-          [columns]="colsVirtual"
-          [sortable]="true"
-          [virtualScroll]="true"
-          [showColumnsToggleBtn]="true"
-          [filterableByColumns]="true"
+          [data]="data"
+          [paginator]="true"
+          [scrollable]="false"
+          sortMode="multiple"
           [resizableColumns]="true"
-          scrollHeight="31.25rem"
-          toolbarTitle="Sortable tree table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled">
-          <ng-template #colgroup>
-            <colgroup>
-              @for (col of colsVirtual; track col) {
-                <col />
-              }
-            </colgroup>
+          [columnResizeMode]="'expand'"
+          [showExportBtn]="true"
+          [exportFilename]="'virtual-tree-data'"
+          toolbarTitle="Tree table with a paginator, resizable columns, multiple sorting and individual filtering">
+          <ng-template #header>
+            <th
+              cpsTTColSortable="name"
+              cpsTTColFilter="name"
+              filterType="text"
+              cpsTTColResizable>
+              Name
+            </th>
+            <th
+              cpsTTColSortable="size"
+              cpsTTColFilter="size"
+              filterType="number"
+              cpsTTColResizable>
+              Size
+            </th>
+            <th
+              cpsTTColSortable="modified"
+              cpsTTColFilter="modified"
+              filterType="date"
+              cpsTTColResizable>
+              Modified
+            </th>
+            <th
+              cpsTTColSortable="encrypted"
+              cpsTTColFilter="encrypted"
+              filterType="boolean"
+              cpsTTColResizable>
+              Encrypted
+            </th>
+            <th
+              cpsTTColSortable="importance"
+              cpsTTColFilter="importance"
+              filterType="category"
+              cpsTTColResizable>
+              Importance
+            </th>
+          </ng-template>
+
+          <ng-template #body let-rowNode let-rowData="rowData">
+            <td [cpsTTRowToggler]="rowNode">
+              {{ rowData.name }}
+            </td>
+            <td>{{ rowData.size }}</td>
+            <td>{{ rowData.modified | date }}</td>
+            <td>
+              <cps-icon
+                [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                [color]="
+                  rowData.encrypted
+                    ? 'var(--cps-color-success)'
+                    : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+              </cps-icon>
+            </td>
+            <td>{{ rowData.importance }}</td>
           </ng-template>
         </cps-tree-table>
-      }
+      </app-code-example>
+    </cps-tab>
+    <cps-tab label="Tree table 2">
+      <app-code-example
+        [htmlCode]="examples.treeTable2.html"
+        [tsCode]="examples.treeTable2.ts">
+        @if (selectedTabIndex === 1) {
+          <cps-tree-table
+            [showGlobalFilter]="true"
+            [data]="dataVirtual"
+            [columns]="colsVirtual"
+            [sortable]="true"
+            [virtualScroll]="true"
+            [showColumnsToggleBtn]="true"
+            [filterableByColumns]="true"
+            [resizableColumns]="true"
+            scrollHeight="22rem"
+            toolbarTitle="Sortable tree table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled">
+            <ng-template #colgroup>
+              <colgroup>
+                @for (col of colsVirtual; track col) {
+                  <col />
+                }
+              </colgroup>
+            </ng-template>
+          </cps-tree-table>
+        }
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 3">
-      <cps-tree-table
-        [data]="data"
-        [showActionBtn]="true"
-        [showRowMenu]="true"
-        [showRowRemoveButton]="isRemoveBtnVisible"
-        [showDataReloadBtn]="true"
-        [showGlobalFilter]="true"
-        (rowsToRemove)="onRowsToRemove($event)"
-        (editRowBtnClicked)="onEditRowButtonClicked()"
-        (actionBtnClicked)="onActionBtnClicked()"
-        (dataReloadBtnClicked)="onReloadBtnClicked()"
-        toolbarTitle="Tree table with rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
-          isRemoveBtnVisible ? 'visible' : 'hidden'
-        }}"
-        actionBtnTitle="{{
-          isRemoveBtnVisible ? 'Hide' : 'Show'
-        }} Remove buttons">
-        <ng-template #header>
-          <th>Name</th>
-          <th>Size</th>
-          <th>Modified</th>
-          <th>Encrypted</th>
-          <th>Importance</th>
-        </ng-template>
+      <app-code-example
+        [htmlCode]="examples.treeTable3.html"
+        [tsCode]="examples.treeTable3.ts">
+        <cps-tree-table
+          [data]="data"
+          [showActionBtn]="true"
+          [showRowMenu]="true"
+          [showRowRemoveButton]="isRemoveBtnVisible"
+          [showDataReloadBtn]="true"
+          [showGlobalFilter]="true"
+          (rowsToRemove)="onRowsToRemove($event)"
+          (editRowBtnClicked)="onEditRowButtonClicked()"
+          (actionBtnClicked)="onActionBtnClicked()"
+          (dataReloadBtnClicked)="onReloadBtnClicked()"
+          toolbarTitle="Tree table with rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
+            isRemoveBtnVisible ? 'visible' : 'hidden'
+          }}"
+          actionBtnTitle="{{
+            isRemoveBtnVisible ? 'Hide' : 'Show'
+          }} Remove buttons">
+          <ng-template #header>
+            <th>Name</th>
+            <th>Size</th>
+            <th>Modified</th>
+            <th>Encrypted</th>
+            <th>Importance</th>
+          </ng-template>
 
-        <ng-template #body let-rowNode let-rowData="rowData">
-          <td [cpsTTRowToggler]="rowNode">
-            {{ rowData.name }}
-          </td>
-          <td>{{ rowData.size }}</td>
-          <td>{{ rowData.modified | date }}</td>
-          <td>
-            <cps-icon
-              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-              [color]="
-                rowData.encrypted
-                  ? 'var(--cps-color-success)'
-                  : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
-            </cps-icon>
-          </td>
-          <td>{{ rowData.importance }}</td>
-        </ng-template>
-      </cps-tree-table>
+          <ng-template #body let-rowNode let-rowData="rowData">
+            <td [cpsTTRowToggler]="rowNode">
+              {{ rowData.name }}
+            </td>
+            <td>{{ rowData.size }}</td>
+            <td>{{ rowData.modified | date }}</td>
+            <td>
+              <cps-icon
+                [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                [color]="
+                  rowData.encrypted
+                    ? 'var(--cps-color-success)'
+                    : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+              </cps-icon>
+            </td>
+            <td>{{ rowData.importance }}</td>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 4">
-      <cps-tree-table
-        [data]="data"
-        [columns]="colsWithFilterType"
-        [selectable]="true"
-        sortMode="multiple"
-        [striped]="false"
-        [showRowMenu]="true"
-        (rowsToRemove)="onRowsToRemove($event)"
-        [showColumnsToggleBtn]="true"
-        (columnsSelected)="onColumnsSelected($event)"
-        (editRowBtnClicked)="onEditRowButtonClicked()"
-        (rowsSelected)="onRowsSelectionChanged($event)"
-        toolbarIcon="toast-success"
-        toolbarIconColor="success"
-        toolbarTitle="Tree table with toolbar icon, external columns toggle and unstriped selectable rows">
-        <ng-template #header>
-          @for (scol of selCols; track scol) {
-            <th
-              [cpsTTColSortable]="scol.field"
-              [cpsTTColFilter]="scol.field"
-              [filterType]="scol.filterType">
-              {{ scol.header }}
-            </th>
-          }
-        </ng-template>
+      <app-code-example
+        [htmlCode]="examples.treeTable4.html"
+        [tsCode]="examples.treeTable4.ts">
+        <cps-tree-table
+          [data]="data"
+          [columns]="colsWithFilterType"
+          [selectable]="true"
+          sortMode="multiple"
+          [striped]="false"
+          [showRowMenu]="true"
+          (rowsToRemove)="onRowsToRemove($event)"
+          [showColumnsToggleBtn]="true"
+          (columnsSelected)="onColumnsSelected($event)"
+          (editRowBtnClicked)="onEditRowButtonClicked()"
+          (rowsSelected)="onRowsSelectionChanged($event)"
+          toolbarIcon="toast-success"
+          toolbarIconColor="success"
+          toolbarTitle="Tree table with toolbar icon, external columns toggle and unstriped selectable rows">
+          <ng-template #header>
+            @for (scol of selCols; track scol) {
+              <th
+                [cpsTTColSortable]="scol.field"
+                [cpsTTColFilter]="scol.field"
+                [filterType]="scol.filterType">
+                {{ scol.header }}
+              </th>
+            }
+          </ng-template>
 
-        <ng-template #body let-rowNode let-rowData="rowData">
-          @for (scol of selCols; track scol) {
-            @switch (scol.field) {
-              @case ('name') {
-                <td [cpsTTRowToggler]="rowNode">
-                  {{ rowData.name }}
-                </td>
-              }
-              @case ('size') {
-                <td>{{ rowData.size }}</td>
-              }
-              @case ('modified') {
-                <td>{{ rowData.modified | date }}</td>
-              }
-              @case ('encrypted') {
-                <td>
-                  <cps-icon
-                    [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-                    [color]="
-                      rowData.encrypted
-                        ? 'var(--cps-color-success)'
-                        : 'var(--cps-color-error)'
-                    "
-                    size="small"
-                    [ariaLabel]="
-                      rowData.encrypted ? 'Encrypted' : 'Not encrypted'
-                    ">
-                  </cps-icon>
-                </td>
-              }
-              @case ('importance') {
-                <td>{{ rowData.importance }}</td>
+          <ng-template #body let-rowNode let-rowData="rowData">
+            @for (scol of selCols; track scol) {
+              @switch (scol.field) {
+                @case ('name') {
+                  <td [cpsTTRowToggler]="rowNode">
+                    {{ rowData.name }}
+                  </td>
+                }
+                @case ('size') {
+                  <td>{{ rowData.size }}</td>
+                }
+                @case ('modified') {
+                  <td>{{ rowData.modified | date }}</td>
+                }
+                @case ('encrypted') {
+                  <td>
+                    <cps-icon
+                      [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                      [color]="
+                        rowData.encrypted
+                          ? 'var(--cps-color-success)'
+                          : 'var(--cps-color-error)'
+                      "
+                      size="small"
+                      [ariaLabel]="
+                        rowData.encrypted ? 'Encrypted' : 'Not encrypted'
+                      ">
+                    </cps-icon>
+                  </td>
+                }
+                @case ('importance') {
+                  <td>{{ rowData.importance }}</td>
+                }
               }
             }
-          }
-        </ng-template>
-      </cps-tree-table>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 5">
-      <cps-tree-table
-        [data]="data"
-        [autoLayout]="false"
-        (rowsToRemove)="onRowsToRemove($event)"
-        [selectable]="true"
-        toolbarSize="small"
-        scrollHeight="calc(100vh - 23.125rem)"
-        toolbarTitle="Tree table with nested header and small toolbar">
-        <ng-template #nestedHeader>
-          <tr>
-            <th rowspan="2" cpsTTHdrSelectable></th>
-            <th colspan="2">Section 1</th>
-            <th colspan="3">Section 2</th>
-          </tr>
-          <tr>
+      <app-code-example
+        [htmlCode]="examples.treeTable5.html"
+        [tsCode]="examples.treeTable5.ts">
+        <cps-tree-table
+          [data]="data"
+          [autoLayout]="false"
+          (rowsToRemove)="onRowsToRemove($event)"
+          [selectable]="true"
+          toolbarSize="small"
+          scrollHeight="calc(100vh - 27.125rem)"
+          toolbarTitle="Tree table with nested header and small toolbar">
+          <ng-template #nestedHeader>
+            <tr>
+              <th rowspan="2" cpsTTHdrSelectable></th>
+              <th colspan="2">Section 1</th>
+              <th colspan="3">Section 2</th>
+            </tr>
+            <tr>
+              <th
+                cpsTTColSortable="name"
+                cpsTTColFilter="name"
+                filterType="text">
+                Name
+              </th>
+              <th
+                cpsTTColSortable="size"
+                cpsTTColFilter="size"
+                filterType="number">
+                Size
+              </th>
+              <th
+                cpsTTColSortable="modified"
+                cpsTTColFilter="modified"
+                filterType="date">
+                Modified
+              </th>
+              <th
+                cpsTTColSortable="encrypted"
+                cpsTTColFilter="encrypted"
+                filterType="boolean">
+                Encrypted
+              </th>
+              <th
+                cpsTTColSortable="importance"
+                cpsTTColFilter="importance"
+                filterType="category">
+                Importance
+              </th>
+            </tr>
+          </ng-template>
+          <ng-template #body let-rowNode let-rowData="rowData">
+            <td [cpsTTRowToggler]="rowNode">
+              {{ rowData.name }}
+            </td>
+            <td>{{ rowData.size }}</td>
+            <td>{{ rowData.modified | date }}</td>
+            <td>
+              <cps-icon
+                [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                [color]="
+                  rowData.encrypted
+                    ? 'var(--cps-color-success)'
+                    : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+              </cps-icon>
+            </td>
+            <td>{{ rowData.importance }}</td>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
+    </cps-tab>
+    <cps-tab label="Tree table 6">
+      <app-code-example
+        [htmlCode]="examples.treeTable6.html"
+        [tsCode]="examples.treeTable6.ts">
+        <cps-tree-table
+          [data]="data"
+          [columns]="cols"
+          [rowHover]="false"
+          [bordered]="false"
+          [sortable]="true"
+          [showRowMenu]="true"
+          [rowMenuItems]="customRowMenuItems"
+          toolbarTitle="Borderless tree table without highlightning on rows hover. Row menu is shown and has custom items.">
+          <ng-template #header>
+            <th cpsTTColSortable="name">Name</th>
+            <th cpsTTColSortable="size">Size</th>
+            <th cpsTTColSortable="modified">Modified</th>
+            <th cpsTTColSortable="encrypted">Encrypted</th>
+            <th cpsTTColSortable="importance">Importance</th>
+          </ng-template>
+
+          <ng-template #body let-rowNode let-rowData="rowData">
+            <td [cpsTTRowToggler]="rowNode">
+              {{ rowData.name }}
+            </td>
+            <td>{{ rowData.size }}</td>
+            <td>{{ rowData.modified | date }}</td>
+            <td>
+              <cps-icon
+                [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                [color]="
+                  rowData.encrypted
+                    ? 'var(--cps-color-success)'
+                    : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+              </cps-icon>
+            </td>
+            <td>{{ rowData.importance }}</td>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
+    </cps-tab>
+    <cps-tab label="Tree table 7">
+      <app-code-example
+        [htmlCode]="examples.treeTable7.html"
+        [tsCode]="examples.treeTable7.ts">
+        <cps-tree-table [data]="data" [size]="selSize">
+          <ng-template #toolbar>
+            <span>Tree table with custom toolbar and different sizes</span>
+            <cps-button-toggle
+              ariaLabel="Table size"
+              [options]="sizesOptions"
+              [(ngModel)]="selSize">
+            </cps-button-toggle>
+          </ng-template>
+          <ng-template #header>
             <th cpsTTColSortable="name" cpsTTColFilter="name" filterType="text">
               Name
             </th>
@@ -255,160 +387,72 @@
               filterType="category">
               Importance
             </th>
-          </tr>
-        </ng-template>
-        <ng-template #body let-rowNode let-rowData="rowData">
-          <td [cpsTTRowToggler]="rowNode">
-            {{ rowData.name }}
-          </td>
-          <td>{{ rowData.size }}</td>
-          <td>{{ rowData.modified | date }}</td>
-          <td>
-            <cps-icon
-              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-              [color]="
-                rowData.encrypted
-                  ? 'var(--cps-color-success)'
-                  : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
-            </cps-icon>
-          </td>
-          <td>{{ rowData.importance }}</td>
-        </ng-template>
-      </cps-tree-table>
-    </cps-tab>
-    <cps-tab label="Tree table 6">
-      <cps-tree-table
-        [data]="data"
-        [columns]="cols"
-        [rowHover]="false"
-        [bordered]="false"
-        [sortable]="true"
-        [showRowMenu]="true"
-        [rowMenuItems]="customRowMenuItems"
-        toolbarTitle="Borderless tree table without highlightning on rows hover. Row menu is shown and has custom items.">
-        <ng-template #header>
-          <th cpsTTColSortable="name">Name</th>
-          <th cpsTTColSortable="size">Size</th>
-          <th cpsTTColSortable="modified">Modified</th>
-          <th cpsTTColSortable="encrypted">Encrypted</th>
-          <th cpsTTColSortable="importance">Importance</th>
-        </ng-template>
+          </ng-template>
 
-        <ng-template #body let-rowNode let-rowData="rowData">
-          <td [cpsTTRowToggler]="rowNode">
-            {{ rowData.name }}
-          </td>
-          <td>{{ rowData.size }}</td>
-          <td>{{ rowData.modified | date }}</td>
-          <td>
-            <cps-icon
-              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-              [color]="
-                rowData.encrypted
-                  ? 'var(--cps-color-success)'
-                  : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
-            </cps-icon>
-          </td>
-          <td>{{ rowData.importance }}</td>
-        </ng-template>
-      </cps-tree-table>
-    </cps-tab>
-    <cps-tab label="Tree table 7">
-      <cps-tree-table [data]="data" [size]="selSize">
-        <ng-template #toolbar>
-          <span>Tree table with custom toolbar and different sizes</span>
-          <cps-button-toggle
-            ariaLabel="Table size"
-            [options]="sizesOptions"
-            [(ngModel)]="selSize">
-          </cps-button-toggle>
-        </ng-template>
-        <ng-template #header>
-          <th cpsTTColSortable="name" cpsTTColFilter="name" filterType="text">
-            Name
-          </th>
-          <th cpsTTColSortable="size" cpsTTColFilter="size" filterType="number">
-            Size
-          </th>
-          <th
-            cpsTTColSortable="modified"
-            cpsTTColFilter="modified"
-            filterType="date">
-            Modified
-          </th>
-          <th
-            cpsTTColSortable="encrypted"
-            cpsTTColFilter="encrypted"
-            filterType="boolean">
-            Encrypted
-          </th>
-          <th
-            cpsTTColSortable="importance"
-            cpsTTColFilter="importance"
-            filterType="category">
-            Importance
-          </th>
-        </ng-template>
-
-        <ng-template #body let-rowNode let-rowData="rowData">
-          <td [cpsTTRowToggler]="rowNode">
-            {{ rowData.name }}
-          </td>
-          <td>{{ rowData.size }}</td>
-          <td>{{ rowData.modified | date }}</td>
-          <td>
-            <cps-icon
-              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
-              [color]="
-                rowData.encrypted
-                  ? 'var(--cps-color-success)'
-                  : 'var(--cps-color-error)'
-              "
-              size="small"
-              [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
-            </cps-icon>
-          </td>
-          <td>{{ rowData.importance }}</td>
-        </ng-template>
-      </cps-tree-table>
+          <ng-template #body let-rowNode let-rowData="rowData">
+            <td [cpsTTRowToggler]="rowNode">
+              {{ rowData.name }}
+            </td>
+            <td>{{ rowData.size }}</td>
+            <td>{{ rowData.modified | date }}</td>
+            <td>
+              <cps-icon
+                [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+                [color]="
+                  rowData.encrypted
+                    ? 'var(--cps-color-success)'
+                    : 'var(--cps-color-error)'
+                "
+                size="small"
+                [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+              </cps-icon>
+            </td>
+            <td>{{ rowData.importance }}</td>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 8">
-      <cps-tree-table
-        [data]="[]"
-        toolbarTitle="Empty tree table"
-        emptyBodyHeight="25rem">
-        <ng-template #header>
-          <th cpsTTColSortable="name">Name</th>
-          <th cpsTTColSortable="size">Size</th>
-          <th cpsTTColSortable="modified">Modified</th>
-          <th cpsTTColSortable="encrypted">Encrypted</th>
-          <th cpsTTColSortable="importance">Importance</th>
-        </ng-template>
-      </cps-tree-table>
+      <app-code-example [htmlCode]="examples.treeTable8.html">
+        <cps-tree-table
+          [data]="[]"
+          toolbarTitle="Empty tree table"
+          emptyBodyHeight="23rem">
+          <ng-template #header>
+            <th cpsTTColSortable="name">Name</th>
+            <th cpsTTColSortable="size">Size</th>
+            <th cpsTTColSortable="modified">Modified</th>
+            <th cpsTTColSortable="encrypted">Encrypted</th>
+            <th cpsTTColSortable="importance">Importance</th>
+          </ng-template>
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 9">
-      <cps-tree-table
-        [data]="data"
-        [loading]="true"
-        scrollHeight="25rem"
-        [columns]="cols"
-        toolbarTitle="Tree table in data loading state">
-      </cps-tree-table>
+      <app-code-example
+        [htmlCode]="examples.treeTable9.html"
+        [tsCode]="examples.treeTable9.ts">
+        <cps-tree-table
+          [data]="data"
+          [loading]="true"
+          scrollHeight="23rem"
+          [columns]="cols"
+          toolbarTitle="Tree table in data loading state">
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
     <cps-tab label="Tree table 10">
-      <cps-tree-table
-        [data]="treeDataWithHTML"
-        scrollHeight="25rem"
-        [columns]="colsHTML"
-        [renderDataAsHTML]="true"
-        toolbarTitle="Table containing HTML">
-      </cps-tree-table>
+      <app-code-example
+        [htmlCode]="examples.treeTable10.html"
+        [tsCode]="examples.treeTable10.ts">
+        <cps-tree-table
+          [data]="treeDataWithHTML"
+          scrollHeight="23rem"
+          [columns]="colsHTML"
+          [renderDataAsHTML]="true"
+          toolbarTitle="Table containing HTML">
+        </cps-tree-table>
+      </app-code-example>
     </cps-tab>
   </cps-tab-group>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.html
@@ -314,7 +314,7 @@
           [sortable]="true"
           [showRowMenu]="true"
           [rowMenuItems]="customRowMenuItems"
-          toolbarTitle="Borderless tree table without highlightning on rows hover. Row menu is shown and has custom items.">
+          toolbarTitle="Borderless tree table without highlighting on rows hover. Row menu is shown and has custom items.">
           <ng-template #header>
             <th cpsTTColSortable="name">Name</th>
             <th cpsTTColSortable="size">Size</th>

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.scss
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.scss
@@ -1,7 +1,13 @@
 :host {
   overflow-x: hidden;
 
-  ::ng-deep .treetable-page--sub-tabs {
-    padding-top: 0.625rem;
+  ::ng-deep {
+    .treetable-page--sub-tabs {
+      padding-top: 0.625rem;
+    }
+
+    app-code-example {
+      margin-top: 0.0625rem;
+    }
   }
 }

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
@@ -16,9 +16,10 @@ import {
   CpsTreeTableColumnResizableDirective,
   CpsIconComponent
 } from 'cps-ui-kit';
-
 import ComponentData from '../../api-data/cps-tree-table.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
+import { CodeExampleComponent } from '../../components/code-example/code-example.component';
+import { treeTableExamples } from './tree-table-page.examples';
 import { DatePipe } from '@angular/common';
 
 @Component({
@@ -36,13 +37,16 @@ import { DatePipe } from '@angular/common';
     CpsTabComponent,
     CpsButtonToggleComponent,
     CpsIconComponent,
-    ComponentDocsViewerComponent
+    ComponentDocsViewerComponent,
+    CodeExampleComponent
   ],
   templateUrl: './tree-table-page.component.html',
   styleUrls: ['./tree-table-page.component.scss'],
   host: { class: 'composition-page' }
 })
 export class TreeTablePageComponent implements OnInit {
+  readonly examples = treeTableExamples;
+
   selectedTabIndex = 0;
 
   sizesOptions: CpsButtonToggleOption[] = [

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.component.ts
@@ -507,13 +507,13 @@ export class TreeTablePageComponent implements OnInit {
       data: {
         a: '<strong>hello</strong>',
         b: '<h2>world</h2>',
-        c: '<a href="https://www.github.com">link to github</a>'
+        c: '<a href="https://www.github.com">link to GitHub</a>'
       },
       children: [
         {
           data: {
             a: 'this is sanitized <script>console.log("pwned")</script>',
-            b: '<img src="./assets/ui_logo.svg" width="100" />',
+            b: '<img src="./assets/ui_logo.svg" alt="CPS UI Kit logo" width="100" />',
             c: '<code>null === undefined</code>'
           }
         }

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.examples.ts
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.examples.ts
@@ -1,0 +1,682 @@
+const treeDataTs = `
+data = [
+  {
+    data: {
+      name: 'Applications',
+      size: 200,
+      modified: new Date(2022, 2, 21),
+      encrypted: true,
+      importance: 'critical'
+    },
+    children: [
+      {
+        data: {
+          name: 'Angular',
+          size: 25,
+          modified: new Date(2023, 4, 10),
+          encrypted: true,
+          importance: 'critical'
+        },
+        children: [
+          {
+            data: {
+              name: 'angular.app',
+              size: 10,
+              modified: new Date(2021, 3, 14),
+              encrypted: true,
+              importance: 'critical'
+            }
+          }
+        ]
+      },
+      {
+        data: {
+          name: 'editor.app',
+          size: 30,
+          modified: new Date(2022, 5, 9),
+          encrypted: true,
+          importance: 'critical'
+        }
+      }
+    ]
+  },
+  {
+    data: {
+      name: 'Cloud',
+      size: 10,
+      modified: new Date(2023, 4, 12),
+      encrypted: false,
+      importance: 'optional'
+    }
+  }
+  // ...more nodes omitted for brevity
+];`;
+
+const removeElementsByNameTs = `
+onRowsToRemove(rows: any) {
+  const names = rows.map((row: any) => row.data.name);
+  this.data = this._removeElementsByName(this.data, names);
+}
+
+private _removeElementsByName(dataArray: any[], namesArray: string[]) {
+  return dataArray.filter((item) => {
+    if (namesArray.includes(item.data.name)) {
+      return false;
+    }
+    if (item.children && item.children.length > 0) {
+      item.children = this._removeElementsByName(item.children, namesArray);
+    }
+
+    return true;
+  });
+}`;
+
+export const treeTableExamples: Record<string, { html: string; ts?: string }> =
+  {
+    treeTable1: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [paginator]="true"
+  [scrollable]="false"
+  sortMode="multiple"
+  [resizableColumns]="true"
+  [columnResizeMode]="'expand'"
+  [showExportBtn]="true"
+  [exportFilename]="'virtual-tree-data'"
+  toolbarTitle="Tree table with a paginator, resizable columns, multiple sorting and individual filtering">
+  <ng-template #header>
+    <th
+      cpsTTColSortable="name"
+      cpsTTColFilter="name"
+      filterType="text"
+      cpsTTColResizable>
+      Name
+    </th>
+    <th
+      cpsTTColSortable="size"
+      cpsTTColFilter="size"
+      filterType="number"
+      cpsTTColResizable>
+      Size
+    </th>
+    <th
+      cpsTTColSortable="modified"
+      cpsTTColFilter="modified"
+      filterType="date"
+      cpsTTColResizable>
+      Modified
+    </th>
+    <th
+      cpsTTColSortable="encrypted"
+      cpsTTColFilter="encrypted"
+      filterType="boolean"
+      cpsTTColResizable>
+      Encrypted
+    </th>
+    <th
+      cpsTTColSortable="importance"
+      cpsTTColFilter="importance"
+      filterType="category"
+      cpsTTColResizable>
+      Importance
+    </th>
+  </ng-template>
+
+  <ng-template #body let-rowNode let-rowData="rowData">
+    <td [cpsTTRowToggler]="rowNode">
+      {{ rowData.name }}
+    </td>
+    <td>{{ rowData.size }}</td>
+    <td>{{ rowData.modified | date }}</td>
+    <td>
+      <cps-icon
+        [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+        [color]="
+          rowData.encrypted
+            ? 'var(--cps-color-success)'
+            : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+      </cps-icon>
+    </td>
+    <td>{{ rowData.importance }}</td>
+  </ng-template>
+</cps-tree-table>`,
+      ts: treeDataTs.trim()
+    },
+
+    treeTable2: {
+      html: `
+<cps-tree-table
+  [showGlobalFilter]="true"
+  [data]="dataVirtual"
+  [columns]="colsVirtual"
+  [sortable]="true"
+  [virtualScroll]="true"
+  [showColumnsToggleBtn]="true"
+  [filterableByColumns]="true"
+  [resizableColumns]="true"
+  scrollHeight="31.25rem"
+  toolbarTitle="Sortable tree table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled">
+  <ng-template #colgroup>
+    <colgroup>
+      @for (col of colsVirtual; track col) {
+        <col />
+      }
+    </colgroup>
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+colsVirtual = [
+  { field: 'name', header: 'Name' },
+  { field: 'size', header: 'Size' },
+  { field: 'tag', header: 'Tag' },
+  { field: 'type', header: 'String (only 5 distinct values)' },
+  { field: 'date', header: 'Date', dateFormat: 'dd. MM. yyyy' },
+  { field: 'sizeEven', header: 'Boolean' },
+  {
+    field: 'date2',
+    header: 'Date but with category filter',
+    filterType: 'category',
+    dateFormat: 'yyyy/MM/dd HH:mm:ss'
+  }
+];
+
+dataVirtual: any[] = [];
+
+ngOnInit(): void {
+  for (let i = 0; i <= 1000; i++) {
+    this.dataVirtual.push({
+      data: {
+        name: \`Folder\${i}\`,
+        size: i,
+        tag: i * 3,
+        type: \`Type-\${i % 5}\`,
+        date: new Date(2020, 1, i),
+        sizeEven: i % 2 === 0,
+        date2: new Date(2020, 1, i, 12, 30, 0)
+      },
+      children: [
+        {
+          data: {
+            name: 'primefaces.mkv',
+            size: 1000,
+            tag: 7,
+            type: \`Type-\${i % 5}\`,
+            date: new Date(2020, 1, i),
+            sizeEven: i % 2 === 0,
+            date2: new Date(2020, 1, i, 12, 30, 0)
+          }
+        },
+        {
+          data: {
+            name: 'intro.avi',
+            size: 500,
+            tag: 9,
+            type: \`Type-\${i % 5}\`,
+            date: new Date(2020, 1, i),
+            sizeEven: i % 2 === 0,
+            date2: new Date(2020, 1, i, 12, 30, 0)
+          }
+        }
+      ]
+    });
+  }
+}`
+    },
+
+    treeTable3: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [showActionBtn]="true"
+  [showRowMenu]="true"
+  [showRowRemoveButton]="isRemoveBtnVisible"
+  [showDataReloadBtn]="true"
+  [showGlobalFilter]="true"
+  (rowsToRemove)="onRowsToRemove($event)"
+  (editRowBtnClicked)="onEditRowButtonClicked()"
+  (actionBtnClicked)="onActionBtnClicked()"
+  (dataReloadBtnClicked)="onReloadBtnClicked()"
+  toolbarTitle="Tree table with rows menus, action and data reload buttons. Each row menu has a 'Remove' button, which is currently {{
+    isRemoveBtnVisible ? 'visible' : 'hidden'
+  }}"
+  actionBtnTitle="{{
+    isRemoveBtnVisible ? 'Hide' : 'Show'
+  }} Remove buttons">
+  <ng-template #header>
+    <th>Name</th>
+    <th>Size</th>
+    <th>Modified</th>
+    <th>Encrypted</th>
+    <th>Importance</th>
+  </ng-template>
+
+  <ng-template #body let-rowNode let-rowData="rowData">
+    <td [cpsTTRowToggler]="rowNode">
+      {{ rowData.name }}
+    </td>
+    <td>{{ rowData.size }}</td>
+    <td>{{ rowData.modified | date }}</td>
+    <td>
+      <cps-icon
+        [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+        [color]="
+          rowData.encrypted
+            ? 'var(--cps-color-success)'
+            : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+      </cps-icon>
+    </td>
+    <td>{{ rowData.importance }}</td>
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+isRemoveBtnVisible = false;
+
+${removeElementsByNameTs.trim()}
+
+onEditRowButtonClicked() {
+  alert('Edit row button clicked');
+}
+
+onActionBtnClicked() {
+  this.isRemoveBtnVisible = !this.isRemoveBtnVisible;
+  const visibilityStatus = this.isRemoveBtnVisible ? 'visible' : 'hidden';
+  alert(\`'Remove' buttons are now \${visibilityStatus}\`);
+}
+
+onReloadBtnClicked() {
+  alert('Data reload button clicked');
+}`
+    },
+
+    treeTable4: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [columns]="colsWithFilterType"
+  [selectable]="true"
+  sortMode="multiple"
+  [striped]="false"
+  [showRowMenu]="true"
+  (rowsToRemove)="onRowsToRemove($event)"
+  [showColumnsToggleBtn]="true"
+  (columnsSelected)="onColumnsSelected($event)"
+  (editRowBtnClicked)="onEditRowButtonClicked()"
+  (rowsSelected)="onRowsSelectionChanged($event)"
+  toolbarIcon="toast-success"
+  toolbarIconColor="success"
+  toolbarTitle="Tree table with toolbar icon, external columns toggle and unstriped selectable rows">
+  <ng-template #header>
+    @for (scol of selCols; track scol) {
+      <th
+        [cpsTTColSortable]="scol.field"
+        [cpsTTColFilter]="scol.field"
+        [filterType]="scol.filterType">
+        {{ scol.header }}
+      </th>
+    }
+  </ng-template>
+
+  <ng-template #body let-rowNode let-rowData="rowData">
+    @for (scol of selCols; track scol) {
+      @switch (scol.field) {
+        @case ('name') {
+          <td [cpsTTRowToggler]="rowNode">
+            {{ rowData.name }}
+          </td>
+        }
+        @case ('size') {
+          <td>{{ rowData.size }}</td>
+        }
+        @case ('modified') {
+          <td>{{ rowData.modified | date }}</td>
+        }
+        @case ('encrypted') {
+          <td>
+            <cps-icon
+              [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+              [color]="
+                rowData.encrypted
+                  ? 'var(--cps-color-success)'
+                  : 'var(--cps-color-error)'
+              "
+              size="small"
+              [ariaLabel]="
+                rowData.encrypted ? 'Encrypted' : 'Not encrypted'
+              ">
+            </cps-icon>
+          </td>
+        }
+        @case ('importance') {
+          <td>{{ rowData.importance }}</td>
+        }
+      }
+    }
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+colsWithFilterType = [
+  { field: 'name', header: 'Name', filterType: 'text' },
+  { field: 'size', header: 'Size', filterType: 'number' },
+  { field: 'modified', header: 'Modified', filterType: 'date' },
+  { field: 'encrypted', header: 'Encrypted', filterType: 'boolean' },
+  { field: 'importance', header: 'Importance', filterType: 'category' }
+];
+
+selCols = this.colsWithFilterType;
+
+${removeElementsByNameTs.trim()}
+
+onColumnsSelected(columns: any) {
+  this.selCols = columns;
+}
+
+onEditRowButtonClicked() {
+  alert('Edit row button clicked');
+}
+
+onRowsSelectionChanged(rows: any) {
+  console.log(rows);
+}`
+    },
+
+    treeTable5: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [autoLayout]="false"
+  (rowsToRemove)="onRowsToRemove($event)"
+  [selectable]="true"
+  toolbarSize="small"
+  scrollHeight="calc(100vh - 23.125rem)"
+  toolbarTitle="Tree table with nested header and small toolbar">
+  <ng-template #nestedHeader>
+    <tr>
+      <th rowspan="2" cpsTTHdrSelectable></th>
+      <th colspan="2">Section 1</th>
+      <th colspan="3">Section 2</th>
+    </tr>
+    <tr>
+      <th cpsTTColSortable="name" cpsTTColFilter="name" filterType="text">
+        Name
+      </th>
+      <th
+        cpsTTColSortable="size"
+        cpsTTColFilter="size"
+        filterType="number">
+        Size
+      </th>
+      <th
+        cpsTTColSortable="modified"
+        cpsTTColFilter="modified"
+        filterType="date">
+        Modified
+      </th>
+      <th
+        cpsTTColSortable="encrypted"
+        cpsTTColFilter="encrypted"
+        filterType="boolean">
+        Encrypted
+      </th>
+      <th
+        cpsTTColSortable="importance"
+        cpsTTColFilter="importance"
+        filterType="category">
+        Importance
+      </th>
+    </tr>
+  </ng-template>
+  <ng-template #body let-rowNode let-rowData="rowData">
+    <td [cpsTTRowToggler]="rowNode">
+      {{ rowData.name }}
+    </td>
+    <td>{{ rowData.size }}</td>
+    <td>{{ rowData.modified | date }}</td>
+    <td>
+      <cps-icon
+        [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+        [color]="
+          rowData.encrypted
+            ? 'var(--cps-color-success)'
+            : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+      </cps-icon>
+    </td>
+    <td>{{ rowData.importance }}</td>
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+${removeElementsByNameTs.trim()}`
+    },
+
+    treeTable6: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [columns]="cols"
+  [rowHover]="false"
+  [bordered]="false"
+  [sortable]="true"
+  [showRowMenu]="true"
+  [rowMenuItems]="customRowMenuItems"
+  toolbarTitle="Borderless tree table without highlightning on rows hover. Row menu is shown and has custom items.">
+  <ng-template #header>
+    <th cpsTTColSortable="name">Name</th>
+    <th cpsTTColSortable="size">Size</th>
+    <th cpsTTColSortable="modified">Modified</th>
+    <th cpsTTColSortable="encrypted">Encrypted</th>
+    <th cpsTTColSortable="importance">Importance</th>
+  </ng-template>
+
+  <ng-template #body let-rowNode let-rowData="rowData">
+    <td [cpsTTRowToggler]="rowNode">
+      {{ rowData.name }}
+    </td>
+    <td>{{ rowData.size }}</td>
+    <td>{{ rowData.modified | date }}</td>
+    <td>
+      <cps-icon
+        [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+        [color]="
+          rowData.encrypted
+            ? 'var(--cps-color-success)'
+            : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+      </cps-icon>
+    </td>
+    <td>{{ rowData.importance }}</td>
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+cols = [
+  { field: 'name', header: 'Name' },
+  { field: 'size', header: 'Size' },
+  { field: 'modified', header: 'Modified' },
+  { field: 'encrypted', header: 'Encrypted' },
+  { field: 'importance', header: 'Importance' }
+];
+
+customRowMenuItems: CpsMenuItem[] = [
+  {
+    title: 'Custom menu item',
+    icon: 'heart',
+    action: (_) => {
+      console.log('Custom menu item clicked');
+    }
+  },
+  {
+    title: 'Edit row',
+    icon: 'edit',
+    action: (_) => {
+      this.onEditRowButtonClicked();
+    }
+  }
+];
+
+onEditRowButtonClicked() {
+  alert('Edit row button clicked');
+}`
+    },
+
+    treeTable7: {
+      html: `
+<cps-tree-table [data]="data" [size]="selSize">
+  <ng-template #toolbar>
+    <span>Tree table with custom toolbar and different sizes</span>
+    <cps-button-toggle
+      ariaLabel="Table size"
+      [options]="sizesOptions"
+      [(ngModel)]="selSize">
+    </cps-button-toggle>
+  </ng-template>
+  <ng-template #header>
+    <th cpsTTColSortable="name" cpsTTColFilter="name" filterType="text">
+      Name
+    </th>
+    <th cpsTTColSortable="size" cpsTTColFilter="size" filterType="number">
+      Size
+    </th>
+    <th
+      cpsTTColSortable="modified"
+      cpsTTColFilter="modified"
+      filterType="date">
+      Modified
+    </th>
+    <th
+      cpsTTColSortable="encrypted"
+      cpsTTColFilter="encrypted"
+      filterType="boolean">
+      Encrypted
+    </th>
+    <th
+      cpsTTColSortable="importance"
+      cpsTTColFilter="importance"
+      filterType="category">
+      Importance
+    </th>
+  </ng-template>
+
+  <ng-template #body let-rowNode let-rowData="rowData">
+    <td [cpsTTRowToggler]="rowNode">
+      {{ rowData.name }}
+    </td>
+    <td>{{ rowData.size }}</td>
+    <td>{{ rowData.modified | date }}</td>
+    <td>
+      <cps-icon
+        [icon]="rowData.encrypted ? 'checked' : 'close-x'"
+        [color]="
+          rowData.encrypted
+            ? 'var(--cps-color-success)'
+            : 'var(--cps-color-error)'
+        "
+        size="small"
+        [ariaLabel]="rowData.encrypted ? 'Encrypted' : 'Not encrypted'">
+      </cps-icon>
+    </td>
+    <td>{{ rowData.importance }}</td>
+  </ng-template>
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+sizesOptions: CpsButtonToggleOption[] = [
+  { label: 'Small', value: 'small' },
+  { label: 'Normal', value: 'normal' },
+  { label: 'Large', value: 'large' }
+];
+
+selSize: CpsTreeTableSize = 'small';`
+    },
+
+    treeTable8: {
+      html: `
+<cps-tree-table
+  [data]="[]"
+  toolbarTitle="Empty tree table"
+  emptyBodyHeight="25rem">
+  <ng-template #header>
+    <th cpsTTColSortable="name">Name</th>
+    <th cpsTTColSortable="size">Size</th>
+    <th cpsTTColSortable="modified">Modified</th>
+    <th cpsTTColSortable="encrypted">Encrypted</th>
+    <th cpsTTColSortable="importance">Importance</th>
+  </ng-template>
+</cps-tree-table>`
+    },
+
+    treeTable9: {
+      html: `
+<cps-tree-table
+  [data]="data"
+  [loading]="true"
+  scrollHeight="25rem"
+  [columns]="cols"
+  toolbarTitle="Tree table in data loading state">
+</cps-tree-table>`,
+      ts: `
+${treeDataTs.trim()}
+
+cols = [
+  { field: 'name', header: 'Name' },
+  { field: 'size', header: 'Size' },
+  { field: 'modified', header: 'Modified' },
+  { field: 'encrypted', header: 'Encrypted' },
+  { field: 'importance', header: 'Importance' }
+];`
+    },
+
+    treeTable10: {
+      html: `
+<cps-tree-table
+  [data]="treeDataWithHTML"
+  scrollHeight="25rem"
+  [columns]="colsHTML"
+  [renderDataAsHTML]="true"
+  toolbarTitle="Table containing HTML">
+</cps-tree-table>`,
+      ts: `
+treeDataWithHTML = [
+  {
+    data: {
+      a: '<strong>hello</strong>',
+      b: '<h2>world</h2>',
+      c: '<a href="https://www.github.com">link to github</a>'
+    },
+    children: [
+      {
+        data: {
+          a: 'this is sanitized <script>console.log("pwned")</script>',
+          b: '<img src="./assets/ui_logo.svg" width="100" />',
+          c: '<code>null === undefined</code>'
+        }
+      }
+    ]
+  }
+];
+
+colsHTML = [
+  { field: 'a', header: 'Header A' },
+  { field: 'b', header: 'Header B' },
+  { field: 'c', header: 'Header C' }
+];`
+    }
+  };

--- a/projects/composition/src/app/pages/tree-table-page/tree-table-page.examples.ts
+++ b/projects/composition/src/app/pages/tree-table-page/tree-table-page.examples.ts
@@ -158,7 +158,7 @@ export const treeTableExamples: Record<string, { html: string; ts?: string }> =
   [showColumnsToggleBtn]="true"
   [filterableByColumns]="true"
   [resizableColumns]="true"
-  scrollHeight="31.25rem"
+  scrollHeight="22rem"
   toolbarTitle="Sortable tree table with resizable columns, virtual scroller, global filter, internal columns toggle and with column filtering enabled">
   <ng-template #colgroup>
     <colgroup>
@@ -398,7 +398,7 @@ onRowsSelectionChanged(rows: any) {
   (rowsToRemove)="onRowsToRemove($event)"
   [selectable]="true"
   toolbarSize="small"
-  scrollHeight="calc(100vh - 23.125rem)"
+  scrollHeight="calc(100vh - 27.125rem)"
   toolbarTitle="Tree table with nested header and small toolbar">
   <ng-template #nestedHeader>
     <tr>
@@ -473,7 +473,7 @@ ${removeElementsByNameTs.trim()}`
   [sortable]="true"
   [showRowMenu]="true"
   [rowMenuItems]="customRowMenuItems"
-  toolbarTitle="Borderless tree table without highlightning on rows hover. Row menu is shown and has custom items.">
+  toolbarTitle="Borderless tree table without highlighting on rows hover. Row menu is shown and has custom items.">
   <ng-template #header>
     <th cpsTTColSortable="name">Name</th>
     <th cpsTTColSortable="size">Size</th>
@@ -612,7 +612,7 @@ selSize: CpsTreeTableSize = 'small';`
 <cps-tree-table
   [data]="[]"
   toolbarTitle="Empty tree table"
-  emptyBodyHeight="25rem">
+  emptyBodyHeight="23rem">
   <ng-template #header>
     <th cpsTTColSortable="name">Name</th>
     <th cpsTTColSortable="size">Size</th>
@@ -628,7 +628,7 @@ selSize: CpsTreeTableSize = 'small';`
 <cps-tree-table
   [data]="data"
   [loading]="true"
-  scrollHeight="25rem"
+  scrollHeight="23rem"
   [columns]="cols"
   toolbarTitle="Tree table in data loading state">
 </cps-tree-table>`,
@@ -648,7 +648,7 @@ cols = [
       html: `
 <cps-tree-table
   [data]="treeDataWithHTML"
-  scrollHeight="25rem"
+  scrollHeight="23rem"
   [columns]="colsHTML"
   [renderDataAsHTML]="true"
   toolbarTitle="Table containing HTML">
@@ -659,13 +659,13 @@ treeDataWithHTML = [
     data: {
       a: '<strong>hello</strong>',
       b: '<h2>world</h2>',
-      c: '<a href="https://www.github.com">link to github</a>'
+      c: '<a href="https://www.github.com">link to GitHub</a>'
     },
     children: [
       {
         data: {
           a: 'this is sanitized <script>console.log("pwned")</script>',
-          b: '<img src="./assets/ui_logo.svg" width="100" />',
+          b: '<img src="./assets/ui_logo.svg" alt="CPS UI Kit logo" width="100" />',
           c: '<code>null === undefined</code>'
         }
       }


### PR DESCRIPTION
Adds live code examples to the Tabs, Table and Treetable components' documentation pages.

Closes #739 
Closes #740 
Closes #747 