### PR TITLE
test: add Playwright coverage and test ids for CpsButtonToggleComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-button-toggle.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-button-toggle.spec.ts
@@ -1,0 +1,254 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+function option(page: Page, exampleTestId: string, index: number): Locator {
+  return example(page, exampleTestId).getByTestId(
+    `cps-button-toggle-option-${index}`
+  );
+}
+
+function optionInput(
+  page: Page,
+  exampleTestId: string,
+  index: number
+): Locator {
+  return example(page, exampleTestId).getByTestId(
+    `cps-button-toggle-option-${index}-input`
+  );
+}
+
+test.describe('cps-button-toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/button-toggle');
+  });
+
+  test.describe('Disabled state', () => {
+    test('the whole group cannot be focused', async ({ page }) => {
+      const input = optionInput(page, 'disabled-toggle', 0);
+
+      await expect(input).toBeDisabled();
+
+      await input.focus();
+      await expect(input).not.toBeFocused();
+    });
+  });
+
+  test.describe('Real click-through selection - radio mode', () => {
+    test('clicking a label moves selection via the hidden native radio input', async ({
+      page
+    }) => {
+      const previouslySelected = option(page, 'basic-toggle', 1);
+      const target = option(page, 'basic-toggle', 2);
+
+      await expect(previouslySelected).toHaveClass(/is-selected/);
+      await expect(optionInput(page, 'basic-toggle', 1)).toBeChecked();
+
+      await target.click();
+
+      await expect(target).toHaveClass(/is-selected/);
+      await expect(optionInput(page, 'basic-toggle', 2)).toBeChecked();
+      await expect(previouslySelected).not.toHaveClass(/is-selected/);
+      await expect(optionInput(page, 'basic-toggle', 1)).not.toBeChecked();
+    });
+  });
+
+  test.describe('Real keyboard navigation - radio group', () => {
+    test('ArrowRight moves selection to the next option in the group', async ({
+      page
+    }) => {
+      await optionInput(page, 'basic-toggle', 1).focus();
+
+      await page.keyboard.press('ArrowRight');
+
+      await expect(option(page, 'basic-toggle', 2)).toHaveClass(/is-selected/);
+      await expect(optionInput(page, 'basic-toggle', 2)).toBeChecked();
+      await expect(option(page, 'basic-toggle', 1)).not.toHaveClass(
+        /is-selected/
+      );
+    });
+  });
+
+  test.describe('Real click-through selection - multi-select mode', () => {
+    test('clicking an unselected option adds it', async ({ page }) => {
+      const added = option(page, 'multiple-toggle', 2);
+
+      await expect(added).not.toHaveClass(/is-selected/);
+
+      await added.click();
+
+      await expect(added).toHaveAttribute('aria-pressed', 'true');
+      await expect(option(page, 'multiple-toggle', 1)).toHaveClass(
+        /is-selected/
+      );
+    });
+
+    test('mandatory blocks removing the last selected option', async ({
+      page
+    }) => {
+      const onlySelected = option(page, 'multiple-toggle', 1);
+
+      await expect(onlySelected).toHaveClass(/is-selected/);
+
+      await onlySelected.click();
+
+      await expect(onlySelected).toHaveClass(/is-selected/);
+      await expect(onlySelected).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('non-mandatory allows clearing the last selected option', async ({
+      page
+    }) => {
+      const onlySelected = option(page, 'multiple-non-mandatory-toggle', 1);
+
+      await expect(onlySelected).toHaveClass(/is-selected/);
+
+      await onlySelected.click();
+
+      await expect(onlySelected).not.toHaveClass(/is-selected/);
+      await expect(onlySelected).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  test.describe('radioNavigation disabled - real keyboard behavior', () => {
+    test('a real click still selects an option, but ArrowRight does not move selection', async ({
+      page
+    }) => {
+      const previouslySelected = option(page, 'no-radio-navigation-toggle', 1);
+      const target = option(page, 'no-radio-navigation-toggle', 2);
+
+      await target.click();
+      await expect(target).toHaveClass(/is-selected/);
+      await expect(previouslySelected).not.toHaveClass(/is-selected/);
+
+      await target.focus();
+      await page.keyboard.press('ArrowRight');
+      await expect(target).toHaveClass(/is-selected/);
+    });
+  });
+
+  test.describe('Disabled options within an otherwise-enabled group', () => {
+    test('a disabled option cannot be interacted with, an enabled sibling stays clickable', async ({
+      page
+    }) => {
+      const disabledOption = option(page, 'partially-disabled-toggle', 0);
+      const currentlySelected = option(page, 'partially-disabled-toggle', 1);
+      const enabledSibling = option(page, 'partially-disabled-toggle', 3);
+
+      await expect(disabledOption).toBeDisabled();
+
+      await enabledSibling.click();
+      await expect(enabledSibling).toHaveClass(/is-selected/);
+      await expect(currentlySelected).not.toHaveClass(/is-selected/);
+    });
+  });
+
+  test.describe('Real equalWidths layout', () => {
+    test('option widths match when equalWidths is enabled', async ({
+      page
+    }) => {
+      const widths = await Promise.all(
+        [0, 1, 2].map(async (index) => {
+          const box = await option(
+            page,
+            'icons-equal-widths-toggle',
+            index
+          ).boundingBox();
+          return box?.width ?? 0;
+        })
+      );
+
+      const max = Math.max(...widths);
+      const min = Math.min(...widths);
+      expect(max - min).toBeLessThan(1);
+    });
+
+    test('option widths differ when equalWidths is disabled', async ({
+      page
+    }) => {
+      const widths = await Promise.all(
+        [0, 1, 2].map(async (index) => {
+          const box = await option(
+            page,
+            'icons-unequal-widths-toggle',
+            index
+          ).boundingBox();
+          return box?.width ?? 0;
+        })
+      );
+
+      const max = Math.max(...widths);
+      const min = Math.min(...widths);
+      expect(max - min).toBeGreaterThan(5);
+    });
+  });
+
+  test.describe('Icon-only options - accessible name', () => {
+    test('expose their aria-label as the real accessible name', async ({
+      page
+    }) => {
+      const group = example(page, 'icons-only-toggle');
+
+      await expect(
+        group.getByRole('radio', { name: 'Succeeded' })
+      ).toBeVisible();
+      await expect(group.getByRole('radio', { name: 'Failed' })).toBeVisible();
+      await expect(group.getByRole('radio', { name: 'Pending' })).toBeVisible();
+    });
+  });
+
+  test.describe('Group label - aria-label without a visible caption', () => {
+    test('exposes aria-label as the real accessible name for the group, with no visible caption', async ({
+      page
+    }) => {
+      const group = example(page, 'aria-label-toggle');
+
+      await expect(
+        group.getByRole('radiogroup', { name: 'Choose an option' })
+      ).toBeVisible();
+      await expect(group.getByTestId('cps-button-toggle-label')).toHaveCount(0);
+    });
+  });
+
+  test.describe('Reactive form integration - real readout', () => {
+    test('a real click updates the bound form control and the visible readout', async ({
+      page
+    }) => {
+      const readout = page.getByTestId('reactive-form-value');
+
+      await expect(readout).toHaveText('Selected value: second');
+
+      await option(page, 'reactive-form-toggle', 3).click();
+      await expect(readout).toHaveText('Selected value: fourth');
+    });
+  });
+
+  test.describe('Two-way binding - real readout', () => {
+    test('single selection updates the visible value via a real click', async ({
+      page
+    }) => {
+      const readout = page.getByTestId('two-way-binding-value');
+
+      await expect(readout).toHaveText('Selected value: first');
+
+      await option(page, 'two-way-binding-toggle', 1).click();
+      await expect(readout).toHaveText('Selected value: second');
+
+      await option(page, 'two-way-binding-toggle', 1).click();
+      await expect(readout).toHaveText('Selected value:');
+    });
+
+    test('multiple selection updates the visible values via a real click', async ({
+      page
+    }) => {
+      const readout = page.getByTestId('two-way-binding-multiple-value');
+
+      await expect(readout).toHaveText('Selected values: third,fourth');
+
+      await option(page, 'two-way-binding-multiple-toggle', 1).click();
+      await expect(readout).toHaveText('Selected values: second,third,fourth');
+    });
+  });
+});

--- a/playwright/cps-ui-kit/components/cps-button-toggle.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-button-toggle.spec.ts
@@ -133,11 +133,15 @@ test.describe('cps-button-toggle', () => {
     test('a disabled option cannot be interacted with, an enabled sibling stays clickable', async ({
       page
     }) => {
-      const disabledOption = option(page, 'partially-disabled-toggle', 0);
+      const disabledOptionInput = optionInput(
+        page,
+        'partially-disabled-toggle',
+        0
+      );
       const currentlySelected = option(page, 'partially-disabled-toggle', 1);
       const enabledSibling = option(page, 'partially-disabled-toggle', 3);
 
-      await expect(disabledOption).toBeDisabled();
+      await expect(disabledOptionInput).toBeDisabled();
 
       await enabledSibling.click();
       await expect(enabledSibling).toHaveClass(/is-selected/);
@@ -151,12 +155,11 @@ test.describe('cps-button-toggle', () => {
     }) => {
       const widths = await Promise.all(
         [0, 1, 2].map(async (index) => {
-          const box = await option(
-            page,
-            'icons-equal-widths-toggle',
-            index
-          ).boundingBox();
-          return box?.width ?? 0;
+          const el = option(page, 'icons-equal-widths-toggle', index);
+          await el.scrollIntoViewIfNeeded();
+          const box = await el.boundingBox();
+          expect(box).not.toBeNull();
+          return box!.width;
         })
       );
 
@@ -170,12 +173,11 @@ test.describe('cps-button-toggle', () => {
     }) => {
       const widths = await Promise.all(
         [0, 1, 2].map(async (index) => {
-          const box = await option(
-            page,
-            'icons-unequal-widths-toggle',
-            index
-          ).boundingBox();
-          return box?.width ?? 0;
+          const el = option(page, 'icons-unequal-widths-toggle', index);
+          await el.scrollIntoViewIfNeeded();
+          const box = await el.boundingBox();
+          expect(box).not.toBeNull();
+          return box!.width;
         })
       );
 

--- a/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
+++ b/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
@@ -4,6 +4,7 @@
     [htmlCode]="examples.basic.html"
     [tsCode]="examples.basic.ts">
     <cps-button-toggle
+      data-testid="basic-toggle"
       label="Single button toggles with a tooltip"
       infoTooltip="Provide any information here"
       [options]="options"
@@ -16,6 +17,7 @@
     [htmlCode]="examples.partiallyDisabled.html"
     [tsCode]="examples.partiallyDisabled.ts">
     <cps-button-toggle
+      data-testid="partially-disabled-toggle"
       label="Single button toggles with partially disabled options and targeted tooltips"
       [options]="partiallyDisabledOptions"
       [value]="partiallyDisabledOptions[1].value">
@@ -27,6 +29,7 @@
     [htmlCode]="examples.disabled.html"
     [tsCode]="examples.disabled.ts">
     <cps-button-toggle
+      data-testid="disabled-toggle"
       label="Disabled button toggles"
       [options]="options"
       [disabled]="true"
@@ -47,10 +50,24 @@
   </app-code-example>
 
   <app-code-example
+    label="Without radio navigation"
+    [htmlCode]="examples.radioNavigation.html"
+    [tsCode]="examples.radioNavigation.ts">
+    <cps-button-toggle
+      data-testid="no-radio-navigation-toggle"
+      label="Single button toggles without radio navigation"
+      [options]="options"
+      [radioNavigation]="false"
+      [value]="options[1].value">
+    </cps-button-toggle>
+  </app-code-example>
+
+  <app-code-example
     label="Multiple selection"
     [htmlCode]="examples.multiple.html"
     [tsCode]="examples.multiple.ts">
     <cps-button-toggle
+      data-testid="multiple-toggle"
       label="Multiple button toggles"
       [options]="options"
       [value]="[options[1].value]"
@@ -63,6 +80,7 @@
     [htmlCode]="examples.multipleNonMandatory.html"
     [tsCode]="examples.multipleNonMandatory.ts">
     <cps-button-toggle
+      data-testid="multiple-non-mandatory-toggle"
       label="Multiple button toggles without mandatory selection"
       [options]="options"
       [value]="[options[1].value]"
@@ -76,6 +94,7 @@
     [htmlCode]="examples.iconsUnequalWidths.html"
     [tsCode]="examples.iconsUnequalWidths.ts">
     <cps-button-toggle
+      data-testid="icons-unequal-widths-toggle"
       label="Single button toggles with icons and unequal widths"
       [options]="iconOptions"
       [equalWidths]="false"
@@ -88,6 +107,7 @@
     [htmlCode]="examples.iconsEqualWidths.html"
     [tsCode]="examples.iconsEqualWidths.ts">
     <cps-button-toggle
+      data-testid="icons-equal-widths-toggle"
       label="Single button toggles with icons and equal widths"
       [options]="iconOptions"
       [value]="iconOptions[2].value">
@@ -99,9 +119,22 @@
     [htmlCode]="examples.iconsOnly.html"
     [tsCode]="examples.iconsOnly.ts">
     <cps-button-toggle
+      data-testid="icons-only-toggle"
       label="Single button toggles only with icons and tooltips"
       optionTooltipPosition="top"
       [options]="iconOnlyOptions">
+    </cps-button-toggle>
+  </app-code-example>
+
+  <app-code-example
+    label="Accessible label without a visible caption"
+    [htmlCode]="examples.ariaLabel.html"
+    [tsCode]="examples.ariaLabel.ts">
+    <cps-button-toggle
+      data-testid="aria-label-toggle"
+      ariaLabel="Choose an option"
+      [options]="options"
+      [value]="options[1].value">
     </cps-button-toggle>
   </app-code-example>
 
@@ -111,12 +144,15 @@
     [tsCode]="examples.twoWayBinding.ts">
     <div class="sync-val-example">
       <cps-button-toggle
+        data-testid="two-way-binding-toggle"
         label="Single button toggles with two-way binding"
         [options]="options"
         [(ngModel)]="syncVal"
         [mandatory]="false">
       </cps-button-toggle>
-      <div class="sync-val">Selected value: {{ syncVal }}</div>
+      <div class="sync-val" data-testid="two-way-binding-value">
+        Selected value: {{ syncVal }}
+      </div>
     </div>
   </app-code-example>
 
@@ -126,13 +162,36 @@
     [tsCode]="examples.twoWayBindingMultiple.ts">
     <div class="sync-val-example">
       <cps-button-toggle
+        data-testid="two-way-binding-multiple-toggle"
         label="Multiple button toggles with two-way binding"
         [options]="options"
         [(ngModel)]="multiSyncVal"
         [multiple]="true"
         [mandatory]="false">
       </cps-button-toggle>
-      <div class="sync-val">Selected values: {{ multiSyncVal }}</div>
+      <div class="sync-val" data-testid="two-way-binding-multiple-value">
+        Selected values: {{ multiSyncVal }}
+      </div>
     </div>
+  </app-code-example>
+
+  <app-code-example
+    label="Reactive form integration"
+    [htmlCode]="examples.reactiveForm.html"
+    [tsCode]="examples.reactiveForm.ts">
+    <form
+      class="sync-val-example"
+      data-testid="reactive-form-example"
+      [formGroup]="toggleForm">
+      <cps-button-toggle
+        data-testid="reactive-form-toggle"
+        label="Single button toggles bound to a reactive form control"
+        [options]="options"
+        formControlName="toggleControl">
+      </cps-button-toggle>
+      <div class="sync-val" data-testid="reactive-form-value">
+        Selected value: {{ toggleForm.value.toggleControl }}
+      </div>
+    </form>
   </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
+++ b/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.html
@@ -179,10 +179,7 @@
     label="Reactive form integration"
     [htmlCode]="examples.reactiveForm.html"
     [tsCode]="examples.reactiveForm.ts">
-    <form
-      class="sync-val-example"
-      data-testid="reactive-form-example"
-      [formGroup]="toggleForm">
+    <form class="sync-val-example" [formGroup]="toggleForm">
       <cps-button-toggle
         data-testid="reactive-form-toggle"
         label="Single button toggles bound to a reactive form control"

--- a/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.ts
+++ b/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CpsButtonToggleComponent, CpsButtonToggleOption } from 'cps-ui-kit';
 
 import ComponentData from '../../api-data/cps-button-toggle.json';
@@ -21,6 +21,8 @@ import { CodeExampleComponent } from '../../components/code-example/code-example
   host: { class: 'composition-page' }
 })
 export class ButtonTogglePageComponent {
+  private readonly fb = inject(FormBuilder);
+
   options: CpsButtonToggleOption[] = [
     { label: 'Option 1', value: 'first' },
     { label: 'Option 2', value: 'second' },
@@ -81,6 +83,11 @@ export class ButtonTogglePageComponent {
 
   syncVal = 'first';
   multiSyncVal = ['third', 'fourth'];
+
+  toggleForm = this.fb.nonNullable.group({
+    toggleControl: this.options[1].value
+  });
+
   componentData = ComponentData;
 
   readonly examples = buttonToggleExamples;

--- a/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.examples.ts
+++ b/projects/composition/src/app/pages/button-toggle-page/button-toggle-page.examples.ts
@@ -68,6 +68,17 @@ partiallyDisabledOptions: CpsButtonToggleOption[] = [
     ts: optionsTs
   },
 
+  radioNavigation: {
+    html: `
+<cps-button-toggle
+  label="Single button toggles without radio navigation"
+  [options]="options"
+  [radioNavigation]="false"
+  [value]="options[1].value">
+</cps-button-toggle>`,
+    ts: optionsTs
+  },
+
   multiple: {
     html: `
 <cps-button-toggle
@@ -127,6 +138,16 @@ iconOnlyOptions: CpsButtonToggleOption[] = [
 ];`
   },
 
+  ariaLabel: {
+    html: `
+<cps-button-toggle
+  ariaLabel="Choose an option"
+  [options]="options"
+  [value]="options[1].value">
+</cps-button-toggle>`,
+    ts: optionsTs
+  },
+
   twoWayBinding: {
     html: `
 <cps-button-toggle
@@ -164,5 +185,25 @@ options: CpsButtonToggleOption[] = [
   { label: 'Option 4', value: 'fourth' }
 ];
 multiSyncVal = ['third', 'fourth'];`
+  },
+
+  reactiveForm: {
+    html: `
+<form [formGroup]="toggleForm">
+  <cps-button-toggle
+    label="Single button toggles bound to a reactive form control"
+    [options]="options"
+    formControlName="toggleControl">
+  </cps-button-toggle>
+  <div>Selected value: {{ toggleForm.value.toggleControl }}</div>
+</form>`,
+    ts: `
+${optionsTs.trim()}
+
+private readonly fb = inject(FormBuilder);
+
+toggleForm = this.fb.nonNullable.group({
+  toggleControl: this.options[1].value
+});`
   }
 };

--- a/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-button-toggle/cps-button-toggle.component.html
@@ -1,10 +1,14 @@
 <div class="cps-btn-toggle">
   @if (label) {
-    <div class="cps-btn-toggle-label" [class.disabled]="disabled">
+    <div
+      class="cps-btn-toggle-label"
+      data-testid="cps-button-toggle-label"
+      [class.disabled]="disabled">
       <span>{{ label }}</span>
       @if (infoTooltip) {
         <cps-info-circle
           class="cps-btn-toggle-label-info-circle"
+          data-testid="cps-button-toggle-label-info-circle"
           size="xsmall"
           [tooltipPosition]="infoTooltipPosition"
           [tooltipContentClass]="infoTooltipClass"
@@ -17,12 +21,13 @@
   }
   <div
     class="cps-btn-toggle-content"
+    data-testid="cps-button-toggle"
     [attr.role]="
       radioNavigation && !multiple && mandatory ? 'radiogroup' : 'group'
     "
     [attr.aria-label]="ariaLabel || label || null"
     [attr.aria-disabled]="disabled || null">
-    @for (option of options; track option.value) {
+    @for (option of options; track option.value; let itemIndex = $index) {
       @if (option.tooltip) {
         <span
           class="cps-btn-toggle-option-wrapper"
@@ -34,7 +39,7 @@
               radioNavigation && !multiple && mandatory
                 ? radioTemplate
                 : buttonTemplate;
-              context: { option }
+              context: { option, itemIndex }
             "></ng-container>
         </span>
       }
@@ -45,16 +50,17 @@
               radioNavigation && !multiple && mandatory
                 ? radioTemplate
                 : buttonTemplate;
-              context: { option }
+              context: { option, itemIndex }
             "></ng-container>
         </span>
       }
     }
   </div>
 </div>
-<ng-template #radioTemplate let-option="option">
+<ng-template #radioTemplate let-option="option" let-itemIndex="itemIndex">
   <label
     class="cps-btn-toggle-content-option"
+    [attr.data-testid]="'cps-button-toggle-option-' + itemIndex"
     [class.is-selected]="
       option.value | checkOptionSelected: value : multiple : true : ''
     "
@@ -63,6 +69,7 @@
     <input
       type="radio"
       class="cps-btn-toggle-radio-input"
+      [attr.data-testid]="'cps-button-toggle-option-' + itemIndex + '-input'"
       [name]="groupName"
       [checked]="
         option.value | checkOptionSelected: value : multiple : true : ''
@@ -72,19 +79,28 @@
       [attr.aria-label]="option.ariaLabel || option.label || null" />
     <span class="cps-btn-toggle-content-option-inner">
       @if (option.icon) {
-        <cps-icon [class.me-2]="!!option.label" [icon]="option.icon">
+        <cps-icon
+          [class.me-2]="!!option.label"
+          [attr.data-testid]="'cps-button-toggle-option-' + itemIndex + '-icon'"
+          [icon]="option.icon">
         </cps-icon>
       }
       @if (option.label) {
-        <span>{{ option.label }}</span>
+        <span
+          [attr.data-testid]="
+            'cps-button-toggle-option-' + itemIndex + '-label'
+          "
+          >{{ option.label }}</span
+        >
       }
     </span>
   </label>
 </ng-template>
-<ng-template #buttonTemplate let-option="option">
+<ng-template #buttonTemplate let-option="option" let-itemIndex="itemIndex">
   <button
     type="button"
     class="cps-btn-toggle-content-option"
+    [attr.data-testid]="'cps-button-toggle-option-' + itemIndex"
     [class.is-selected]="
       option.value | checkOptionSelected: value : multiple : true : ''
     "
@@ -97,11 +113,19 @@
     [style.min-width.rem]="equalWidths ? largestButtonWidthRem : null">
     <span class="cps-btn-toggle-content-option-inner">
       @if (option.icon) {
-        <cps-icon [class.me-2]="!!option.label" [icon]="option.icon">
+        <cps-icon
+          [class.me-2]="!!option.label"
+          [attr.data-testid]="'cps-button-toggle-option-' + itemIndex + '-icon'"
+          [icon]="option.icon">
         </cps-icon>
       }
       @if (option.label) {
-        <span>{{ option.label }}</span>
+        <span
+          [attr.data-testid]="
+            'cps-button-toggle-option-' + itemIndex + '-label'
+          "
+          >{{ option.label }}</span
+        >
       }
     </span>
   </button>


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsButtonToggleComponent`, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite: real click-through selection in both radio and multi-select modes, real native radiogroup arrow-key navigation, real `equalWidths` layout measurement, real disabled hit-testing within a partially-enabled group, real accessible-name computation, and real two-way-binding/reactive-form readouts.
- Added `data-testid` attributes to `cps-button-toggle`'s internal template (group container, group label, info circle, and per-option label/button/radio input/icon/label) so consumer apps have stable selectors for their own tests.
- Added three new examples to the `/button-toggle` docs page to showcase previously-undemonstrated functionality: `radioNavigation=false`, a component-level `ariaLabel` without a visible caption, and reactive-forms integration (`formControlName`).

---

Release notes:
- added Playwright E2E coverage for cps-button-toggle component
- added test ids to cps-button-toggle component