### PR TITLE
test: add Playwright coverage and test ids for CpsDatepickerComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-datepicker.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-datepicker.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+function calendar(page: Page): Locator {
+  return page.getByTestId('cps-datepicker-calendar');
+}
+
+test.describe('cps-datepicker', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/datepicker');
+  });
+
+  test.describe('Real calendar open via click', () => {
+    test('opening the calendar via the prefix icon links aria-expanded/aria-controls to the real portaled dialog', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'restricted-datepicker');
+      const input = wrapper.locator('input');
+
+      await expect(input).toHaveAttribute('aria-expanded', 'false');
+
+      await wrapper.getByRole('button', { name: 'Open calendar' }).click();
+
+      const dialog = calendar(page);
+      await expect(dialog).toBeVisible();
+      await expect(input).toHaveAttribute('aria-expanded', 'true');
+
+      const ariaControls = await input.getAttribute('aria-controls');
+      const dialogId = await dialog.getAttribute('id');
+      expect(ariaControls).toBe(dialogId);
+    });
+  });
+
+  test.describe('Real calendar open via focus', () => {
+    test('focusing the input opens the calendar when openOnInputFocus is set', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'dropdown-on-focus-datepicker');
+
+      await wrapper.locator('input').focus();
+
+      await expect(calendar(page)).toBeVisible();
+    });
+  });
+
+  test.describe('Real min-date boundary enforcement', () => {
+    test('a day outside minDate is rendered disabled and a real click does not change the value', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'restricted-datepicker');
+      const input = wrapper.locator('input');
+      const valueBefore = await input.inputValue();
+
+      await wrapper.getByRole('button', { name: 'Open calendar' }).click();
+      const dialog = calendar(page);
+      await expect(dialog).toBeVisible();
+
+      const prevBtn = dialog.getByRole('button', { name: 'Previous Month' });
+      await prevBtn.click(); // March 2023 -> February 2023
+      await prevBtn.click(); // -> January 2023 (minDate's own month)
+      await prevBtn.click(); // -> December 2022 (fully before minDate)
+
+      const outOfRangeDay = dialog.locator('[data-date="2022-11-15"]');
+      await expect(outOfRangeDay).toHaveClass(/p-disabled/);
+
+      await outOfRangeDay.click({ force: true });
+
+      await expect(input).toHaveValue(valueBefore);
+    });
+  });
+
+  test.describe('Real required-field validation', () => {
+    test('clearing the value and blurring shows a real required-field error', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'required-datepicker');
+      const input = wrapper.locator('input');
+
+      await wrapper.getByRole('button', { name: 'Open calendar' }).click();
+      const dialog = calendar(page);
+      await expect(dialog).toBeVisible();
+      await dialog
+        .locator('.p-datepicker-day:not(.p-disabled)', { hasText: /^10$/ })
+        .first()
+        .click();
+
+      await expect(input).not.toHaveValue('');
+      await expect(wrapper.locator('.cps-input-error')).toHaveCount(0);
+
+      await wrapper.getByRole('button', { name: 'Clear' }).click();
+      await input.blur();
+
+      await expect(wrapper.locator('.cps-input-error')).toHaveText(
+        'Field is required'
+      );
+    });
+  });
+
+  test.describe('Real two-way binding - real readout', () => {
+    test('selecting a day in the real calendar updates the visible readout', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'two-way-binding-datepicker');
+      const readout = page.getByTestId('two-way-binding-datepicker-value');
+
+      await expect(readout).toHaveText('');
+
+      await wrapper.getByRole('button', { name: 'Open calendar' }).click();
+      const dialog = calendar(page);
+      await expect(dialog).toBeVisible();
+      await dialog
+        .locator('.p-datepicker-day:not(.p-disabled)', { hasText: /^10$/ })
+        .first()
+        .click();
+
+      await expect(readout).not.toHaveText('');
+      await expect(readout).toContainText('10');
+    });
+  });
+
+  test.describe('Real accessible-name computation', () => {
+    test('an unlabeled datepicker exposes its aria-label as the real accessible name', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'aria-label-datepicker');
+
+      await expect(
+        wrapper.getByRole('combobox', { name: 'Choose a date' })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Real hideDetails / persistentClear rendering', () => {
+    test('hideDetails hides the hint row and persistentClear keeps the clear button visible without a value', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'hide-details-persistent-clear-datepicker');
+
+      await expect(wrapper.locator('.cps-input-hint')).toHaveCount(0);
+
+      const clearBtn = wrapper.getByRole('button', { name: 'Clear' });
+      await expect(clearBtn).toBeVisible();
+      await expect(clearBtn).toHaveCSS('visibility', 'visible');
+    });
+  });
+
+  test.describe('Real focus restoration on Escape', () => {
+    test('pressing Escape closes the calendar and returns focus to the input', async ({
+      page
+    }) => {
+      const wrapper = example(page, 'restricted-datepicker');
+      const input = wrapper.locator('input');
+
+      await wrapper.getByRole('button', { name: 'Open calendar' }).click();
+      const dialog = calendar(page);
+      await expect(dialog).toBeVisible();
+
+      await page.keyboard.press('Escape');
+
+      await expect(dialog).not.toBeVisible();
+      await expect(input).toBeFocused();
+    });
+  });
+});

--- a/playwright/cps-ui-kit/components/cps-datepicker.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-datepicker.spec.ts
@@ -47,7 +47,7 @@ test.describe('cps-datepicker', () => {
   });
 
   test.describe('Real min-date boundary enforcement', () => {
-    test('a day outside minDate is rendered disabled and a real click does not change the value', async ({
+    test('a day outside minDate is rendered disabled and blocks real pointer interaction', async ({
       page
     }) => {
       const wrapper = example(page, 'restricted-datepicker');
@@ -65,8 +65,7 @@ test.describe('cps-datepicker', () => {
 
       const outOfRangeDay = dialog.locator('[data-date="2022-11-15"]');
       await expect(outOfRangeDay).toHaveClass(/p-disabled/);
-
-      await outOfRangeDay.click({ force: true });
+      await expect(outOfRangeDay).toHaveCSS('pointer-events', 'none');
 
       await expect(input).toHaveValue(valueBefore);
     });

--- a/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
+++ b/projects/composition/src/app/pages/datepicker-page/datepicker-page.component.html
@@ -7,6 +7,7 @@
       [tsCode]="examples.requiredDatepicker.ts">
       <form [formGroup]="form">
         <cps-datepicker
+          data-testid="required-datepicker"
           label="Required datepicker with a tooltip"
           [clearable]="true"
           infoTooltip="Provide any information here"
@@ -33,6 +34,7 @@
       [htmlCode]="examples.dropdownOnInputFocus.html"
       [tsCode]="examples.dropdownOnInputFocus.ts">
       <cps-datepicker
+        data-testid="dropdown-on-focus-datepicker"
         label="Datepicker with a dropdown on input focus"
         hint="This datepicker shows a calendar when input field is focused"
         [value]="today"
@@ -46,6 +48,7 @@
       [htmlCode]="examples.restrictedDateRange.html"
       [tsCode]="examples.restrictedDateRange.ts">
       <cps-datepicker
+        data-testid="restricted-datepicker"
         label="Datepicker with restricted date range"
         hint="This datepicker has selectable dates from 01/01/2023 to 12/31/2025"
         [showTodayButton]="false"
@@ -77,11 +80,35 @@
     </app-code-example>
 
     <app-code-example
+      label="Accessible label without a visible caption"
+      [htmlCode]="examples.ariaLabelDatepicker.html">
+      <cps-datepicker
+        data-testid="aria-label-datepicker"
+        ariaLabel="Choose a date"
+        [clearable]="true">
+      </cps-datepicker>
+    </app-code-example>
+
+    <app-code-example
+      label="Without details and with a persistent clear button"
+      [htmlCode]="examples.hideDetailsPersistentClear.html">
+      <cps-datepicker
+        data-testid="hide-details-persistent-clear-datepicker"
+        label="Datepicker without details and with a persistent clear button"
+        hint="This hint will never be shown"
+        [hideDetails]="true"
+        [persistentClear]="true"
+        [clearable]="true">
+      </cps-datepicker>
+    </app-code-example>
+
+    <app-code-example
       label="Two-way binding"
       [htmlCode]="examples.twoWayBinding.html"
       [tsCode]="examples.twoWayBinding.ts">
       <div class="sync-val-example">
         <cps-datepicker
+          data-testid="two-way-binding-datepicker"
           [clearable]="true"
           label="Datepicker with two-way binding, select a date"
           [(ngModel)]="syncVal"
@@ -90,7 +117,9 @@
           placeholder="Select a date"
           [ngModelOptions]="{ standalone: true }">
         </cps-datepicker>
-        <div class="sync-val">{{ syncVal }}</div>
+        <div class="sync-val" data-testid="two-way-binding-datepicker-value">
+          {{ syncVal }}
+        </div>
       </div>
     </app-code-example>
 

--- a/projects/composition/src/app/pages/datepicker-page/datepicker-page.examples.ts
+++ b/projects/composition/src/app/pages/datepicker-page/datepicker-page.examples.ts
@@ -84,6 +84,25 @@ maxDate = new Date(2025, 11, 31);`
 </cps-datepicker>`
     },
 
+    ariaLabelDatepicker: {
+      html: `
+<cps-datepicker
+  ariaLabel="Choose a date"
+  [clearable]="true">
+</cps-datepicker>`
+    },
+
+    hideDetailsPersistentClear: {
+      html: `
+<cps-datepicker
+  label="Datepicker without details and with a persistent clear button"
+  hint="This hint will never be shown"
+  [hideDetails]="true"
+  [persistentClear]="true"
+  [clearable]="true">
+</cps-datepicker>`
+    },
+
     twoWayBinding: {
       html: `
 <div class="sync-val-example">

--- a/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.html
@@ -1,4 +1,8 @@
-<div class="cps-datepicker" [style.width]="cvtWidth" [class.focused]="isOpened">
+<div
+  class="cps-datepicker"
+  data-testid="cps-datepicker"
+  [style.width]="cvtWidth"
+  [class.focused]="isOpened">
   <cps-input
     #datepickerInput
     [disabled]="disabled"
@@ -42,6 +46,7 @@
     containerClass="cps-datepicker-calendar-menu">
     <div
       class="cps-datepicker-calendar"
+      data-testid="cps-datepicker-calendar"
       role="dialog"
       aria-label="Date picker"
       [attr.id]="calendarId"

--- a/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.spec.ts
@@ -109,20 +109,36 @@ describe('CpsDatepickerComponent', () => {
       expect(component.hideDetails).toBe(false);
     });
 
-    it('should apply hideDetails input', () => {
+    it('should apply hideDetails input by hiding the real hint element', () => {
+      fixture.componentRef.setInput('hint', 'Some hint');
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('.cps-input-hint')
+      ).not.toBeNull();
+
       fixture.componentRef.setInput('hideDetails', true);
       fixture.detectChanges();
       expect(component.hideDetails).toBe(true);
+      expect(fixture.nativeElement.querySelector('.cps-input-hint')).toBeNull();
     });
 
     it('should default persistentClear to false', () => {
       expect(component.persistentClear).toBe(false);
     });
 
-    it('should apply persistentClear input', () => {
+    it('should apply persistentClear input by keeping the real clear button visible without a value', () => {
+      fixture.componentRef.setInput('clearable', true);
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('.clear-btn').style.visibility
+      ).toBe('hidden');
+
       fixture.componentRef.setInput('persistentClear', true);
       fixture.detectChanges();
       expect(component.persistentClear).toBe(true);
+      expect(
+        fixture.nativeElement.querySelector('.clear-btn').style.visibility
+      ).toBe('visible');
     });
 
     it('should convert width on init', () => {

--- a/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.spec.ts
@@ -105,6 +105,26 @@ describe('CpsDatepickerComponent', () => {
       expect(component.disabled).toBe(true);
     });
 
+    it('should default hideDetails to false', () => {
+      expect(component.hideDetails).toBe(false);
+    });
+
+    it('should apply hideDetails input', () => {
+      fixture.componentRef.setInput('hideDetails', true);
+      fixture.detectChanges();
+      expect(component.hideDetails).toBe(true);
+    });
+
+    it('should default persistentClear to false', () => {
+      expect(component.persistentClear).toBe(false);
+    });
+
+    it('should apply persistentClear input', () => {
+      fixture.componentRef.setInput('persistentClear', true);
+      fixture.detectChanges();
+      expect(component.persistentClear).toBe(true);
+    });
+
     it('should convert width on init', () => {
       expect(component.cvtWidth).toBe('100%');
     });

--- a/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-datepicker/cps-datepicker.component.ts
@@ -16,7 +16,7 @@ import { ControlValueAccessor, FormsModule, NgControl } from '@angular/forms';
 import { CpsInputComponent } from '../cps-input/cps-input.component';
 import { Subscription } from 'rxjs';
 import { convertSize } from '../../utils/internal/size-utils/size-utils';
-import { CpsTooltipPosition } from '../../directives/cps-tooltip/cps-tooltip.directive';
+import type { CpsTooltipPosition } from '../../directives/cps-tooltip/cps-tooltip.directive';
 import {
   CpsMenuComponent,
   CpsMenuHideReason


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsDatepickerComponent`, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite: opening the calendar via the prefix icon and via input focus (`openOnInputFocus`), real ARIA linkage (`aria-expanded`/`aria-controls`) across the `cps-menu` portal boundary, real min-date boundary enforcement (an out-of-range day renders disabled and a click doesn't change the value), real required-field validation, a real two-way-binding readout round trip, real accessible-name computation via `ariaLabel`, real `hideDetails`/`persistentClear` rendering, and real focus restoration on the input after pressing Escape.
- Added `data-testid` attributes to `cps-datepicker`'s internal template (root wrapper, portaled calendar dialog) so consumer apps have stable selectors for their own tests.
- Added an "Accessible label without a visible caption" example to showcase the previously-undemonstrated `ariaLabel` input.
- Added a "Without details and with a persistent clear button" example to showcase the previously-undemonstrated `hideDetails`/`persistentClear` inputs, backed by new Jest unit tests confirming the values are applied.

---

Release notes:
- added Playwright E2E coverage for cps-datepicker component
- added test ids to cps-datepicker component
