### PR TITLE
test: add Playwright coverage and test ids for CpsExpansionPanelComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-expansion-panel.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-expansion-panel.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function panel(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+function resolveCssColorVar(page: Page, varName: string): Promise<string> {
+  return page.evaluate((name) => {
+    const probe = document.createElement('div');
+    probe.style.color = `var(${name})`;
+    document.body.appendChild(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    return resolved;
+  }, varName);
+}
+
+test.describe('cps-expansion-panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/expansion-panel');
+  });
+
+  test.describe('Real click toggle reaches the real final post-animation state', () => {
+    test('clicking the header expands and collapses the real content, past the AnimationBuilder pipeline', async ({
+      page
+    }) => {
+      const header = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-header'
+      );
+      const content = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-content'
+      );
+
+      await expect(content).toHaveCSS('visibility', 'hidden');
+      await expect(content).toHaveAttribute('aria-hidden', 'true');
+
+      await header.click();
+
+      await expect(content).toHaveCSS('visibility', 'visible');
+      await expect(content).toHaveAttribute('aria-hidden', 'false');
+      await expect(content).not.toHaveCSS('height', '0px');
+      await expect(content).not.toHaveCSS('overflow', 'hidden');
+
+      await header.click();
+
+      await expect(content).toHaveCSS('visibility', 'hidden');
+      await expect(content).toHaveAttribute('aria-hidden', 'true');
+      await expect(content).toHaveCSS('height', '0px');
+    });
+  });
+
+  test.describe('Real keyboard toggle', () => {
+    test('Enter expands and Space collapses the real content', async ({
+      page
+    }) => {
+      const header = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-header'
+      );
+      const content = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-content'
+      );
+
+      await header.focus();
+      await page.keyboard.press('Enter');
+
+      await expect(content).toHaveCSS('visibility', 'visible');
+      await expect(header).toHaveAttribute('aria-expanded', 'true');
+      await expect(content).not.toHaveCSS('overflow', 'hidden');
+
+      await page.keyboard.press('Space');
+
+      await expect(content).toHaveCSS('visibility', 'hidden');
+      await expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  test.describe('Real header border-bottom animation', () => {
+    test('the bordered header gets a real border-bottom once expanded, and loses it once collapsed', async ({
+      page
+    }) => {
+      const header = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-header'
+      );
+      const content = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-content'
+      );
+
+      await expect(header).toHaveCSS('border-bottom-style', 'none');
+
+      await header.click();
+
+      await expect(header).toHaveCSS('border-bottom-style', 'solid');
+      await expect(content).not.toHaveCSS('overflow', 'hidden');
+
+      await header.click();
+
+      await expect(header).toHaveCSS('border-bottom-style', 'none');
+    });
+  });
+
+  test.describe('Real disabled panel blocks interaction', () => {
+    test('the disabled header blocks real pointer interaction and is removed from the tab order', async ({
+      page
+    }) => {
+      const header = panel(page, 'disabled-panel').getByTestId(
+        'cps-expansion-panel-header'
+      );
+      const content = panel(page, 'disabled-panel').getByTestId(
+        'cps-expansion-panel-content'
+      );
+
+      await expect(header).toHaveAttribute('tabindex', '-1');
+      await expect(header).toHaveCSS('pointer-events', 'none');
+
+      await expect(content).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  test.describe('Real color resolution - default token borderColor', () => {
+    test('the default borderColor token resolves through a real CSS variable', async ({
+      page
+    }) => {
+      const header = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-header'
+      );
+      const content = panel(page, 'bordered-transparent-panel').getByTestId(
+        'cps-expansion-panel-content'
+      );
+
+      await header.click();
+      await expect(content).not.toHaveCSS('overflow', 'hidden');
+
+      const expectedTokenColor = await resolveCssColorVar(
+        page,
+        '--cps-color-line-light'
+      );
+      await expect(header).toHaveCSS('border-bottom-color', expectedTokenColor);
+    });
+  });
+
+  test.describe('Real color resolution - raw CSS keyword backgroundColor', () => {
+    test('a raw CSS keyword backgroundColor renders literally', async ({
+      page
+    }) => {
+      const whitePanelRoot = panel(page, 'borderless-white-panel').getByTestId(
+        'cps-expansion-panel'
+      );
+      await expect(whitePanelRoot).toHaveCSS(
+        'background-color',
+        'rgb(255, 255, 255)'
+      );
+    });
+  });
+
+  test.describe('Real color resolution - custom token borderColor', () => {
+    test('a custom borderColor token resolves through a real CSS variable', async ({
+      page
+    }) => {
+      const customColorHeader = panel(
+        page,
+        'custom-border-color-panel'
+      ).getByTestId('cps-expansion-panel-header');
+
+      await customColorHeader.click();
+
+      const expectedCustomColor = await resolveCssColorVar(
+        page,
+        '--cps-color-calm'
+      );
+      await expect(customColorHeader).toHaveCSS(
+        'border-bottom-color',
+        expectedCustomColor
+      );
+    });
+  });
+});

--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.html
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.component.html
@@ -5,6 +5,7 @@
       label="Bordered panel with transparent background"
       [htmlCode]="examples.borderedTransparentBackground.html">
       <cps-expansion-panel
+        data-testid="bordered-transparent-panel"
         headerTitle="Bordered panel with transparent background">
         <div>
           <cps-button label="Sample button"></cps-button>
@@ -15,7 +16,10 @@
     <app-code-example
       label="Disabled panel"
       [htmlCode]="examples.disabledPanel.html">
-      <cps-expansion-panel headerTitle="Disabled panel" [disabled]="true">
+      <cps-expansion-panel
+        data-testid="disabled-panel"
+        headerTitle="Disabled panel"
+        [disabled]="true">
         <div>Some content</div>
       </cps-expansion-panel>
     </app-code-example>
@@ -35,6 +39,7 @@
       label="Borderless panel with white background"
       [htmlCode]="examples.borderlessWhiteBackground.html">
       <cps-expansion-panel
+        data-testid="borderless-white-panel"
         headerTitle="Borderless panel with white background"
         backgroundColor="white"
         [bordered]="false">
@@ -62,6 +67,17 @@
         backgroundColor="white"
         borderRadius="0.25rem"
         width="32rem">
+        <div>Some content</div>
+      </cps-expansion-panel>
+    </app-code-example>
+
+    <app-code-example
+      label="Panel with custom border color"
+      [htmlCode]="examples.customBorderColor.html">
+      <cps-expansion-panel
+        data-testid="custom-border-color-panel"
+        headerTitle="Bordered panel with a custom border color"
+        borderColor="calm">
         <div>Some content</div>
       </cps-expansion-panel>
     </app-code-example>

--- a/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.examples.ts
+++ b/projects/composition/src/app/pages/expansion-panel-page/expansion-panel-page.examples.ts
@@ -59,5 +59,14 @@ export const expansionPanelExamples: Record<
   width="32rem">
   <div>Some content</div>
 </cps-expansion-panel>`
+  },
+
+  customBorderColor: {
+    html: `
+<cps-expansion-panel
+  headerTitle="Bordered panel with a custom border color"
+  borderColor="calm">
+  <div>Some content</div>
+</cps-expansion-panel>`
   }
 };

--- a/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.html
@@ -1,5 +1,6 @@
 <div
   class="cps-expansion-panel"
+  data-testid="cps-expansion-panel"
   [class.expanded]="isExpanded"
   [style.background-color]="cvtBackgroundColor"
   [style.border-radius]="cvtBorderRadius"
@@ -7,6 +8,7 @@
   [style.border]="bordered ? '1px solid ' + cvtBorderColor : ''">
   <div
     class="cps-expansion-panel-header"
+    data-testid="cps-expansion-panel-header"
     role="button"
     [attr.tabindex]="disabled ? -1 : 0"
     [attr.aria-expanded]="isExpanded"
@@ -23,11 +25,15 @@
     [class.disabled]="disabled"
     [class.keyboard-active]="isKeyboardActive"
     [style.cursor]="disabled ? 'default' : 'pointer'"
+    [style.border-bottom-left-radius]="isExpanded ? '0' : null"
+    [style.border-bottom-right-radius]="isExpanded ? '0' : null"
     (click)="toggleExpansion()"
     (keydown)="onHeaderKeydown($event)"
     (keyup)="onHeaderKeyup($event)">
     @if (prefixIcon) {
-      <span class="cps-expansion-panel-prefix-icon">
+      <span
+        class="cps-expansion-panel-prefix-icon"
+        data-testid="cps-expansion-panel-prefix-icon">
         <cps-icon
           [icon]="prefixIcon"
           size="small"
@@ -35,9 +41,15 @@
         </cps-icon>
       </span>
     }
-    <div class="cps-expansion-panel-title">{{ headerTitle }}</div>
+    <div
+      class="cps-expansion-panel-title"
+      data-testid="cps-expansion-panel-title">
+      {{ headerTitle }}
+    </div>
     @if (showChevron && !disabled) {
-      <span class="cps-expansion-panel-chevron">
+      <span
+        class="cps-expansion-panel-chevron"
+        data-testid="cps-expansion-panel-chevron">
         <cps-icon icon="chevron-down" size="small" color="text-dark">
         </cps-icon>
       </span>
@@ -45,6 +57,7 @@
   </div>
   <div
     class="cps-expansion-panel-content"
+    data-testid="cps-expansion-panel-content"
     #panelContentElem
     [id]="contentPanelId"
     [attr.aria-hidden]="!isExpanded">

--- a/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.spec.ts
@@ -126,6 +126,27 @@ describe('CpsExpansionPanelComponent', () => {
     expect(component.cvtBorderRadius).toBe('1rem');
   });
 
+  it('should square the header bottom corners when expanded with a border radius set', () => {
+    fixture.componentRef.setInput('borderRadius', '1rem');
+    component.toggleExpansion();
+    fixture.detectChanges();
+    const header = fixture.nativeElement.querySelector(
+      '.cps-expansion-panel-header'
+    );
+    expect(header.style.borderBottomLeftRadius).toBe('0');
+    expect(header.style.borderBottomRightRadius).toBe('0');
+  });
+
+  it('should not override the header bottom corners when collapsed with a border radius set', () => {
+    fixture.componentRef.setInput('borderRadius', '1rem');
+    fixture.detectChanges();
+    const header = fixture.nativeElement.querySelector(
+      '.cps-expansion-panel-header'
+    );
+    expect(header.style.borderBottomLeftRadius).toBe('');
+    expect(header.style.borderBottomRightRadius).toBe('');
+  });
+
   it('should update cvtWidth via ngOnChanges', () => {
     fixture.componentRef.setInput('width', 400);
     fixture.detectChanges();

--- a/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-expansion-panel/cps-expansion-panel.component.ts
@@ -13,7 +13,10 @@ import {
   inject,
   type SimpleChanges
 } from '@angular/core';
-import { CpsIconComponent, IconType } from '../cps-icon/cps-icon.component';
+import {
+  CpsIconComponent,
+  type IconType
+} from '../cps-icon/cps-icon.component';
 import { getCSSColor } from '../../utils/colors-utils/colors-utils';
 import { convertSize } from '../../utils/internal/size-utils/size-utils';
 import { generateUniqueId } from '../../utils/internal/accessibility-utils/accessibility-utils';


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsExpansionPanelComponent`, covering behavior that requires a real browser and isn't exercised by the existing Jest unit suite (every interaction there is driven by calling `toggleExpansion()`/`onHeaderKeydown()` directly, never through real DOM events, and Angular's `AnimationBuilder`-driven height animation never actually runs to completion in the test environment): a real click on the header toggling expansion and the `AnimationBuilder` -> `onDone` pipeline genuinely completing (real computed `height`/`visibility` reaching their final collapsed/expanded values, not just the state flag flipping); real keyboard activation (`Enter`/`Space`) producing the same real outcome; the declarative `@panelHeader` trigger actually rendering a real `border-bottom` on expand and removing it on collapse; the disabled panel's header genuinely blocking real pointer interaction (`pointer-events: none`) and being removed from the tab order (`tabindex="-1"`); and real color resolution for a design-token `borderColor` (default and custom values) and a raw CSS keyword `backgroundColor`, the same `getCSSColor`/`isValidCSSColor` real-browser-sensitive mechanism as `CpsDividerComponent`'s `color` input.
- Added `data-testid` attributes to the library component's template (root, header, content, title, chevron, prefix icon) so consumer apps have stable selectors for their own tests.
- Added a "Panel with custom border color" example (`borderColor="calm"`) - the only input with zero live example away from its default before this.
- Fixed a visual bug: the header kept fully rounded corners even while expanded, so with a non-zero `borderRadius` its bottom-left/bottom-right corners stayed rounded against the now-visible content edge below it. Fixed with two conditional inline-style bindings on the header (`border-bottom-left/right-radius` -> `'0'` while expanded, `null`/inherited otherwise), covered by two new Jest tests.

#### TODO: Merge with `feat: add test ids to expansion panel component and fix header bottom border radius`

---

Release notes:
- added Playwright E2E coverage for cps-expansion-panel component
- added test ids to cps-expansion-panel component
- fixed cps-expansion-panel header bottom border radius