### PR TITLE
test: add Playwright coverage and test ids for CpsDividerComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-divider.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-divider.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+test.describe('cps-divider', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/divider');
+  });
+
+  test.describe('Real horizontal border rendering', () => {
+    test('the default divider renders a real top border and no right border', async ({
+      page
+    }) => {
+      const divider = example(page, 'horizontal-divider-example').locator(
+        'cps-divider'
+      );
+
+      await expect(divider).toHaveCSS('border-top-style', 'solid');
+      await expect(divider).not.toHaveCSS('border-top-width', '0px');
+      await expect(divider).toHaveCSS('border-right-style', 'none');
+    });
+  });
+
+  test.describe('Real vertical border rendering', () => {
+    test('a vertical divider renders a real right border and no top border', async ({
+      page
+    }) => {
+      const divider = example(page, 'vertical-divider-example')
+        .locator('cps-divider')
+        .first();
+
+      await expect(divider).toHaveCSS('border-right-style', 'solid');
+      await expect(divider).not.toHaveCSS('border-right-width', '0px');
+      await expect(divider).toHaveCSS('border-top-style', 'none');
+    });
+  });
+
+  test.describe('Real color-resolution and thickness rendering', () => {
+    test('a raw CSS color keyword renders literally, and thickness/type are reflected in the real computed border', async ({
+      page
+    }) => {
+      const divider = example(page, 'dashed-thick-red-divider-example').locator(
+        'cps-divider'
+      );
+
+      await expect(divider).toHaveCSS('border-top-style', 'dashed');
+      await expect(divider).toHaveCSS('border-top-width', '4px');
+      await expect(divider).toHaveCSS('border-top-color', 'rgb(255, 0, 0)');
+    });
+  });
+
+  test.describe('Real dotted border rendering', () => {
+    test('type="dotted" is reflected in the real computed border style', async ({
+      page
+    }) => {
+      const divider = example(page, 'dotted-divider-example').locator(
+        'cps-divider'
+      );
+
+      await expect(divider).toHaveCSS('border-top-style', 'dotted');
+      await expect(divider).not.toHaveCSS('border-top-width', '0px');
+    });
+  });
+});

--- a/projects/composition/src/app/pages/divider-page/divider-page.component.html
+++ b/projects/composition/src/app/pages/divider-page/divider-page.component.html
@@ -2,7 +2,7 @@
   <app-code-example
     label="Horizontal divider"
     [htmlCode]="examples.horizontalDivider.html">
-    <div>
+    <div data-testid="horizontal-divider-example">
       <p>First row</p>
       <cps-divider></cps-divider>
       <p>Second row</p>
@@ -11,7 +11,7 @@
   <app-code-example
     label="Vertical divider"
     [htmlCode]="examples.verticalDivider.html">
-    <div class="vertical-section">
+    <div class="vertical-section" data-testid="vertical-divider-example">
       <p>First column</p>
       <cps-divider [vertical]="true"></cps-divider>
       <p>Second column</p>
@@ -22,9 +22,18 @@
   <app-code-example
     label="Dashed, thick and red divider"
     [htmlCode]="examples.dashedThickRedDivider.html">
-    <div>
+    <div data-testid="dashed-thick-red-divider-example">
       <p>First row</p>
       <cps-divider thickness="0.25rem" color="red" type="dashed"></cps-divider>
+      <p>Second row</p>
+    </div>
+  </app-code-example>
+  <app-code-example
+    label="Dotted divider"
+    [htmlCode]="examples.dottedDivider.html">
+    <div data-testid="dotted-divider-example">
+      <p>First row</p>
+      <cps-divider type="dotted"></cps-divider>
       <p>Second row</p>
     </div>
   </app-code-example>

--- a/projects/composition/src/app/pages/divider-page/divider-page.examples.ts
+++ b/projects/composition/src/app/pages/divider-page/divider-page.examples.ts
@@ -22,5 +22,12 @@ export const dividerExamples: Record<string, { html: string; ts?: string }> = {
 <p>First row</p>
 <cps-divider thickness="0.25rem" color="red" type="dashed"></cps-divider>
 <p>Second row</p>`
+  },
+
+  dottedDivider: {
+    html: `
+<p>First row</p>
+<cps-divider type="dotted"></cps-divider>
+<p>Second row</p>`
   }
 };

--- a/projects/cps-ui-kit/src/lib/components/cps-divider/cps-divider.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-divider/cps-divider.component.ts
@@ -23,6 +23,7 @@ export type CpsDividerType = 'solid' | 'dashed' | 'dotted';
   selector: 'cps-divider',
   host: {
     class: 'cps-divider',
+    'data-testid': 'cps-divider',
     role: 'separator',
     '[attr.aria-orientation]': 'vertical() ? "vertical" : "horizontal"',
     '[style.border-top]': 'borderTop()',


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsDividerComponent`, covering real computed CSS that Jest/JSDOM can't reliably verify (the component has no template - its entire visual presence is host-bound inline styles): a real top border rendering by default and no right border; a real right border rendering (and no top border) when `vertical` is set; and real color/thickness/style resolution on a divider using a raw CSS color keyword (`color="red"`) rather than a design-token name, confirming `isValidCSSColor` correctly renders it literally instead of tokenizing it into a CSS variable, with `thickness="0.25rem"` and `type="dashed"` reflected in the real computed border.
- Added `data-testid="cps-divider"` to the library component's host metadata so consumer apps have a stable selector.
- Added a "Dotted divider" example (`type="dotted"`) to `/divider` - the only `type` variant with no live example before this.

---

Release notes:
- added Playwright E2E coverage for cps-divider component
- added test ids to cps-divider component