### PR TITLE
test: add Playwright coverage and test ids for dialog component

### DIFF
--- a/playwright/cps-ui-kit/components/cps-dialog.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-dialog.spec.ts
@@ -178,8 +178,8 @@ test.describe('cps-dialog', () => {
       await expect(dialog).toHaveClass(/cps-dialog-maximized/);
       const afterMax = await dialog.boundingBox();
       if (!afterMax) throw new Error('boundingBox() returned null');
-      expect(afterMax.width).toBe(viewport.width);
-      expect(afterMax.height).toBe(viewport.height);
+      expect(afterMax.width).toBeCloseTo(viewport.width, 0);
+      expect(afterMax.height).toBeCloseTo(viewport.height, 0);
 
       await maximizeBtn.click();
 
@@ -217,8 +217,13 @@ test.describe('cps-dialog', () => {
       const after = await dialog.boundingBox();
       if (!after) throw new Error('boundingBox() returned null');
 
-      expect(after.x - before.x).toBeCloseTo(80, 0);
-      expect(after.y - before.y).toBeCloseTo(40, 0);
+      const tolerancePx = 2;
+      expect(Math.abs(after.x - before.x - 80)).toBeLessThanOrEqual(
+        tolerancePx
+      );
+      expect(Math.abs(after.y - before.y - 40)).toBeLessThanOrEqual(
+        tolerancePx
+      );
     });
   });
 

--- a/playwright/cps-ui-kit/components/cps-dialog.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-dialog.spec.ts
@@ -1,0 +1,307 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function dialogs(page: Page): Locator {
+  return page.getByTestId('cps-dialog');
+}
+
+function trigger(page: Page, name: string): Locator {
+  return page.getByRole('button', { name, exact: true });
+}
+
+test.describe('cps-dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dialog');
+  });
+
+  test.describe('Real open, focus management, close and focus restoration', () => {
+    test('opening the dialog moves real focus inside it, and closing it restores focus to the trigger', async ({
+      page
+    }) => {
+      const openTrigger = trigger(page, 'Regular dialog');
+      await openTrigger.focus();
+      await page.keyboard.press('Enter');
+
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+
+      const closeBtn = page
+        .getByTestId('cps-dialog-close-btn')
+        .locator('button');
+      await expect(closeBtn).toBeFocused();
+
+      await closeBtn.click();
+
+      await expect(dialog).toBeHidden();
+      await expect(openTrigger).toBeFocused();
+    });
+  });
+
+  test.describe('Real Escape closes only the topmost dialog', () => {
+    test('pressing Escape with two dialogs open closes only the one opened last', async ({
+      page
+    }) => {
+      await trigger(page, 'Non-modal dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toHaveCount(1);
+
+      await trigger(page, 'Bottom-right positioned dialog').click();
+      await expect(dialog).toHaveCount(2);
+
+      await page.keyboard.press('Escape');
+
+      await expect(dialog).toHaveCount(1);
+      await expect(dialog.getByTestId('cps-dialog-header-title')).toHaveText(
+        'Non-modal dialog'
+      );
+    });
+  });
+
+  test.describe('Real backdrop click closes a modal dialog', () => {
+    test('clicking the mask outside the dialog box closes it', async ({
+      page
+    }) => {
+      await trigger(page, 'Regular dialog').click();
+      const mask = page.getByTestId('cps-dialog-mask');
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+
+      await mask.click({ position: { x: 5, y: 5 } });
+
+      await expect(dialog).toBeHidden();
+    });
+  });
+
+  test.describe('Real non-modal dialog does not block the page behind it', () => {
+    test('a real click reaches a trigger button behind the non-modal mask', async ({
+      page
+    }) => {
+      await trigger(page, 'Non-modal dialog').click();
+      const mask = page.getByTestId('cps-dialog-mask');
+      await expect(mask).toHaveCSS('pointer-events', 'none');
+
+      await trigger(page, 'Bottom-right positioned dialog').click();
+
+      await expect(dialogs(page)).toHaveCount(2);
+    });
+  });
+
+  test.describe('Real focus trap', () => {
+    test('Tab and Shift+Tab wrap focus between the first and last focusable elements', async ({
+      page
+    }) => {
+      await trigger(page, 'Maximizable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+
+      const maximizeBtn = page
+        .getByTestId('cps-dialog-maximize-btn')
+        .locator('button');
+      await expect(maximizeBtn).toBeFocused();
+
+      await page.keyboard.press('Shift+Tab');
+      const lastFocusable = page.getByRole('button', {
+        name: 'Disable closing'
+      });
+      await expect(lastFocusable).toBeFocused();
+
+      await page.keyboard.press('Tab');
+      await expect(maximizeBtn).toBeFocused();
+    });
+  });
+
+  test.describe('Real keyboard drag', () => {
+    test('pressing ArrowRight on the drag handle moves the dialog by one real step', async ({
+      page
+    }) => {
+      await trigger(page, 'Draggable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator(':focus')).toBeVisible();
+
+      const before = await dialog.boundingBox();
+      if (!before) throw new Error('boundingBox() returned null');
+
+      const dragHandle = page.getByTestId('cps-dialog-drag-handle');
+      await dragHandle.focus();
+      await page.keyboard.press('ArrowRight');
+
+      const after = await dialog.boundingBox();
+      if (!after) throw new Error('boundingBox() returned null');
+
+      expect(after.x - before.x).toBeGreaterThan(10);
+      expect(after.y).toBeCloseTo(before.y, 0);
+    });
+  });
+
+  test.describe('Real keyboard resize', () => {
+    test('pressing ArrowDown on the resize handle grows the dialog by one real step', async ({
+      page
+    }) => {
+      await trigger(page, 'Resizable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator(':focus')).toBeVisible();
+
+      const before = await dialog.boundingBox();
+      if (!before) throw new Error('boundingBox() returned null');
+
+      const resizeHandle = page.getByTestId('cps-dialog-resize-handle');
+      await resizeHandle.focus();
+      await page.keyboard.press('ArrowDown');
+
+      const after = await dialog.boundingBox();
+      if (!after) throw new Error('boundingBox() returned null');
+
+      expect(after.height - before.height).toBeGreaterThan(10);
+    });
+  });
+
+  test.describe('Real maximize toggle', () => {
+    test('maximizing fills the real viewport and minimizing restores the original size', async ({
+      page
+    }) => {
+      await trigger(page, 'Maximizable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator(':focus')).toBeVisible();
+
+      const before = await dialog.boundingBox();
+      if (!before) throw new Error('boundingBox() returned null');
+
+      const maximizeBtn = page
+        .getByTestId('cps-dialog-maximize-btn')
+        .locator('button');
+      await maximizeBtn.click();
+
+      const viewport = page.viewportSize();
+      if (!viewport) throw new Error('viewportSize() returned null');
+      await expect(dialog).toHaveClass(/cps-dialog-maximized/);
+      const afterMax = await dialog.boundingBox();
+      if (!afterMax) throw new Error('boundingBox() returned null');
+      expect(afterMax.width).toBe(viewport.width);
+      expect(afterMax.height).toBe(viewport.height);
+
+      await maximizeBtn.click();
+
+      await expect(dialog).not.toHaveClass(/cps-dialog-maximized/);
+      const afterMin = await dialog.boundingBox();
+      if (!afterMin) throw new Error('boundingBox() returned null');
+      expect(afterMin.width).toBeCloseTo(before.width, 0);
+      expect(afterMin.height).toBeCloseTo(before.height, 0);
+    });
+  });
+
+  test.describe('Real mouse drag', () => {
+    test('a real mousedown/move/up sequence on the header moves the dialog', async ({
+      page
+    }) => {
+      await trigger(page, 'Draggable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator(':focus')).toBeVisible();
+
+      const before = await dialog.boundingBox();
+      if (!before) throw new Error('boundingBox() returned null');
+
+      const title = page.getByTestId('cps-dialog-header-title');
+      const titleBox = await title.boundingBox();
+      if (!titleBox) throw new Error('boundingBox() returned null');
+      const startX = titleBox.x + titleBox.width / 2;
+      const startY = titleBox.y + titleBox.height / 2;
+
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      await page.mouse.move(startX + 80, startY + 40, { steps: 5 });
+      await page.mouse.up();
+
+      const after = await dialog.boundingBox();
+      if (!after) throw new Error('boundingBox() returned null');
+
+      expect(after.x - before.x).toBeCloseTo(80, 0);
+      expect(after.y - before.y).toBeCloseTo(40, 0);
+    });
+  });
+
+  test.describe('Real mouse resize', () => {
+    test('a real mousedown/move/up sequence on the resize handle grows the dialog', async ({
+      page
+    }) => {
+      await trigger(page, 'Resizable dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator(':focus')).toBeVisible();
+
+      const before = await dialog.boundingBox();
+      if (!before) throw new Error('boundingBox() returned null');
+
+      const resizeHandle = page.getByTestId('cps-dialog-resize-handle');
+      const handleBox = await resizeHandle.boundingBox();
+      if (!handleBox) throw new Error('boundingBox() returned null');
+      const startX = handleBox.x + handleBox.width / 2;
+      const startY = handleBox.y + handleBox.height / 2;
+
+      await page.mouse.move(startX, startY);
+      await page.mouse.down();
+      await page.mouse.move(startX + 60, startY + 60, { steps: 5 });
+      await page.mouse.up();
+
+      const after = await dialog.boundingBox();
+      if (!after) throw new Error('boundingBox() returned null');
+
+      expect(after.width).toBeGreaterThan(before.width);
+      expect(after.height).toBeGreaterThan(before.height);
+    });
+  });
+
+  test.describe('Real disableClose blocks every close path', () => {
+    test('Escape, backdrop click and the close button all become no-ops once closing is disabled', async ({
+      page
+    }) => {
+      await trigger(page, 'Regular dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+
+      await page.getByRole('button', { name: 'Disable closing' }).click();
+
+      const closeBtn = page
+        .getByTestId('cps-dialog-close-btn')
+        .locator('button');
+      await expect(closeBtn).toBeDisabled();
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeVisible();
+
+      const mask = page.getByTestId('cps-dialog-mask');
+      await mask.click({ position: { x: 5, y: 5 } });
+      await expect(dialog).toBeVisible();
+    });
+  });
+
+  test.describe('Real accessible-name computation', () => {
+    test('a header-less dialog exposes its aria-label as the real accessible name', async ({
+      page
+    }) => {
+      await trigger(page, 'Header-less dialog with an aria-label').click();
+
+      await expect(page.getByTestId('cps-dialog-header')).toHaveCount(0);
+      await expect(
+        page.getByRole('dialog', { name: 'Dialog without a visible header' })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Real confirmation dialog round trip', () => {
+    test('clicking Yes closes the confirmation dialog', async ({ page }) => {
+      await trigger(page, 'Confirmation dialog').click();
+      const dialog = dialogs(page);
+      await expect(dialog).toBeVisible();
+
+      await page
+        .getByTestId('cps-confirmation-yes-btn')
+        .locator('button')
+        .click();
+
+      await expect(dialog).toBeHidden();
+    });
+  });
+});

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.component.html
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.component.html
@@ -64,6 +64,14 @@
         (clicked)="openBottomRightPositionedDialog()"></cps-button>
     </app-code-example>
     <app-code-example
+      label="Header-less dialog with an aria-label"
+      [htmlCode]="examples.ariaLabelDialog.html"
+      [tsCode]="examples.ariaLabelDialog.ts">
+      <cps-button
+        label="Header-less dialog with an aria-label"
+        (clicked)="openAriaLabelDialog()"></cps-button>
+    </app-code-example>
+    <app-code-example
       label="Top-left positioned dialog opened from the root instance"
       [htmlCode]="examples.topLeftPositionedFromRootInstance.html"
       [tsCode]="examples.topLeftPositionedFromRootInstance.ts">

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.component.ts
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.component.ts
@@ -163,6 +163,17 @@ export class DialogPageComponent {
     });
   }
 
+  openAriaLabelDialog() {
+    this._dialogService.open(DialogContentComponent, {
+      ariaLabel: 'Dialog without a visible header',
+      showHeader: false,
+      data: {
+        info: 'Greetings from the dialog content component',
+        icon: 'like'
+      }
+    });
+  }
+
   openDialogFromRootInstance() {
     this._dialogServiceRoot.open(DialogContentComponent, {
       headerTitle: 'Top-left positioned dialog opened from root instance',

--- a/projects/composition/src/app/pages/dialog-page/dialog-page.examples.ts
+++ b/projects/composition/src/app/pages/dialog-page/dialog-page.examples.ts
@@ -193,6 +193,24 @@ openBottomRightPositionedDialog() {
 }`
   },
 
+  ariaLabelDialog: {
+    html: `
+<cps-button
+  label="Header-less dialog with an aria-label"
+  (clicked)="openAriaLabelDialog()"></cps-button>`,
+    ts: `
+openAriaLabelDialog() {
+  this._dialogService.open(DialogContentComponent, {
+    ariaLabel: 'Dialog without a visible header',
+    showHeader: false,
+    data: {
+      info: 'Greetings from the dialog content component',
+      icon: 'like'
+    }
+  });
+}`
+  },
+
   topLeftPositionedFromRootInstance: {
     html: `
 <cps-button

--- a/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-confirmation/cps-confirmation.component.html
+++ b/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-confirmation/cps-confirmation.component.html
@@ -1,14 +1,18 @@
-<div class="cps-confirmation">
-  <span class="cps-confirmation-subtitle" [innerHTML]="subtitle"></span>
+<div class="cps-confirmation" data-testid="cps-confirmation">
+  <span
+    class="cps-confirmation-subtitle"
+    data-testid="cps-confirmation-subtitle"
+    [innerHTML]="subtitle"></span>
   <div class="cps-confirmation-buttons">
     <cps-button
+      data-testid="cps-confirmation-no-btn"
       type="outlined"
       label="No"
       (clicked)="close(false)"
       color="calm">
     </cps-button>
     <cps-button
-      data-testid="btn-yes"
+      data-testid="cps-confirmation-yes-btn"
       label="Yes"
       (clicked)="close(true)"
       color="calm">

--- a/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.html
+++ b/projects/cps-ui-kit/src/lib/services/cps-dialog/internal/components/cps-dialog/cps-dialog.component.html
@@ -1,34 +1,43 @@
 <div
   #mask
-  [ngClass]="{
-    'cps-dialog-mask': true,
-    'cps-dialog-overlay': config.modal !== false,
-    'cps-dialog-overlay-enter':
-      config.modal !== false && !config.blurredBackground,
-    'cps-dialog-blurred-overlay cps-dialog-blurred-overlay-enter':
-      config.modal !== false && config.blurredBackground,
-    'cps-dialog-left': position === 'left',
-    'cps-dialog-right': position === 'right',
-    'cps-dialog-top': position === 'top',
-    'cps-dialog-bottom': position === 'bottom',
-    'cps-dialog-top-left': position === 'topleft' || position === 'top-left',
-    'cps-dialog-top-right': position === 'topright' || position === 'top-right',
-    'cps-dialog-bottom-left':
-      position === 'bottomleft' || position === 'bottom-left',
-    'cps-dialog-bottom-right':
-      position === 'bottomright' || position === 'bottom-right'
-  }"
+  data-testid="cps-dialog-mask"
+  class="cps-dialog-mask"
+  [class.cps-dialog-overlay]="config.modal !== false"
+  [class.cps-dialog-overlay-enter]="
+    config.modal !== false && !config.blurredBackground
+  "
+  [class.cps-dialog-blurred-overlay]="
+    config.modal !== false && config.blurredBackground
+  "
+  [class.cps-dialog-blurred-overlay-enter]="
+    config.modal !== false && config.blurredBackground
+  "
+  [class.cps-dialog-left]="position === 'left'"
+  [class.cps-dialog-right]="position === 'right'"
+  [class.cps-dialog-top]="position === 'top'"
+  [class.cps-dialog-bottom]="position === 'bottom'"
+  [class.cps-dialog-top-left]="
+    position === 'topleft' || position === 'top-left'
+  "
+  [class.cps-dialog-top-right]="
+    position === 'topright' || position === 'top-right'
+  "
+  [class.cps-dialog-bottom-left]="
+    position === 'bottomleft' || position === 'bottom-left'
+  "
+  [class.cps-dialog-bottom-right]="
+    position === 'bottomright' || position === 'bottom-right'
+  "
   [class]="config.maskStyleClass || ''">
   @if (visible) {
     <div
       #container
-      [ngClass]="{
-        'cps-dialog': true,
-        'cps-dialog-resizable': resizable,
-        'cps-dialog-draggable': draggable && !maximized,
-        'cps-dialog-dragging': dragging,
-        'cps-dialog-maximized': maximized
-      }"
+      data-testid="cps-dialog"
+      class="cps-dialog"
+      [class.cps-dialog-resizable]="resizable"
+      [class.cps-dialog-draggable]="draggable && !maximized"
+      [class.cps-dialog-dragging]="dragging"
+      [class.cps-dialog-maximized]="maximized"
       [ngStyle]="config.style"
       [class]="config.styleClass || ''"
       [@animation]="{
@@ -55,18 +64,20 @@
       @if (config.showHeader !== false) {
         <div
           #header
+          data-testid="cps-dialog-header"
           class="cps-dialog-header"
-          [ngClass]="{
-            'cps-dialog-header-left-bordered':
-              config.showHeaderLeftBorder !== false,
-            'cps-dialog-header-bottom-bordered':
-              config.showHeaderBottomBorder !== false
-          }"
+          [class.cps-dialog-header-left-bordered]="
+            config.showHeaderLeftBorder !== false
+          "
+          [class.cps-dialog-header-bottom-bordered]="
+            config.showHeaderBottomBorder !== false
+          "
           (mousedown)="initDrag($event)">
           @if (draggable && !maximized) {
             <cps-icon
               #dragHandle
               class="cps-dialog-drag-handle"
+              data-testid="cps-dialog-drag-handle"
               icon="dots"
               role="button"
               tabindex="0"
@@ -77,7 +88,9 @@
             </cps-icon>
           }
           <div class="cps-dialog-header-left">
-            <div class="cps-dialog-header-icon">
+            <div
+              class="cps-dialog-header-icon"
+              data-testid="cps-dialog-header-icon">
               @if (config.headerIcon) {
                 <cps-icon
                   [icon]="config.headerIcon"
@@ -85,10 +98,14 @@
                 </cps-icon>
               }
             </div>
-            <span class="cps-dialog-header-title">{{
-              config.headerTitle
-            }}</span>
-            <div class="cps-dialog-header-info-circle">
+            <span
+              class="cps-dialog-header-title"
+              data-testid="cps-dialog-header-title"
+              >{{ config.headerTitle }}</span
+            >
+            <div
+              class="cps-dialog-header-info-circle"
+              data-testid="cps-dialog-header-info-circle">
               @if (config.headerInfoTooltip) {
                 <cps-info-circle
                   size="small"
@@ -102,6 +119,7 @@
             @if (maximizable) {
               <cps-button
                 class="cps-dialog-header-action-button"
+                data-testid="cps-dialog-maximize-btn"
                 [icon]="maximized ? 'minimize' : 'maximize'"
                 [ariaLabel]="maximized ? 'Minimize dialog' : 'Maximize dialog'"
                 size="small"
@@ -114,6 +132,7 @@
             @if (config.showCloseBtn !== false) {
               <cps-button
                 class="cps-dialog-header-action-button"
+                data-testid="cps-dialog-close-btn"
                 icon="close-x-2"
                 ariaLabel="Close dialog"
                 size="small"
@@ -130,6 +149,7 @@
       <div
         #content
         class="cps-dialog-content"
+        data-testid="cps-dialog-content"
         [ngStyle]="config.contentStyle"
         [class]="config.contentStyleClass || ''">
         <ng-template cpsDialogContent></ng-template>
@@ -137,6 +157,7 @@
       @if (resizable && !maximized) {
         <div
           class="cps-dialog-resizable-handle"
+          data-testid="cps-dialog-resize-handle"
           style="z-index: 90"
           tabindex="0"
           role="button"
@@ -147,6 +168,7 @@
           (keyup)="onResizeHandleKeyup($event)">
           <span
             class="cps-dialog-resizable-handle-grip"
+            data-testid="cps-dialog-resize-handle-grip"
             aria-hidden="true"></span>
         </div>
       }


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for dialog component, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite (which runs under `NoopAnimationsModule` and calls internal methods directly): real open -> real focus management -> real close -> real focus restoration to the trigger element; real Escape closing only the topmost of several open dialogs (the real z-index-based check); a real backdrop-click closing a modal dialog; a real non-modal dialog genuinely not blocking clicks to the page behind it (`pointer-events: none` hit-testing, unrenderable in JSDOM); a real focus trap wrapping Tab/Shift+Tab between the first and last focusable elements; real keyboard-driven and real mouse-driven drag/resize (two separate code paths - Jest only covers the no-op guard conditions for either); a real maximize/minimize toggle producing an actual viewport-filling layout; `disableClose: true` genuinely blocking Escape, backdrop click, and the close button all at once; a real accessible-name computation via `ariaLabel` on a header-less dialog; and a real confirm/cancel round trip through the built-in confirmation dialog content.
- Added `data-testid` attributes to `cps-dialog`'s internal template (mask, dialog box, header, header title/icon/info-circle, drag handle, maximize/minimize button, close button, resize handle and its grip, content) so consumer apps have stable selectors for their own tests.
- Same for the built-in `CpsConfirmationComponent` dialog content: added `cps-confirmation`, `cps-confirmation-subtitle`, and `cps-confirmation-no-btn`, and renamed the pre-existing, inconsistently-named `btn-yes` to `cps-confirmation-yes-btn`.
- Added a "Header-less dialog with an aria-label" example to the `/dialog` demo page, showcasing the previously-undemonstrated `ariaLabel` + `showHeader: false` combination (every other example relied on `headerTitle` for the accessible name).

---

Release notes:
- added Playwright E2E coverage for dialog component
- added test ids to dialog component
