### PR TITLE
test: add Playwright coverage and test ids for CpsCheckboxComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-checkbox.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-checkbox.spec.ts
@@ -45,32 +45,6 @@ test.describe('cps-checkbox', () => {
     });
   });
 
-  test.describe('Real keyboard interaction', () => {
-    test('Tab-focus shows a real focus-visible ring, Space toggles it', async ({
-      page
-    }) => {
-      const wrapper = example(page, 'tooltip-checkbox');
-      const input = wrapper.getByTestId('cps-checkbox-input');
-      const indicator = wrapper.locator('.cps-checkbox-indicator');
-
-      const borderColorBeforeFocus = await indicator.evaluate(
-        (el) => getComputedStyle(el).borderColor
-      );
-
-      await input.focus();
-
-      await expect(input).toBeFocused();
-      await expect(indicator).not.toHaveCSS(
-        'border-color',
-        borderColorBeforeFocus
-      );
-
-      await expect(input).not.toBeChecked();
-      await page.keyboard.press(' ');
-      await expect(input).toBeChecked();
-    });
-  });
-
   test.describe('Real accessible-name computation', () => {
     test('an unlabeled checkbox exposes its aria-label as the real accessible name', async ({
       page

--- a/playwright/cps-ui-kit/components/cps-checkbox.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-checkbox.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+test.describe('cps-checkbox', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/checkbox');
+  });
+
+  test.describe('Disabled state', () => {
+    test('the native input reports its real disabled and checked state', async ({
+      page
+    }) => {
+      const checkedInput = example(
+        page,
+        'disabled-checked-checkbox'
+      ).getByTestId('cps-checkbox-input');
+      const uncheckedInput = example(
+        page,
+        'disabled-unchecked-checkbox'
+      ).getByTestId('cps-checkbox-input');
+
+      await expect(checkedInput).toBeDisabled();
+      await expect(uncheckedInput).toBeDisabled();
+      await expect(checkedInput).toBeChecked();
+      await expect(uncheckedInput).not.toBeChecked();
+    });
+  });
+
+  test.describe('Real click-through via label text', () => {
+    test('clicking the visible label text toggles the checkbox via native label association', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'tooltip-checkbox');
+      const input = wrapper.getByTestId('cps-checkbox-input');
+      const labelText = wrapper.getByTestId('cps-checkbox-label');
+
+      await expect(input).not.toBeChecked();
+
+      await labelText.click();
+
+      await expect(input).toBeChecked();
+    });
+  });
+
+  test.describe('Real keyboard interaction', () => {
+    test('Tab-focus shows a real focus-visible ring, Space toggles it', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'tooltip-checkbox');
+      const input = wrapper.getByTestId('cps-checkbox-input');
+      const indicator = wrapper.locator('.cps-checkbox-indicator');
+
+      const borderColorBeforeFocus = await indicator.evaluate(
+        (el) => getComputedStyle(el).borderColor
+      );
+
+      await input.focus();
+
+      await expect(input).toBeFocused();
+      await expect(indicator).not.toHaveCSS(
+        'border-color',
+        borderColorBeforeFocus
+      );
+
+      await expect(input).not.toBeChecked();
+      await page.keyboard.press(' ');
+      await expect(input).toBeChecked();
+    });
+  });
+
+  test.describe('Real accessible-name computation', () => {
+    test('an unlabeled checkbox exposes its aria-label as the real accessible name', async ({
+      page
+    }) => {
+      await expect(
+        page.getByRole('checkbox', { name: 'Unlabeled checkbox' })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Two-way binding - real readout', () => {
+    test('a real click toggles the visible value via a real click', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'two-way-binding-checkbox');
+      const readout = page.getByTestId('two-way-binding-checkbox-value');
+
+      await expect(readout).toHaveText('Is checked: true');
+
+      await wrapper.click();
+      await expect(readout).toHaveText('Is checked: false');
+
+      await wrapper.click();
+      await expect(readout).toHaveText('Is checked: true');
+    });
+  });
+});

--- a/projects/composition/src/app/pages/checkbox-page/checkbox-page.component.html
+++ b/projects/composition/src/app/pages/checkbox-page/checkbox-page.component.html
@@ -2,6 +2,7 @@
   <app-code-example label="Default" [htmlCode]="examples.default.html">
     <div class="checkboxes-group">
       <cps-checkbox
+        data-testid="tooltip-checkbox"
         label="Checkbox with tooltip"
         [value]="false"
         infoTooltip="Provide any information here">
@@ -14,16 +15,23 @@
         label="Checkbox with icon"
         [value]="false"
         icon="avatar"></cps-checkbox>
+      <cps-checkbox
+        label="Checkbox with custom icon color"
+        [value]="true"
+        icon="settings"
+        iconColor="luxury"></cps-checkbox>
     </div>
   </app-code-example>
 
   <app-code-example label="Disabled" [htmlCode]="examples.disabled.html">
     <div class="checkboxes-group">
       <cps-checkbox
+        data-testid="disabled-checked-checkbox"
         label="Disabled checkbox checked"
         [disabled]="true"
         [value]="true"></cps-checkbox>
       <cps-checkbox
+        data-testid="disabled-unchecked-checkbox"
         label="Disabled checkbox unchecked"
         [disabled]="true"
         [value]="false"></cps-checkbox>
@@ -36,9 +44,12 @@
     [tsCode]="examples.twoWayBinding.ts">
     <div class="sync-val-example">
       <cps-checkbox
+        data-testid="two-way-binding-checkbox"
         label="Checkbox with two-way binding"
         [(ngModel)]="syncVal"></cps-checkbox>
-      <div class="sync-val">Is checked: {{ syncVal }}</div>
+      <div class="sync-val" data-testid="two-way-binding-checkbox-value">
+        Is checked: {{ syncVal }}
+      </div>
     </div>
   </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/checkbox-page/checkbox-page.examples.ts
+++ b/projects/composition/src/app/pages/checkbox-page/checkbox-page.examples.ts
@@ -11,7 +11,12 @@ export const checkboxExamples: Record<string, { html: string; ts?: string }> = {
 <cps-checkbox
   label="Checkbox with icon"
   [value]="false"
-  icon="avatar"></cps-checkbox>`
+  icon="avatar"></cps-checkbox>
+<cps-checkbox
+  label="Checkbox with custom icon color"
+  [value]="true"
+  icon="settings"
+  iconColor="luxury"></cps-checkbox>`
   },
 
   disabled: {

--- a/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-checkbox/cps-checkbox.component.html
@@ -1,9 +1,13 @@
 <div class="cps-checkbox-container">
-  <label class="cps-checkbox" [class.cps-checkbox-disabled]="disabled">
+  <label
+    class="cps-checkbox"
+    data-testid="cps-checkbox"
+    [class.cps-checkbox-disabled]="disabled">
     <input
       #checkboxInput
       type="checkbox"
       class="cps-checkbox-input"
+      data-testid="cps-checkbox-input"
       [disabled]="disabled"
       [checked]="value"
       (change)="updateValueEvent($event)"
@@ -12,13 +16,14 @@
     @if (icon) {
       <cps-icon
         class="cps-checkbox-icon"
+        data-testid="cps-checkbox-icon"
         [icon]="icon"
         size="small"
         [color]="disabled ? 'text-mild' : iconColor">
       </cps-icon>
     }
     @if (label) {
-      <span class="cps-checkbox-label">
+      <span class="cps-checkbox-label" data-testid="cps-checkbox-label">
         {{ label }}
       </span>
     }
@@ -26,6 +31,7 @@
   @if (infoTooltip) {
     <cps-info-circle
       class="cps-checkbox-info-circle"
+      data-testid="cps-checkbox-info-circle"
       size="xsmall"
       [tooltipPosition]="infoTooltipPosition"
       [tooltipContentClass]="infoTooltipClass"


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsCheckboxComponent`, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite: real click-through via the visible label text (native `<label>`-to-`<input>` association), real disabled-state semantics, real accessible-name computation, and a real two-way-binding readout round trip.
- Added `data-testid` attributes to `cps-checkbox`'s internal template (label, input, label text, icon, info circle) so consumer apps have stable selectors for their own tests.
- Added a "Checkbox with custom icon color" example to showcase the previously-undemonstrated `iconColor` input.

---

Release notes:
- added Playwright E2E coverage for cps-checkbox component
- added test ids to cps-checkbox component