### PR TITLE
test: add Playwright coverage and test ids for CpsChipComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-chip.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-chip.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+test.describe('cps-chip', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/chip');
+  });
+
+  test.describe('Disabled state', () => {
+    test('the chip and its close button block real interaction', async ({
+      page
+    }) => {
+      const chip = example(page, 'disabled-closable-chip');
+      const chipInner = chip.getByTestId('cps-chip');
+      const closeBtn = chip.getByTestId('cps-chip-close-btn');
+
+      await expect(chipInner).toHaveCSS('pointer-events', 'none');
+      await expect(closeBtn).toBeDisabled();
+
+      await closeBtn.focus();
+      await expect(closeBtn).not.toBeFocused();
+    });
+  });
+
+  test.describe('Real layout - icon position', () => {
+    test('the icon renders before the label when iconPosition is before, and after when after', async ({
+      page
+    }) => {
+      const beforeChip = example(page, 'icon-before-chip');
+      const beforeIconBox = await beforeChip
+        .getByTestId('cps-chip-icon')
+        .boundingBox();
+      const beforeLabelBox = await beforeChip
+        .getByTestId('cps-chip-label')
+        .boundingBox();
+      if (!beforeIconBox || !beforeLabelBox) {
+        throw new Error('boundingBox() returned null for icon-before-chip');
+      }
+      expect(beforeIconBox.x).toBeLessThan(beforeLabelBox.x);
+
+      const afterChip = example(page, 'icon-after-chip');
+      const afterIconBox = await afterChip
+        .getByTestId('cps-chip-icon')
+        .boundingBox();
+      const afterLabelBox = await afterChip
+        .getByTestId('cps-chip-label')
+        .boundingBox();
+      if (!afterIconBox || !afterLabelBox) {
+        throw new Error('boundingBox() returned null for icon-after-chip');
+      }
+      expect(afterIconBox.x).toBeGreaterThan(afterLabelBox.x);
+    });
+  });
+
+  test.describe('Real accessible-name computation', () => {
+    test('the chip and its close button expose real accessible names', async ({
+      page
+    }) => {
+      await expect(
+        page.getByRole('group', { name: 'Basic chip' })
+      ).toBeVisible();
+
+      const closeBtn = example(page, 'closable-chip').getByRole('button', {
+        name: 'Close'
+      });
+      await expect(closeBtn).toBeVisible();
+
+      const closeBtnWithCustomCloseLabel = example(
+        page,
+        'closable-chip-with-custom-close-label'
+      ).getByRole('button', {
+        name: 'Dismiss'
+      });
+      await expect(closeBtnWithCustomCloseLabel).toBeVisible();
+    });
+  });
+});

--- a/projects/composition/src/app/pages/chip-page/chip-page.component.html
+++ b/projects/composition/src/app/pages/chip-page/chip-page.component.html
@@ -8,8 +8,12 @@
 
   <app-code-example label="With icon" [htmlCode]="examples.withIcon.html">
     <div class="chips-group-row">
-      <cps-chip label="Left icon chip" icon="checked"></cps-chip>
       <cps-chip
+        data-testid="icon-before-chip"
+        label="Left icon chip"
+        icon="checked"></cps-chip>
+      <cps-chip
+        data-testid="icon-after-chip"
         label="Right icon chip"
         icon="checked"
         iconPosition="after"></cps-chip>
@@ -28,16 +32,32 @@
     <div class="chips-group-row">
       @if (!chipClosed) {
         <cps-chip
+          #closableChipRef
+          data-testid="closable-chip"
           label="Closable chip"
           [closable]="true"
           (closed)="onToggleChip()"></cps-chip>
       }
       @if (chipClosed) {
         <cps-button
+          #resetChipBtnRef
+          data-testid="reset-chip-button"
           label="Reset chip"
           (clicked)="onToggleChip()"
           size="xsmall"></cps-button>
       }
+      <cps-chip
+        data-testid="closable-chip-with-custom-close-label"
+        label="Closable chip with custom close label"
+        [closable]="true"
+        closeButtonAriaLabel="Dismiss"
+        (closed)="onDismissChip()">
+      </cps-chip>
+      <cps-chip
+        data-testid="disabled-closable-chip"
+        label="Disabled closable chip"
+        [disabled]="true"
+        [closable]="true"></cps-chip>
     </div>
   </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/chip-page/chip-page.component.ts
+++ b/projects/composition/src/app/pages/chip-page/chip-page.component.ts
@@ -1,5 +1,10 @@
-import { Component } from '@angular/core';
-import { CpsButtonComponent, CpsChipComponent } from 'cps-ui-kit';
+import { Component, ElementRef, inject, ViewChild } from '@angular/core';
+import {
+  CpsButtonComponent,
+  CpsChipComponent,
+  CpsFocusService,
+  CpsNotificationService
+} from 'cps-ui-kit';
 
 import ComponentData from '../../api-data/cps-chip.json';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
@@ -19,6 +24,15 @@ import { chipExamples } from './chip-page.examples';
   host: { class: 'composition-page' }
 })
 export class ChipPageComponent {
+  private readonly _notifService = inject(CpsNotificationService);
+  private readonly _focusService = inject(CpsFocusService);
+
+  @ViewChild('closableChipRef', { read: ElementRef })
+  closableChipRef?: ElementRef<HTMLElement>;
+
+  @ViewChild('resetChipBtnRef', { read: ElementRef })
+  resetChipBtnRef?: ElementRef<HTMLElement>;
+
   chipClosed = false;
   componentData = ComponentData;
 
@@ -26,5 +40,23 @@ export class ChipPageComponent {
 
   onToggleChip() {
     this.chipClosed = !this.chipClosed;
+
+    setTimeout(() => {
+      const el = this.chipClosed
+        ? this.resetChipBtnRef?.nativeElement.querySelector<HTMLElement>(
+            'button'
+          )
+        : this.closableChipRef?.nativeElement.querySelector<HTMLElement>(
+            '.cps-chip-close-btn'
+          );
+
+      if (el) {
+        this._focusService.focusElement(el, this._focusService.isKeyboard());
+      }
+    });
+  }
+
+  onDismissChip() {
+    this._notifService.info('Chip dismissed');
   }
 }

--- a/projects/composition/src/app/pages/chip-page/chip-page.examples.ts
+++ b/projects/composition/src/app/pages/chip-page/chip-page.examples.ts
@@ -24,21 +24,56 @@ export const chipExamples: Record<string, { html: string; ts?: string }> = {
     html: `
 @if (!chipClosed) {
   <cps-chip
+    #closableChipRef
     label="Closable chip"
     [closable]="true"
     (closed)="onToggleChip()"></cps-chip>
 }
 @if (chipClosed) {
   <cps-button
+    #resetChipBtnRef
     label="Reset chip"
     (clicked)="onToggleChip()"
     size="xsmall"></cps-button>
-}`,
+}
+<cps-chip
+  label="Closable chip with custom close label"
+  [closable]="true"
+  closeButtonAriaLabel="Dismiss"
+  (closed)="onDismissChip()">
+</cps-chip>
+<cps-chip
+  label="Disabled closable chip"
+  [disabled]="true"
+  [closable]="true"></cps-chip>`,
     ts: `
+private readonly _notifService = inject(CpsNotificationService);
+private readonly _focusService = inject(CpsFocusService);
+
+@ViewChild('closableChipRef', { read: ElementRef })
+closableChipRef?: ElementRef<HTMLElement>;
+
+@ViewChild('resetChipBtnRef', { read: ElementRef })
+resetChipBtnRef?: ElementRef<HTMLElement>;
+
 chipClosed = false;
 
 onToggleChip(): void {
   this.chipClosed = !this.chipClosed;
+
+  setTimeout(() => {
+    const el = this.chipClosed
+      ? this.resetChipBtnRef?.nativeElement.querySelector<HTMLElement>('button')
+      : this.closableChipRef?.nativeElement.querySelector<HTMLElement>('.cps-chip-close-btn');
+
+    if (el) {
+      this._focusService.focusElement(el, this._focusService.isKeyboard());
+    }
+  });
+}
+
+onDismissChip(): void {
+  this._notifService.info('Chip dismissed');
 }`
   }
 };

--- a/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.html
@@ -1,15 +1,21 @@
-<div [ngClass]="classesList" role="group" [attr.aria-label]="label">
+<div
+  [ngClass]="classesList"
+  data-testid="cps-chip"
+  role="group"
+  [attr.aria-label]="label">
   @if (icon) {
     <cps-icon
       class="cps-chip-icon"
+      data-testid="cps-chip-icon"
       [icon]="icon"
       [color]="iconColor"></cps-icon>
   }
-  <span class="cps-chip-label">{{ label }}</span>
+  <span class="cps-chip-label" data-testid="cps-chip-label">{{ label }}</span>
   @if (closable) {
     <button
       type="button"
       class="cps-chip-close-btn"
+      data-testid="cps-chip-close-btn"
       [disabled]="disabled"
       [attr.aria-label]="closeButtonAriaLabel"
       (mousedown)="$event.preventDefault()"

--- a/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.spec.ts
@@ -56,6 +56,14 @@ describe('CpsChipComponent', () => {
     expect(component.closed.emit).toHaveBeenCalledWith('Test');
   });
 
+  it('should set custom close button aria-label', () => {
+    fixture.componentRef.setInput('closable', true);
+    fixture.componentRef.setInput('closeButtonAriaLabel', 'Dismiss');
+    fixture.detectChanges();
+    const closeBtn = fixture.nativeElement.querySelector('.cps-chip-close-btn');
+    expect(closeBtn.getAttribute('aria-label')).toBe('Dismiss');
+  });
+
   it('should stop propagation on close click', () => {
     const event = new Event('click');
     jest.spyOn(event, 'stopPropagation');

--- a/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-chip/cps-chip.component.ts
@@ -5,7 +5,10 @@ import {
   OnChanges,
   Output
 } from '@angular/core';
-import { CpsIconComponent, IconType } from '../cps-icon/cps-icon.component';
+import {
+  CpsIconComponent,
+  type IconType
+} from '../cps-icon/cps-icon.component';
 import { CommonModule } from '@angular/common';
 
 /**


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsChipComponent`, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite: real disabled-state click/focus blocking on the close button, real accessible-name computation for both the chip's own group label and its close button (including a custom `closeButtonAriaLabel` value), and real icon-position layout (the `:has()`-driven CSS spacing between the icon, label, and close button).
- Added `data-testid` attributes to `cps-chip`'s internal template (root chip, label, icon, close button) so consumer apps have stable selectors for their own tests.
- Added a "Disabled closable chip" example to showcase the previously-undemonstrated combination of `disabled` and `closable` together.
- Added a "Closable chip with custom close label" example to showcase the previously-undemonstrated `closeButtonAriaLabel` input, backed by a new Jest unit test.
- Demo page improvements:
  - Dismissing the custom-label chip now shows a notification via `CpsNotificationService`.
  - Closing/resetting the "Closable chip" example now moves focus to whichever element newly appears (via `CpsFocusService`), fixing a real keyboard-accessibility gap where focus previously fell back to `<body>`.

---

Release notes:
- added Playwright E2E coverage for cps-chip component
- added test ids to cps-chip component
