### PR TITLE
fix: CpsTreeTableComponent issues

### DIFF
--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.html
@@ -50,7 +50,8 @@
   (onNodeExpand)="onNodeExpanded($event)"
   (onNodeCollapse)="onNodeCollapsed($event)"
   (onNodeSelect)="onNodeSelected($event)"
-  (onNodeUnselect)="onNodeUnselected($event)">
+  (onNodeUnselect)="onNodeUnselected($event)"
+  (onColResize)="onColumnResized($event)">
   @if (colgroupTemplate) {
     <ng-template pTemplate="colgroup">
       <ng-container *ngTemplateOutlet="colgroupTemplate"></ng-container>

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.scss
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.scss
@@ -23,6 +23,10 @@ $tbar-normal-height: 4.5rem;
   ::ng-deep {
     .p-treetable {
       position: relative;
+      display: block;
+    }
+    .p-treetable.p-treetable-flex-scrollable {
+      display: flex;
     }
     .p-component,
     .p-component * {

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.spec.ts
@@ -36,6 +36,61 @@ describe('CpsTreeTableComponent', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
+  function itSchedulesRecalcAsMicrotask(
+    label: string,
+    invoke: () => void,
+    recalcMethodName: string,
+    expectedArgs: unknown[]
+  ) {
+    it(`${label} defers to the recalculation after change detection`, async () => {
+      const recalcSpy = jest
+        .spyOn(component as any, recalcMethodName)
+        .mockImplementation(() => {});
+
+      invoke();
+      await Promise.resolve();
+
+      expect(recalcSpy).toHaveBeenCalledWith(...expectedArgs);
+    });
+
+    it(`${label} runs detectChanges() before the recalculation, in that order`, async () => {
+      const callOrder: string[] = [];
+      jest
+        .spyOn((component as any).cdRef, 'detectChanges')
+        .mockImplementation(() => {
+          callOrder.push('detectChanges');
+        });
+      jest.spyOn(component as any, recalcMethodName).mockImplementation(() => {
+        callOrder.push('recalc');
+      });
+
+      invoke();
+      expect(callOrder).toEqual([]);
+
+      await Promise.resolve();
+      expect(callOrder).toEqual(['detectChanges', 'recalc']);
+    });
+
+    it(`${label} schedules the recalculation as a real microtask, not a macrotask`, async () => {
+      jest.useFakeTimers({ doNotFake: ['queueMicrotask'] });
+      try {
+        jest
+          .spyOn((component as any).cdRef, 'detectChanges')
+          .mockImplementation(() => {});
+        const recalcSpy = jest
+          .spyOn(component as any, recalcMethodName)
+          .mockImplementation(() => {});
+
+        invoke();
+        await Promise.resolve();
+
+        expect(recalcSpy).toHaveBeenCalledWith(...expectedArgs);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -375,6 +430,13 @@ describe('CpsTreeTableComponent', () => {
       component.onSort(event);
       expect(component.sorted.emit).toHaveBeenCalledWith(event);
     });
+
+    itSchedulesRecalcAsMicrotask(
+      'onSort',
+      () => component.onSort({ field: 'name', order: 1 }),
+      '_calcAutoLayoutHeaderWidths',
+      [true]
+    );
   });
 
   describe('onFilter', () => {
@@ -384,6 +446,13 @@ describe('CpsTreeTableComponent', () => {
       component.onFilter(event);
       expect(component.filtered.emit).toHaveBeenCalledWith(event);
     });
+
+    itSchedulesRecalcAsMicrotask(
+      'onFilter',
+      () => component.onFilter({ filters: {} }),
+      '_calcAutoLayoutHeaderWidths',
+      [true]
+    );
   });
 
   describe('onLazyLoaded', () => {
@@ -721,6 +790,693 @@ describe('CpsTreeTableComponent', () => {
       jest.spyOn(event, 'preventDefault');
       component.onPaginatorKeydown(event);
       expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe('auto layout column widths (incremental expand/collapse)', () => {
+    let originalOffsetWidth: PropertyDescriptor | undefined;
+
+    beforeAll(() => {
+      originalOffsetWidth = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'offsetWidth'
+      );
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        get(this: HTMLElement) {
+          return Number(this.getAttribute('data-test-width') || 0);
+        }
+      });
+    });
+
+    afterAll(() => {
+      if (originalOffsetWidth) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'offsetWidth',
+          originalOffsetWidth
+        );
+      }
+    });
+
+    function makeCell(
+      tag: 'th' | 'td',
+      width: number,
+      extraClass?: string
+    ): HTMLElement {
+      const el = document.createElement(tag);
+      el.setAttribute('data-test-width', String(width));
+      if (extraClass) el.classList.add(extraClass);
+      return el;
+    }
+
+    function makeHeaderBox(cells: HTMLElement[]): HTMLElement {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = '<table><thead><tr></tr></thead></table>';
+      const tr = wrapper.querySelector('tr') as HTMLElement;
+      cells.forEach((c) => tr.appendChild(c));
+      return wrapper;
+    }
+
+    function makeScrollableBody(rows: HTMLElement[][]): HTMLElement {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = '<table><tbody></tbody></table>';
+      const tbody = wrapper.querySelector('tbody') as HTMLElement;
+      rows.forEach((cells) => {
+        const tr = document.createElement('tr');
+        cells.forEach((c) => tr.appendChild(c));
+        tbody.appendChild(tr);
+      });
+      return wrapper;
+    }
+
+    function setupBasicTable() {
+      component.autoLayout = true;
+      component.scrollable = true;
+      component.virtualScroll = false;
+
+      const th1 = makeCell('th', 100);
+      const th2 = makeCell('th', 50);
+      (component as any)._headerBox = makeHeaderBox([th1, th2]);
+
+      const nodeA: any = { data: { id: 'a' } };
+      const nodeB: any = { data: { id: 'b' } };
+      const rowA = [makeCell('td', 80), makeCell('td', 40)];
+      const rowB = [makeCell('td', 120), makeCell('td', 60)];
+      (component as any)._scrollableBody = makeScrollableBody([rowA, rowB]);
+      component.primengTreeTable.serializedValue = [
+        { node: nodeA, visible: true },
+        { node: nodeB, visible: true }
+      ] as any;
+
+      (component as any)._calcAutoLayoutHeaderWidths(true);
+
+      return { th1, th2, nodeA, nodeB, rowA, rowB };
+    }
+
+    describe('_calcAutoLayoutHeaderWidths (full recalc)', () => {
+      it('populates the per-row cache keyed by tree node and applies percentages', () => {
+        const { th1, th2, nodeA, nodeB } = setupBasicTable();
+
+        expect((component as any)._visibleRowWidthsPxByNode.get(nodeA)).toEqual(
+          [80, 40]
+        );
+        expect((component as any)._visibleRowWidthsPxByNode.get(nodeB)).toEqual(
+          [120, 60]
+        );
+        expect((component as any)._headerWidthsPx).toEqual([100, 50]);
+
+        expect(th1.style.width).toBe(`${(120 / 180) * 100}%`);
+        expect(th2.style.width).toBe(`${(60 / 180) * 100}%`);
+      });
+
+      it('clears stale cache entries for nodes no longer present', () => {
+        const { nodeA } = setupBasicTable();
+        expect((component as any)._visibleRowWidthsPxByNode.has(nodeA)).toBe(
+          true
+        );
+
+        const nodeC: any = { data: { id: 'c' } };
+        const rowC = [makeCell('td', 90), makeCell('td', 45)];
+        (component as any)._scrollableBody = makeScrollableBody([rowC]);
+        component.primengTreeTable.serializedValue = [
+          { node: nodeC, visible: true }
+        ] as any;
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect((component as any)._visibleRowWidthsPxByNode.has(nodeA)).toBe(
+          false
+        );
+        expect((component as any)._visibleRowWidthsPxByNode.get(nodeC)).toEqual(
+          [90, 45]
+        );
+      });
+
+      it('marks _needRecalcAutoLayout for retry when there are no header cells', () => {
+        setupBasicTable();
+        (component as any)._needRecalcAutoLayout = false;
+        (component as any)._headerBox = makeHeaderBox([]);
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect((component as any)._needRecalcAutoLayout).toBe(true);
+      });
+
+      it('marks _needRecalcAutoLayout for retry when header cells all have zero width', () => {
+        setupBasicTable();
+        (component as any)._needRecalcAutoLayout = false;
+        (component as any)._headerBox = makeHeaderBox([
+          makeCell('th', 0),
+          makeCell('th', 0)
+        ]);
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect((component as any)._needRecalcAutoLayout).toBe(true);
+      });
+
+      it('marks _needRecalcAutoLayout for retry when there are no body rows yet', () => {
+        setupBasicTable();
+        (component as any)._needRecalcAutoLayout = false;
+        (component as any)._scrollableBody = makeScrollableBody([]);
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect((component as any)._needRecalcAutoLayout).toBe(true);
+      });
+
+      it('leaves _needRecalcAutoLayout false after a successful recalc', () => {
+        setupBasicTable();
+        expect((component as any)._needRecalcAutoLayout).toBe(false);
+      });
+    });
+
+    describe('resize-pinned columns', () => {
+      function setupThreeColumnTable() {
+        component.autoLayout = true;
+        component.scrollable = true;
+        component.virtualScroll = false;
+
+        const th0 = makeCell('th', 100);
+        const th1 = makeCell('th', 50);
+        const th2 = makeCell('th', 80);
+        (component as any)._headerBox = makeHeaderBox([th0, th1, th2]);
+
+        const nodeA: any = { data: { id: 'a' } };
+        const rowA = [
+          makeCell('td', 100),
+          makeCell('td', 50),
+          makeCell('td', 80)
+        ];
+        (component as any)._scrollableBody = makeScrollableBody([rowA]);
+        component.primengTreeTable.serializedValue = [
+          { node: nodeA, visible: true }
+        ] as any;
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        return { th0, th1, th2, nodeA, rowA };
+      }
+
+      it('onColumnResized pins the resized column by index', () => {
+        const { th1 } = setupThreeColumnTable();
+        th1.setAttribute('data-test-width', '150');
+
+        (component as any).onColumnResized({ element: th1, delta: 100 });
+
+        expect((component as any)._pinnedColumnWidthsPx.get(1)).toBe(150);
+      });
+
+      it('ignores resize events on selectable-checkbox/row-menu columns', () => {
+        setupThreeColumnTable();
+        const th = makeCell('th', 50, 'cps-treetable-selectable-cell');
+
+        (component as any).onColumnResized({ element: th, delta: 10 });
+
+        expect((component as any)._pinnedColumnWidthsPx.size).toBe(0);
+      });
+
+      it('excludes the pinned column from the percentage sum and keeps it at its exact px width', () => {
+        const { th0, th1, th2 } = setupThreeColumnTable();
+
+        (component as any)._pinnedColumnWidthsPx.set(1, 150);
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect(th1.style.width).toBe('150px');
+        expect(th0.style.width).toBe(`${(100 / 180) * 100}%`);
+        expect(th2.style.width).toBe(`${(80 / 180) * 100}%`);
+      });
+
+      it('applies the same fixed width to header and body for a pinned column', () => {
+        const { rowA } = setupThreeColumnTable();
+        (component as any)._pinnedColumnWidthsPx.set(1, 150);
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect(rowA[1].style.width).toBe('150px');
+      });
+
+      it('clears pinned columns when the header cell count changes', () => {
+        setupThreeColumnTable();
+        (component as any)._pinnedColumnWidthsPx.set(1, 150);
+
+        const newTh0 = makeCell('th', 100);
+        const newTh1 = makeCell('th', 50);
+        (component as any)._headerBox = makeHeaderBox([newTh0, newTh1]);
+        const nodeX: any = { data: { id: 'x' } };
+        const rowX = [makeCell('td', 100), makeCell('td', 50)];
+        (component as any)._scrollableBody = makeScrollableBody([rowX]);
+        component.primengTreeTable.serializedValue = [
+          { node: nodeX, visible: true }
+        ] as any;
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect((component as any)._pinnedColumnWidthsPx.size).toBe(0);
+      });
+
+      it('keeps a pinned column at its exact width even when new content would otherwise grow it', () => {
+        const { nodeA, th1 } = setupThreeColumnTable();
+        (component as any)._pinnedColumnWidthsPx.set(1, 150);
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+
+        const newTr = document.createElement('tr');
+        [makeCell('td', 10), makeCell('td', 300), makeCell('td', 10)].forEach(
+          (c) => newTr.appendChild(c)
+        );
+        const rowATr = (component as any)._scrollableBody.querySelectorAll(
+          'tr'
+        )[0];
+        rowATr.parentElement.insertBefore(newTr, rowATr.nextSibling);
+
+        component.primengTreeTable.serializedValue = [
+          { node: nodeA, visible: true },
+          { node: nodeAChild, visible: true }
+        ] as any;
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(th1.style.width).toBe('150px');
+        expect(newTr.querySelectorAll('td')[1].style.width).toBe('150px');
+      });
+    });
+
+    describe('_expandAutoLayoutIncremental', () => {
+      function setSerializedValue(entries: { node: any; visible: boolean }[]) {
+        component.primengTreeTable.serializedValue = entries as any;
+      }
+
+      it('measures only the newly-revealed rows and adds them to the cache', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+        const measureSpy = jest.spyOn(component as any, '_measureRowsWidthsPx');
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+
+        const newTr = document.createElement('tr');
+        [makeCell('td', 55), makeCell('td', 20)].forEach((c) =>
+          newTr.appendChild(c)
+        );
+        const rowATr = (component as any)._scrollableBody.querySelectorAll(
+          'tr'
+        )[0];
+        rowATr.parentElement.insertBefore(newTr, rowATr.nextSibling);
+
+        setSerializedValue([
+          { node: nodeA, visible: true },
+          { node: nodeAChild, visible: true },
+          { node: nodeB, visible: true }
+        ]);
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(
+          (component as any)._visibleRowWidthsPxByNode.get(nodeAChild)
+        ).toEqual([55, 20]);
+        expect(measureSpy).toHaveBeenCalledWith(
+          null,
+          [newTr],
+          expect.any(Function)
+        );
+      });
+
+      it('restyles every currently-visible row, not just the new ones, even when nothing grew', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+
+        const newTr = document.createElement('tr');
+        [makeCell('td', 10), makeCell('td', 5)].forEach((c) =>
+          newTr.appendChild(c)
+        );
+        const rowATr = (component as any)._scrollableBody.querySelectorAll(
+          'tr'
+        )[0];
+        rowATr.parentElement.insertBefore(newTr, rowATr.nextSibling);
+
+        setSerializedValue([
+          { node: nodeA, visible: true },
+          { node: nodeAChild, visible: true },
+          { node: nodeB, visible: true }
+        ]);
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(applySpy).toHaveBeenCalledTimes(1);
+        const allRows = (component as any)._queryBodyRows();
+        expect(applySpy.mock.calls[0][1]).toEqual(allRows);
+        expect(allRows).toContain(newTr);
+      });
+
+      it('restyles headers and all visible rows when a column grows', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+
+        const newTr = document.createElement('tr');
+        [makeCell('td', 500), makeCell('td', 5)].forEach((c) =>
+          newTr.appendChild(c)
+        );
+        const rowATr = (component as any)._scrollableBody.querySelectorAll(
+          'tr'
+        )[0];
+        rowATr.parentElement.insertBefore(newTr, rowATr.nextSibling);
+
+        setSerializedValue([
+          { node: nodeA, visible: true },
+          { node: nodeAChild, visible: true },
+          { node: nodeB, visible: true }
+        ]);
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(applySpy).toHaveBeenCalledTimes(1);
+        const allRows = (component as any)._queryBodyRows();
+        expect(applySpy.mock.calls[0][1]).toEqual(allRows);
+      });
+
+      it('recurses into already-expanded children to find every newly-visible node', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+
+        const grandchild: any = { data: { id: 'grandchild' } };
+        const child: any = {
+          data: { id: 'child' },
+          expanded: true,
+          children: [grandchild]
+        };
+        nodeA.children = [child];
+
+        const childRow = document.createElement('tr');
+        [makeCell('td', 10), makeCell('td', 5)].forEach((c) =>
+          childRow.appendChild(c)
+        );
+        const grandchildRow = document.createElement('tr');
+        [makeCell('td', 15), makeCell('td', 6)].forEach((c) =>
+          grandchildRow.appendChild(c)
+        );
+
+        const rowATr = (component as any)._scrollableBody.querySelectorAll(
+          'tr'
+        )[0];
+        rowATr.parentElement.insertBefore(grandchildRow, rowATr.nextSibling);
+        rowATr.parentElement.insertBefore(childRow, rowATr.nextSibling);
+
+        setSerializedValue([
+          { node: nodeA, visible: true },
+          { node: child, visible: true },
+          { node: grandchild, visible: true },
+          { node: nodeB, visible: true }
+        ]);
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect((component as any)._visibleRowWidthsPxByNode.get(child)).toEqual(
+          [10, 5]
+        );
+        expect(
+          (component as any)._visibleRowWidthsPxByNode.get(grandchild)
+        ).toEqual([15, 6]);
+      });
+
+      it('never measures when the node has no children, but still reapplies cached widths to every visible row', () => {
+        const { nodeA } = setupBasicTable();
+        const measureSpy = jest.spyOn(component as any, '_measureRowsWidthsPx');
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+        const fullRecalcSpy = jest.spyOn(
+          component as any,
+          '_calcAutoLayoutHeaderWidths'
+        );
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(measureSpy).not.toHaveBeenCalled();
+        expect(applySpy).toHaveBeenCalledTimes(1);
+        expect(fullRecalcSpy).not.toHaveBeenCalled();
+      });
+
+      it('falls back to a full recalc when virtualScroll is true', () => {
+        const { nodeA } = setupBasicTable();
+        nodeA.children = [{ data: { id: 'a-child' } }];
+        component.virtualScroll = true;
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when no cache exists yet', () => {
+        const { nodeA } = setupBasicTable();
+        nodeA.children = [{ data: { id: 'a-child' } }];
+        (component as any)._headerWidthsPx = null;
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when event.node is missing', () => {
+        setupBasicTable();
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._expandAutoLayoutIncremental({});
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when the toggled node cannot be located in serializedValue', () => {
+        const { nodeA } = setupBasicTable();
+        nodeA.children = [{ data: { id: 'a-child' } }];
+
+        setSerializedValue([]);
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when fewer sibling rows exist than expected', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+        const child1: any = { data: { id: 'child-1' } };
+        const child2: any = { data: { id: 'child-2' } };
+        nodeA.children = [child1, child2];
+
+        setSerializedValue([
+          { node: nodeA, visible: true },
+          { node: child1, visible: true },
+          { node: child2, visible: true },
+          { node: nodeB, visible: true }
+        ]);
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._expandAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+    });
+
+    describe('_collapseAutoLayoutIncremental', () => {
+      it('deletes the collapsed subtree from the cache without measuring anything', () => {
+        const { nodeA, nodeB } = setupBasicTable();
+        const measureSpy = jest.spyOn(component as any, '_measureRowsWidthsPx');
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+        (component as any)._visibleRowWidthsPxByNode.set(nodeAChild, [10, 5]);
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect(
+          (component as any)._visibleRowWidthsPxByNode.has(nodeAChild)
+        ).toBe(false);
+        expect((component as any)._visibleRowWidthsPxByNode.has(nodeB)).toBe(
+          true
+        );
+        expect(measureSpy).not.toHaveBeenCalled();
+      });
+
+      it('still reapplies to every visible row even when the collapsed subtree was not driving any column width', () => {
+        const { nodeA } = setupBasicTable();
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+        const measureSpy = jest.spyOn(component as any, '_measureRowsWidthsPx');
+
+        const nodeAChild: any = { data: { id: 'a-child' } };
+        nodeA.children = [nodeAChild];
+        (component as any)._visibleRowWidthsPxByNode.set(nodeAChild, [10, 5]);
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect(applySpy).toHaveBeenCalledTimes(1);
+        expect(measureSpy).not.toHaveBeenCalled();
+      });
+
+      it('recomputes and reapplies from the remaining cache when a column shrinks', () => {
+        const { nodeB } = setupBasicTable();
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+        const measureSpy = jest.spyOn(component as any, '_measureRowsWidthsPx');
+
+        const parent: any = { data: { id: 'parent' }, children: [nodeB] };
+
+        (component as any)._collapseAutoLayoutIncremental({ node: parent });
+
+        expect((component as any)._visibleRowWidthsPxByNode.has(nodeB)).toBe(
+          false
+        );
+        expect(measureSpy).not.toHaveBeenCalled();
+        expect(applySpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('recurses into already-expanded children to find every newly-invisible node', () => {
+        const { nodeA } = setupBasicTable();
+
+        const grandchild: any = { data: { id: 'grandchild' } };
+        const child: any = {
+          data: { id: 'child' },
+          expanded: true,
+          children: [grandchild]
+        };
+        nodeA.children = [child];
+        (component as any)._visibleRowWidthsPxByNode.set(child, [10, 5]);
+        (component as any)._visibleRowWidthsPxByNode.set(grandchild, [15, 6]);
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect((component as any)._visibleRowWidthsPxByNode.has(child)).toBe(
+          false
+        );
+        expect(
+          (component as any)._visibleRowWidthsPxByNode.has(grandchild)
+        ).toBe(false);
+      });
+
+      it('reapplies cached widths without falling back when the node has no children', () => {
+        const { nodeA } = setupBasicTable();
+        const applySpy = jest.spyOn(component as any, '_applyColumnWidths');
+        const fullRecalcSpy = jest.spyOn(
+          component as any,
+          '_calcAutoLayoutHeaderWidths'
+        );
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect(applySpy).toHaveBeenCalledTimes(1);
+        expect(fullRecalcSpy).not.toHaveBeenCalled();
+      });
+
+      it('falls back to a full recalc when virtualScroll is true', () => {
+        const { nodeA } = setupBasicTable();
+        nodeA.children = [{ data: { id: 'a-child' } }];
+        component.virtualScroll = true;
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when no cache exists yet', () => {
+        const { nodeA } = setupBasicTable();
+        nodeA.children = [{ data: { id: 'a-child' } }];
+        (component as any)._headerWidthsPx = null;
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._collapseAutoLayoutIncremental({ node: nodeA });
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+
+      it('falls back to a full recalc when event.node is missing', () => {
+        setupBasicTable();
+
+        const fullRecalcSpy = jest
+          .spyOn(component as any, '_calcAutoLayoutHeaderWidths')
+          .mockImplementation(() => {});
+
+        (component as any)._collapseAutoLayoutIncremental({});
+
+        expect(fullRecalcSpy).toHaveBeenCalledWith(true);
+      });
+    });
+
+    describe('_collectToggledDescendantNodes', () => {
+      it('returns an empty array for a node with no children', () => {
+        expect((component as any)._collectToggledDescendantNodes({})).toEqual(
+          []
+        );
+      });
+
+      it('collects direct children only, when none are already expanded', () => {
+        const child1 = {};
+        const child2 = {};
+        const node = { children: [child1, child2] };
+        expect((component as any)._collectToggledDescendantNodes(node)).toEqual(
+          [child1, child2]
+        );
+      });
+
+      it('recurses into already-expanded children but not collapsed ones', () => {
+        const grandchild = {};
+        const expandedChild = { expanded: true, children: [grandchild] };
+        const collapsedGrandchild = {};
+        const collapsedChild = {
+          expanded: false,
+          children: [collapsedGrandchild]
+        };
+        const node = { children: [expandedChild, collapsedChild] };
+
+        expect((component as any)._collectToggledDescendantNodes(node)).toEqual(
+          [expandedChild, grandchild, collapsedChild]
+        );
+      });
+    });
+
+    describe('wiring into onNodeExpanded/onNodeCollapsed', () => {
+      const expandEvent = { node: { data: { id: 1 } } };
+      const collapseEvent = { node: { data: { id: 2 } } };
+
+      itSchedulesRecalcAsMicrotask(
+        'onNodeExpanded',
+        () => component.onNodeExpanded(expandEvent),
+        '_expandAutoLayoutIncremental',
+        [expandEvent]
+      );
+
+      itSchedulesRecalcAsMicrotask(
+        'onNodeCollapsed',
+        () => component.onNodeCollapsed(collapseEvent),
+        '_collapseAutoLayoutIncremental',
+        [collapseEvent]
+      );
     });
   });
 });

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.spec.ts
@@ -913,6 +913,38 @@ describe('CpsTreeTableComponent', () => {
         );
       });
 
+      it('does not resize a row whose cell count does not match the header (e.g. an empty-message row)', () => {
+        const th0 = makeCell('th', 100, 'cps-treetable-selectable-cell');
+        const th1 = makeCell('th', 100);
+        const th2 = makeCell('th', 50);
+        (component as any)._headerBox = makeHeaderBox([th0, th1, th2]);
+
+        const nodeA: any = { data: { id: 'a' } };
+        const rowA = [
+          makeCell('td', 20, 'cps-treetable-selectable-cell'),
+          makeCell('td', 80),
+          makeCell('td', 40)
+        ];
+
+        const emptyMessageCell = makeCell('td', 999);
+        const emptyMessageRow = document.createElement('tr');
+        emptyMessageRow.appendChild(emptyMessageCell);
+
+        (component as any)._scrollableBody = makeScrollableBody([rowA]);
+        (component as any)._scrollableBody
+          .querySelector('tbody')
+          .appendChild(emptyMessageRow);
+
+        component.primengTreeTable.serializedValue = [
+          { node: nodeA, visible: true }
+        ] as any;
+
+        (component as any)._calcAutoLayoutHeaderWidths(true);
+
+        expect(emptyMessageCell.style.width).toBe('');
+        expect(rowA[0].style.width).toBe('3.4375rem');
+      });
+
       it('marks _needRecalcAutoLayout for retry when there are no header cells', () => {
         setupBasicTable();
         (component as any)._needRecalcAutoLayout = false;

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
@@ -58,6 +58,8 @@ export function treeTableFactory(tableComponent: CpsTreeTableComponent) {
   return tableComponent.primengTreeTable;
 }
 
+const DEFAULT_CELL_WIDTH_REM = 3.4375;
+
 /**
  * CpsTreeTableSize is used to define the size of the tree table.
  * @group Types
@@ -993,12 +995,18 @@ export class CpsTreeTableComponent
       let hasSelectableCell = false;
       let hasRowMenuCell = false;
 
+      const defaultCellWidthPx = DEFAULT_CELL_WIDTH_REM * this._rootFontSizePx;
+
       const ths = Array.from(headerCells);
       if (ths.every((th: any) => th.offsetWidth === 0)) return;
 
-      const thWidths = ths.map((th: any) => {
-        const wprev = th.style.width;
+      const hiddenDiv = this.renderer.createElement('div');
+      this.renderer.setStyle(hiddenDiv, 'visibility', 'hidden');
+      this.renderer.setStyle(hiddenDiv, 'position', 'absolute');
+      this.renderer.setStyle(hiddenDiv, 'white-space', 'nowrap');
+      this.renderer.appendChild(this.document.body, hiddenDiv);
 
+      const thWidths = ths.map((th: any) => {
         const isSelectableCell = th.classList.contains(
           'cps-treetable-selectable-cell'
         );
@@ -1008,30 +1016,22 @@ export class CpsTreeTableComponent
         if (isSelectableCell) hasSelectableCell = true;
         if (isRowCell) hasRowMenuCell = true;
 
-        let thWidth = 55;
-        if (!isSelectableCell && !isRowCell) {
-          this.renderer.setStyle(th, 'width', 'min-content');
-          this.renderer.setStyle(th, 'display', 'block');
-          this.renderer.setStyle(th, 'text-wrap', 'nowrap');
-          thWidth = th.offsetWidth;
-          this.renderer.setStyle(th, 'width', wprev);
-          this.renderer.removeStyle(th, 'display');
-          this.renderer.removeStyle(th, 'text-wrap');
-        }
-        return thWidth;
+        if (isSelectableCell || isRowCell) return defaultCellWidthPx;
+
+        hiddenDiv.innerHTML = th.innerHTML;
+        hiddenDiv.style.width = 'auto';
+        return hiddenDiv.offsetWidth;
       });
 
       const bodyRows = this._scrollableBody?.querySelectorAll('tr');
-      if (!bodyRows?.length) return;
+      if (!bodyRows?.length) {
+        this.renderer.removeChild(this.document.body, hiddenDiv);
+        return;
+      }
 
       const tdWidths: number[] = [];
       const fragment = this.document.createDocumentFragment();
-      const hiddenDiv = this.document.createElement('div');
-      hiddenDiv.style.visibility = 'hidden';
-      hiddenDiv.style.position = 'absolute';
-      hiddenDiv.style.whiteSpace = 'nowrap';
 
-      this.document.body.appendChild(hiddenDiv);
       bodyRows.forEach((tr: HTMLElement) => {
         const tds = tr?.querySelectorAll('td');
         tds?.forEach((td: HTMLElement, idx: number) => {
@@ -1039,7 +1039,7 @@ export class CpsTreeTableComponent
             td.classList.contains('cps-treetable-selectable-cell') ||
             td.classList.contains('cps-treetable-row-menu-cell');
 
-          let tdWidth = 55;
+          let tdWidth = defaultCellWidthPx;
           if (!isSelectableOrRowMenuCell) {
             const clonedTd = td.cloneNode(true) as HTMLElement;
             fragment.appendChild(clonedTd);
@@ -1054,18 +1054,18 @@ export class CpsTreeTableComponent
           tdWidths[idx] = Math.max(tdWidths[idx], tdWidth);
         });
       });
-      this.document.body.removeChild(hiddenDiv);
+      this.renderer.removeChild(this.document.body, hiddenDiv);
 
       if (thWidths.length !== tdWidths.length) return;
 
       const maxWidths = thWidths.map((v, idx) => Math.max(v, tdWidths[idx]));
       let sum = maxWidths.reduce((a, b) => a + b, 0);
       if (hasSelectableCell) {
-        sum -= 55;
+        sum -= defaultCellWidthPx;
         maxWidths.shift();
       }
       if (hasRowMenuCell) {
-        sum -= 55;
+        sum -= defaultCellWidthPx;
         maxWidths.pop();
       }
 
@@ -1076,7 +1076,7 @@ export class CpsTreeTableComponent
           (hasSelectableCell && idx === 0) ||
           (hasRowMenuCell && idx === headerCells.length - 1)
         ) {
-          this.renderer.setStyle(th, 'width', '3.4375rem');
+          this.renderer.setStyle(th, 'width', `${DEFAULT_CELL_WIDTH_REM}rem`);
         } else
           this.renderer.setStyle(
             th,
@@ -1092,7 +1092,7 @@ export class CpsTreeTableComponent
             (hasSelectableCell && idx === 0) ||
             (hasRowMenuCell && idx === tds.length - 1)
           ) {
-            this.renderer.setStyle(td, 'width', '3.4375rem');
+            this.renderer.setStyle(td, 'width', `${DEFAULT_CELL_WIDTH_REM}rem`);
           } else {
             this.renderer.setStyle(
               td,
@@ -1437,7 +1437,8 @@ export class CpsTreeTableComponent
 
   onNodeExpanded(event: any) {
     this.nodeExpanded.emit(event);
-    setTimeout(() => {
+    queueMicrotask(() => {
+      this.cdRef.detectChanges();
       this._calcAutoLayoutHeaderWidths(true);
     });
     this._recalcVirtualHeight();
@@ -1445,7 +1446,8 @@ export class CpsTreeTableComponent
 
   onNodeCollapsed(event: any) {
     this.nodeCollapsed.emit(event);
-    setTimeout(() => {
+    queueMicrotask(() => {
+      this.cdRef.detectChanges();
       this._calcAutoLayoutHeaderWidths(true);
     });
     this._recalcVirtualHeight();

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
@@ -1218,7 +1218,8 @@ export class CpsTreeTableComponent
     hasSelectableCell: boolean,
     hasRowMenuCell: boolean
   ) {
-    const widthFor = (idx: number, totalCols: number): string =>
+    const totalCols = headerCells.length;
+    const widthFor = (idx: number): string =>
       this._getFixedColumnWidth(
         idx,
         totalCols,
@@ -1227,13 +1228,15 @@ export class CpsTreeTableComponent
       )?.cssValue ?? percentages[idx] + '%';
 
     headerCells.forEach((th, idx) => {
-      this.renderer.setStyle(th, 'width', widthFor(idx, headerCells.length));
+      this.renderer.setStyle(th, 'width', widthFor(idx));
     });
 
     bodyRows.forEach((tr) => {
       const tds = Array.from(tr.querySelectorAll('td')) as HTMLElement[];
+      if (tds.length !== totalCols) return;
+
       tds.forEach((td, idx) => {
-        this.renderer.setStyle(td, 'width', widthFor(idx, tds.length));
+        this.renderer.setStyle(td, 'width', widthFor(idx));
         this.renderer.setStyle(td, 'opacity', '1');
         this.renderer.setStyle(td, 'overflow', 'hidden');
         if (this.bordered)

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/cps-tree-table.component.ts
@@ -746,6 +746,13 @@ export class CpsTreeTableComponent
 
   private _needRecalcAutoLayout = true;
 
+  private _visibleRowWidthsPxByNode = new Map<any, number[]>();
+  private _headerWidthsPx: number[] | null = null;
+  private _lastHasSelectableCell = false;
+  private _lastHasRowMenuCell = false;
+  private _pinnedColumnWidthsPx = new Map<number, number>();
+  private _lastHeaderCellCount: number | null = null;
+
   private _data: any[] = [];
 
   private window: Window;
@@ -756,7 +763,10 @@ export class CpsTreeTableComponent
     return this._cpsRootFontSizeService?.fontSize() || 16;
   }
 
-  // eslint-disable-next-line no-useless-constructor
+  private get _defaultCellWidthPx(): number {
+    return DEFAULT_CELL_WIDTH_REM * this._rootFontSizePx;
+  }
+
   constructor(
     private cdRef: ChangeDetectorRef,
     @Inject(DOCUMENT) private document: Document,
@@ -985,134 +995,372 @@ export class CpsTreeTableComponent
 
       if (!this._needRecalcAutoLayout && !forced) return;
 
-      const headerRows = this._headerBox?.querySelectorAll('tr');
-      if (!headerRows?.length) return;
-
-      const headerCells =
-        headerRows[headerRows.length - 1]?.querySelectorAll('th');
-      if (!headerCells?.length) return;
-
-      let hasSelectableCell = false;
-      let hasRowMenuCell = false;
-
-      const defaultCellWidthPx = DEFAULT_CELL_WIDTH_REM * this._rootFontSizePx;
-
-      const ths = Array.from(headerCells);
-      if (ths.every((th: any) => th.offsetWidth === 0)) return;
-
-      const hiddenDiv = this.renderer.createElement('div');
-      this.renderer.setStyle(hiddenDiv, 'visibility', 'hidden');
-      this.renderer.setStyle(hiddenDiv, 'position', 'absolute');
-      this.renderer.setStyle(hiddenDiv, 'white-space', 'nowrap');
-      this.renderer.appendChild(this.document.body, hiddenDiv);
-
-      const thWidths = ths.map((th: any) => {
-        const isSelectableCell = th.classList.contains(
-          'cps-treetable-selectable-cell'
-        );
-
-        const isRowCell = th.classList.contains('cps-treetable-row-menu-cell');
-
-        if (isSelectableCell) hasSelectableCell = true;
-        if (isRowCell) hasRowMenuCell = true;
-
-        if (isSelectableCell || isRowCell) return defaultCellWidthPx;
-
-        hiddenDiv.innerHTML = th.innerHTML;
-        hiddenDiv.style.width = 'auto';
-        return hiddenDiv.offsetWidth;
-      });
-
-      const bodyRows = this._scrollableBody?.querySelectorAll('tr');
-      if (!bodyRows?.length) {
-        this.renderer.removeChild(this.document.body, hiddenDiv);
+      const headerCells = this._queryHeaderCells();
+      if (!headerCells?.length) {
+        this._needRecalcAutoLayout = true;
         return;
       }
 
-      const tdWidths: number[] = [];
-      const fragment = this.document.createDocumentFragment();
-
-      bodyRows.forEach((tr: HTMLElement) => {
-        const tds = tr?.querySelectorAll('td');
-        tds?.forEach((td: HTMLElement, idx: number) => {
-          const isSelectableOrRowMenuCell =
-            td.classList.contains('cps-treetable-selectable-cell') ||
-            td.classList.contains('cps-treetable-row-menu-cell');
-
-          let tdWidth = defaultCellWidthPx;
-          if (!isSelectableOrRowMenuCell) {
-            const clonedTd = td.cloneNode(true) as HTMLElement;
-            fragment.appendChild(clonedTd);
-            this.renderer.setStyle(clonedTd, 'width', 'min-content');
-            this.renderer.setStyle(clonedTd, 'display', 'block');
-            hiddenDiv.innerHTML = clonedTd.innerHTML;
-            hiddenDiv.style.width = 'auto';
-            tdWidth = hiddenDiv.offsetWidth;
-            fragment.removeChild(clonedTd);
-          }
-          if (!tdWidths[idx]) tdWidths[idx] = 0;
-          tdWidths[idx] = Math.max(tdWidths[idx], tdWidth);
-        });
-      });
-      this.renderer.removeChild(this.document.body, hiddenDiv);
-
-      if (thWidths.length !== tdWidths.length) return;
-
-      const maxWidths = thWidths.map((v, idx) => Math.max(v, tdWidths[idx]));
-      let sum = maxWidths.reduce((a, b) => a + b, 0);
-      if (hasSelectableCell) {
-        sum -= defaultCellWidthPx;
-        maxWidths.shift();
-      }
-      if (hasRowMenuCell) {
-        sum -= defaultCellWidthPx;
-        maxWidths.pop();
+      if (headerCells.every((th) => th.offsetWidth === 0)) {
+        this._needRecalcAutoLayout = true;
+        return;
       }
 
-      const percentages = maxWidths.map((v) => (v / sum) * 100);
+      if (
+        this._lastHeaderCellCount !== null &&
+        this._lastHeaderCellCount !== headerCells.length
+      ) {
+        this._pinnedColumnWidthsPx.clear();
+      }
+      this._lastHeaderCellCount = headerCells.length;
 
-      headerCells.forEach((th: any, idx: number) => {
-        if (
-          (hasSelectableCell && idx === 0) ||
-          (hasRowMenuCell && idx === headerCells.length - 1)
-        ) {
-          this.renderer.setStyle(th, 'width', `${DEFAULT_CELL_WIDTH_REM}rem`);
-        } else
-          this.renderer.setStyle(
-            th,
-            'width',
-            percentages[hasSelectableCell ? idx - 1 : idx] + '%'
-          );
-      });
+      const bodyRows = this._queryBodyRows();
+      if (!bodyRows.length) {
+        this._needRecalcAutoLayout = true;
+        return;
+      }
 
-      bodyRows.forEach((tr: HTMLElement) => {
-        const tds = tr?.querySelectorAll('td');
-        tds?.forEach((td: HTMLElement, idx: number) => {
-          if (
-            (hasSelectableCell && idx === 0) ||
-            (hasRowMenuCell && idx === tds.length - 1)
-          ) {
-            this.renderer.setStyle(td, 'width', `${DEFAULT_CELL_WIDTH_REM}rem`);
-          } else {
-            this.renderer.setStyle(
-              td,
-              'width',
-              percentages[hasSelectableCell ? idx - 1 : idx] + '%'
-            );
-          }
-          this.renderer.setStyle(td, 'opacity', '1');
-          this.renderer.setStyle(td, 'overflow', 'hidden');
-          if (this.bordered)
-            this.renderer.setStyle(
-              td,
-              'border-left-color',
-              'var(--cps-color-line-mid)'
-            );
-        });
+      const hasSelectableCell = headerCells.some((th) =>
+        th.classList.contains('cps-treetable-selectable-cell')
+      );
+      const hasRowMenuCell = headerCells.some((th) =>
+        th.classList.contains('cps-treetable-row-menu-cell')
+      );
+
+      const { theadWidthsPx, tbodyWidthsPxByRow } = this._measureRowsWidthsPx(
+        headerCells,
+        bodyRows,
+        this._isSkippableCell
+      );
+      if (!theadWidthsPx) return;
+
+      const serializedVisibleNodes = (
+        this.primengTreeTable?.serializedValue || []
+      ).filter((rn: any) => rn?.visible);
+
+      this._visibleRowWidthsPxByNode.clear();
+      tbodyWidthsPxByRow.forEach((widths, idx) => {
+        const node = serializedVisibleNodes[idx]?.node;
+        if (node) this._visibleRowWidthsPxByNode.set(node, widths);
       });
+      this._headerWidthsPx = theadWidthsPx;
+      this._lastHasSelectableCell = hasSelectableCell;
+      this._lastHasRowMenuCell = hasRowMenuCell;
+
+      const tdWidths = theadWidthsPx.map((_, idx) =>
+        tbodyWidthsPxByRow.reduce(
+          (max, widths) => Math.max(max, widths[idx] ?? 0),
+          0
+        )
+      );
+
+      if (theadWidthsPx.length !== tdWidths.length) return;
+
+      const maxWidths = theadWidthsPx.map((v, idx) =>
+        Math.max(v, tdWidths[idx])
+      );
+
+      const percentages = this._widthsToPercentages(
+        maxWidths,
+        hasSelectableCell,
+        hasRowMenuCell
+      );
+
+      this._applyColumnWidths(
+        headerCells,
+        bodyRows,
+        percentages,
+        hasSelectableCell,
+        hasRowMenuCell
+      );
 
       this._needRecalcAutoLayout = false;
     });
+  }
+
+  private _isSkippableCell(cell: HTMLElement): boolean {
+    return (
+      cell.classList.contains('cps-treetable-selectable-cell') ||
+      cell.classList.contains('cps-treetable-row-menu-cell')
+    );
+  }
+
+  private _queryHeaderCells(): HTMLElement[] {
+    const headerRows = this._headerBox?.querySelectorAll('tr');
+    if (!headerRows?.length) return [];
+    return Array.from(
+      headerRows[headerRows.length - 1]?.querySelectorAll('th') || []
+    ) as HTMLElement[];
+  }
+
+  private _queryBodyRows(): HTMLElement[] {
+    return Array.from(
+      this._scrollableBody?.querySelectorAll('tr') || []
+    ) as HTMLElement[];
+  }
+
+  private _measureRowsWidthsPx(
+    headerCells: HTMLElement[] | null,
+    bodyRows: HTMLElement[],
+    isSkippableCell: (cell: HTMLElement) => boolean
+  ): { theadWidthsPx: number[] | null; tbodyWidthsPxByRow: number[][] } {
+    const shadowWrapper = this.renderer.createElement('div');
+    this.renderer.addClass(shadowWrapper, 'p-treetable');
+    this.renderer.addClass(shadowWrapper, 'p-component');
+    this.renderer.setStyle(shadowWrapper, 'position', 'absolute');
+    this.renderer.setStyle(shadowWrapper, 'visibility', 'hidden');
+    this.renderer.setStyle(shadowWrapper, 'white-space', 'nowrap');
+    this.renderer.appendChild(this._elementRef.nativeElement, shadowWrapper);
+
+    const createShadowRow = (
+      sectionTag: 'thead' | 'tbody',
+      sectionClass: string
+    ) => {
+      const row = this.renderer.createElement('tr');
+      const section = this.renderer.createElement(sectionTag);
+      this.renderer.addClass(section, sectionClass);
+      this.renderer.appendChild(section, row);
+      const table = this.renderer.createElement('table');
+      this.renderer.setStyle(table, 'table-layout', 'fixed');
+      this.renderer.appendChild(table, section);
+      this.renderer.appendChild(shadowWrapper, table);
+      return row;
+    };
+
+    const appendClone = (cell: HTMLElement, shadowRow: HTMLElement) => {
+      const clone = cell.cloneNode(true) as HTMLElement;
+      this.renderer.setStyle(clone, 'display', 'block');
+      this.renderer.setStyle(clone, 'width', 'min-content');
+      this.renderer.appendChild(shadowRow, clone);
+      return clone;
+    };
+
+    let theadClones: (HTMLElement | null)[] | null = null;
+    if (headerCells?.length) {
+      const shadowTheadRow = createShadowRow('thead', 'p-treetable-thead');
+      theadClones = headerCells.map((th) =>
+        isSkippableCell(th) ? null : appendClone(th, shadowTheadRow)
+      );
+    }
+
+    const tbodyClonesByRow: (HTMLElement | null)[][] = bodyRows.map((tr) => {
+      const shadowRow = createShadowRow('tbody', 'p-treetable-tbody');
+      const tds = Array.from(tr.querySelectorAll('td')) as HTMLElement[];
+      return tds.map((td) =>
+        isSkippableCell(td) ? null : appendClone(td, shadowRow)
+      );
+    });
+
+    const theadWidthsPx = theadClones
+      ? theadClones.map((clone) =>
+          clone ? clone.offsetWidth : this._defaultCellWidthPx
+        )
+      : null;
+
+    const tbodyWidthsPxByRow = tbodyClonesByRow.map((clones) =>
+      clones.map((clone) =>
+        clone ? clone.offsetWidth : this._defaultCellWidthPx
+      )
+    );
+
+    this.renderer.removeChild(this._elementRef.nativeElement, shadowWrapper);
+
+    return { theadWidthsPx, tbodyWidthsPxByRow };
+  }
+
+  private _getFixedColumnWidth(
+    idx: number,
+    totalCols: number,
+    hasSelectableCell: boolean,
+    hasRowMenuCell: boolean
+  ): { px: number; cssValue: string } | null {
+    if (
+      (hasSelectableCell && idx === 0) ||
+      (hasRowMenuCell && idx === totalCols - 1)
+    ) {
+      return {
+        px: this._defaultCellWidthPx,
+        cssValue: `${DEFAULT_CELL_WIDTH_REM}rem`
+      };
+    }
+    const pinnedPx = this._pinnedColumnWidthsPx.get(idx);
+    return pinnedPx != null
+      ? { px: pinnedPx, cssValue: `${pinnedPx}px` }
+      : null;
+  }
+
+  private _widthsToPercentages(
+    maxWidths: number[],
+    hasSelectableCell: boolean,
+    hasRowMenuCell: boolean
+  ): number[] {
+    const fixedByIdx = maxWidths.map((_, idx) =>
+      this._getFixedColumnWidth(
+        idx,
+        maxWidths.length,
+        hasSelectableCell,
+        hasRowMenuCell
+      )
+    );
+    const flexibleSum = maxWidths.reduce(
+      (sum, w, idx) => sum + (fixedByIdx[idx] ? 0 : w),
+      0
+    );
+    return maxWidths.map((w, idx) =>
+      fixedByIdx[idx] ? 0 : (w / flexibleSum) * 100
+    );
+  }
+
+  private _applyColumnWidths(
+    headerCells: HTMLElement[],
+    bodyRows: HTMLElement[],
+    percentages: number[],
+    hasSelectableCell: boolean,
+    hasRowMenuCell: boolean
+  ) {
+    const widthFor = (idx: number, totalCols: number): string =>
+      this._getFixedColumnWidth(
+        idx,
+        totalCols,
+        hasSelectableCell,
+        hasRowMenuCell
+      )?.cssValue ?? percentages[idx] + '%';
+
+    headerCells.forEach((th, idx) => {
+      this.renderer.setStyle(th, 'width', widthFor(idx, headerCells.length));
+    });
+
+    bodyRows.forEach((tr) => {
+      const tds = Array.from(tr.querySelectorAll('td')) as HTMLElement[];
+      tds.forEach((td, idx) => {
+        this.renderer.setStyle(td, 'width', widthFor(idx, tds.length));
+        this.renderer.setStyle(td, 'opacity', '1');
+        this.renderer.setStyle(td, 'overflow', 'hidden');
+        if (this.bordered)
+          this.renderer.setStyle(
+            td,
+            'border-left-color',
+            'var(--cps-color-line-mid)'
+          );
+      });
+    });
+  }
+
+  private _recomputeMaxWidthsFromCache(): number[] | null {
+    if (!this._headerWidthsPx) return null;
+    const maxWidths = [...this._headerWidthsPx];
+    this._visibleRowWidthsPxByNode.forEach((widths) => {
+      widths.forEach((w, idx) => {
+        if (w > (maxWidths[idx] ?? 0)) maxWidths[idx] = w;
+      });
+    });
+    return maxWidths;
+  }
+
+  private _collectToggledDescendantNodes(node: any): any[] {
+    const result: any[] = [];
+    const children = node?.children;
+    if (!children?.length) return result;
+    for (const child of children) {
+      result.push(child);
+      if (child.expanded)
+        result.push(...this._collectToggledDescendantNodes(child));
+    }
+    return result;
+  }
+
+  private _tryBeginIncrementalRecalc(event: any): HTMLElement[] | null {
+    if (
+      !this.autoLayout ||
+      !this.scrollable ||
+      this.virtualScroll ||
+      !this._headerWidthsPx ||
+      !event?.node
+    ) {
+      this._calcAutoLayoutHeaderWidths(true);
+      return null;
+    }
+
+    const headerCells = this._queryHeaderCells();
+    if (!headerCells.length) {
+      this._calcAutoLayoutHeaderWidths(true);
+      return null;
+    }
+
+    return headerCells;
+  }
+
+  private _recomputeAndReapplyFromCache(headerCells: HTMLElement[]): void {
+    const maxWidths = this._recomputeMaxWidthsFromCache();
+    if (!maxWidths) {
+      this._calcAutoLayoutHeaderWidths(true);
+      return;
+    }
+
+    const percentages = this._widthsToPercentages(
+      maxWidths,
+      this._lastHasSelectableCell,
+      this._lastHasRowMenuCell
+    );
+
+    this._applyColumnWidths(
+      headerCells,
+      this._queryBodyRows(),
+      percentages,
+      this._lastHasSelectableCell,
+      this._lastHasRowMenuCell
+    );
+  }
+
+  private _expandAutoLayoutIncremental(event: any) {
+    const headerCells = this._tryBeginIncrementalRecalc(event);
+    if (!headerCells) return;
+
+    const newNodes = this._collectToggledDescendantNodes(event.node);
+
+    if (newNodes.length) {
+      const serializedVisibleNodes = (
+        this.primengTreeTable?.serializedValue || []
+      ).filter((rn: any) => rn?.visible);
+      const parentIdx = serializedVisibleNodes.findIndex(
+        (rn: any) => rn?.node === event.node
+      );
+      if (parentIdx === -1) {
+        this._calcAutoLayoutHeaderWidths(true);
+        return;
+      }
+
+      const newRows = this._queryBodyRows().slice(
+        parentIdx + 1,
+        parentIdx + 1 + newNodes.length
+      );
+      if (newRows.length !== newNodes.length) {
+        this._calcAutoLayoutHeaderWidths(true);
+        return;
+      }
+
+      const { tbodyWidthsPxByRow } = this._measureRowsWidthsPx(
+        null,
+        newRows,
+        this._isSkippableCell
+      );
+
+      tbodyWidthsPxByRow.forEach((widths, idx) => {
+        this._visibleRowWidthsPxByNode.set(newNodes[idx], widths);
+      });
+    }
+
+    this._recomputeAndReapplyFromCache(headerCells);
+  }
+
+  private _collapseAutoLayoutIncremental(event: any) {
+    const headerCells = this._tryBeginIncrementalRecalc(event);
+    if (!headerCells) return;
+
+    const removedNodes = this._collectToggledDescendantNodes(event.node);
+    removedNodes.forEach((node) => this._visibleRowWidthsPxByNode.delete(node));
+
+    this._recomputeAndReapplyFromCache(headerCells);
   }
 
   private _updateVirtualScrollItemSize() {
@@ -1439,7 +1687,7 @@ export class CpsTreeTableComponent
     this.nodeExpanded.emit(event);
     queueMicrotask(() => {
       this.cdRef.detectChanges();
-      this._calcAutoLayoutHeaderWidths(true);
+      this._expandAutoLayoutIncremental(event);
     });
     this._recalcVirtualHeight();
   }
@@ -1448,7 +1696,7 @@ export class CpsTreeTableComponent
     this.nodeCollapsed.emit(event);
     queueMicrotask(() => {
       this.cdRef.detectChanges();
-      this._calcAutoLayoutHeaderWidths(true);
+      this._collapseAutoLayoutIncremental(event);
     });
     this._recalcVirtualHeight();
   }
@@ -1463,7 +1711,7 @@ export class CpsTreeTableComponent
 
   onSort(event: any) {
     this.sorted.emit(event);
-    setTimeout(() => {
+    queueMicrotask(() => {
       this.cdRef.detectChanges();
       this._calcAutoLayoutHeaderWidths(true);
     });
@@ -1471,10 +1719,23 @@ export class CpsTreeTableComponent
 
   onFilter(event: any) {
     this.filtered.emit(event);
-    setTimeout(() => {
+    queueMicrotask(() => {
+      this.cdRef.detectChanges();
       this._calcAutoLayoutHeaderWidths(true);
     });
     this._recalcVirtualHeight();
+  }
+
+  onColumnResized(event: { element: HTMLElement; delta: number }) {
+    const th = event?.element;
+    if (!th || !this.autoLayout || !this.scrollable) return;
+    if (this._isSkippableCell(th)) return;
+
+    const idx = Array.from(th.parentElement?.children ?? []).indexOf(th);
+    if (idx === -1) return;
+
+    this._pinnedColumnWidthsPx.set(idx, th.offsetWidth);
+    this._calcAutoLayoutHeaderWidths(true);
   }
 
   onSelectionChanged(selection: any) {

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/cps-tree-table-column-resizable/cps-tree-table-column-resizable.directive.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/cps-tree-table-column-resizable/cps-tree-table-column-resizable.directive.spec.ts
@@ -250,6 +250,24 @@ describe('CpsTreeTableColumnResizableDirective', () => {
       expect(col0.style.width).toBe('120px');
       expect(col1.style.width).toBe('80px');
     });
+
+    it('should not backfill a width onto columns other than the resized one and its neighbor', () => {
+      const table = document.createElement('table');
+      const colGroup = document.createElement('colgroup');
+      const col0 = document.createElement('col');
+      const col1 = document.createElement('col');
+      const col2 = document.createElement('col');
+      colGroup.appendChild(col0);
+      colGroup.appendChild(col1);
+      colGroup.appendChild(col2);
+      table.appendChild(colGroup);
+
+      mockTreeTable.resizeColGroup(table, 0, 120, null);
+
+      expect(col0.style.width).toBe('120px');
+      expect(col1.style.width).toBe('');
+      expect(col2.style.width).toBe('');
+    });
   });
 
   describe('onAfterViewInit — onColumnResize patch', () => {

--- a/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/cps-tree-table-column-resizable/cps-tree-table-column-resizable.directive.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-tree-table/directives/cps-tree-table-column-resizable/cps-tree-table-column-resizable.directive.ts
@@ -87,16 +87,6 @@ export class CpsTreeTableColumnResizableDirective extends TTResizableColumn {
           table.children[0]?.nodeName === 'COLGROUP' ? table.children[0] : null;
         if (!colGroup) return;
         const cols = Array.from(colGroup.children) as HTMLElement[];
-        if (cols.some((c) => !c.style.width)) {
-          const ths = Array.from(
-            table.querySelectorAll('thead > tr:first-child > th')
-          ) as HTMLElement[];
-          cols.forEach((col, i) => {
-            if (!col.style.width && ths[i]) {
-              col.style.width = ths[i].offsetWidth + 'px';
-            }
-          });
-        }
         const col = cols[resizeColumnIndex] ?? null;
         const nextCol = col?.nextElementSibling as HTMLElement | null;
         if (col) col.style.width = newColumnWidth + 'px';


### PR DESCRIPTION
## Description

### Summary
Fixes several cross-browser rendering and column-width bugs in `cps-tree-table`, makes manually-resized columns coexist correctly with its auto-fit column layout.

### Changes

- **Safari: loader now renders correctly.** PrimeNG's TreeTable base styles were missing `display: block` on the root element (unlike the sibling DataTable component), which made Safari collapse the loading mask's width instead of sizing it to the table. Added the missing `display: block`, plus a compensating rule so tables using `scrollHeight="flex"` still lay out as a flex column as intended.

Before:
<img width="1163" height="766" alt="load_before" src="https://github.com/user-attachments/assets/5dbc3bb2-52ed-43aa-b6fa-0c5a42bd313c" />

After:
<img width="1167" height="773" alt="load_after" src="https://github.com/user-attachments/assets/bf0e27a2-5e0c-4257-8b15-f9ad5a432922" />

- **Chromium: row expand/collapse no longer jumps.** The column-width recalculation triggered by expanding/collapsing a row ran too early — before the newly expanded/collapsed rows were actually reflected in the table — causing a visible correction a moment later. It's now deferred to run immediately after that update completes, before the next paint, so the correct layout is what renders the first time. PrimeNG's TreeTableToggler emits onNodeExpand *before* it calls updateSerializedValue() (the step that actually recomputes which rows are visible), so at this point the new child rows don't exist yet in the bound data. A queued microtask runs after that synchronous call chain finishes (so the new rows are ready) but still before the browser paints (unlike setTimeout, which yields to a paint first) - that's what avoids visibly jumping between the old and new content.

Before:
<img width="800" height="496" alt="before" src="https://github.com/user-attachments/assets/2560ade6-a3a0-4ca1-9db9-7ae4c9daa9ec" />

After:
<img width="800" height="496" alt="after" src="https://github.com/user-attachments/assets/d9394655-f9ef-4bc5-bbee-6bb1ac33d55b" />

- **Resized columns now stay aligned with the header, and keep their width.** Manually resizing a column (drag or keyboard) previously caused the header and body columns to drift out of alignment as soon as anything else triggered a layout recalculation (sorting, filtering, expanding a row, etc.), because header and body columns were being frozen inconsistently with each other. A resized column now keeps its exact width and the rest of the columns continue to auto-fit their content around it, with header and body always staying in sync.

- **Fixed a column-misalignment case when expanding multiple different rows in a row.** Expanding a second, different row after an initial expand could leave earlier rows out of sync with the header. Column widths are now consistently kept in sync across any sequence of expand/collapse actions, not just the first one.

- **Chromium: columns no longer jump when sorting or filtering.** Same root cause and fix as the expand/collapse jump above - the column-width recalculation triggered by sorting or filtering now also runs immediately after the update completes, before the next paint, instead of a moment later.

- **Fixed columns staying misaligned after clearing a global filter on virtual-scroll tables.** When a filtered result set jumped from no matches back to many rows, the column-width recalculation could run before the virtual scroller finished repopulating rows, leaving the body permanently unstyled. It now automatically retries once the rows are actually available, instead of giving up after a single attempt.

Before:
<img width="2190" height="638" alt="image" src="https://github.com/user-attachments/assets/ed587bae-36c2-410c-a371-85944aaa16e1" />

After:
<img width="2196" height="640" alt="image" src="https://github.com/user-attachments/assets/4f3e8992-3211-40b5-8e67-a973e87064a7" />


- **Removed a hardcoded pixel value.** The fixed width used for selectable/row-menu columns was hardcoded as `55` (px) in several places; it's now derived from the root font size service (`3.4375rem` equivalent), so it stays correct if the root font size changes.

---

Release notes:
- fix tree table safari loader position and 
- fix tree table columns/content jump when expanding or collapsing rows in Chromium
- fix tree table column widths misalign after resizing a column
- fix tree table column widths misalign after expanding multiple different rows
- fix tree table columns jump when sorting in Chromium
- fix columns misalign after clearing a global filter on a virtual-scroll table
- fix dynamic columns widths depending on root font size