### PR TITLE
test: add Playwright coverage and test ids for CpsFileUploadComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-file-upload.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-file-upload.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+test.describe('cps-file-upload', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/file-upload');
+  });
+
+  test.describe('Real file selection accepts a matching file', () => {
+    test('a real file picked through the hidden input is uploaded and announced', async ({
+      page
+    }) => {
+      const panel = example(page, 'extension-dependent-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('fake image data')
+      });
+
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toBeVisible();
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file-name')
+      ).toHaveText('photo.jpg');
+      await expect(panel.locator('.cps-sr-only')).toHaveText(
+        'File successfully uploaded'
+      );
+    });
+  });
+
+  test.describe('Real extension validation rejects a mismatched file', () => {
+    test('a real file with an unsupported extension shows a real error and is announced', async ({
+      page
+    }) => {
+      const panel = example(page, 'extension-dependent-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'notes.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('nope')
+      });
+
+      const errorBox = panel.getByTestId('cps-file-upload-error');
+      await expect(errorBox).toBeVisible();
+      await expect(errorBox).toContainText('Unsupported file type');
+      await expect(panel.locator('.cps-sr-only')).toHaveText(
+        'Unsupported file type'
+      );
+    });
+  });
+
+  test.describe('Real dragover visual state', () => {
+    test('a real dragenter highlights the dropzone, and dragleave reverts it', async ({
+      page
+    }) => {
+      const panel = example(page, 'extension-dependent-file-upload');
+      const dropzone = panel.getByTestId('cps-file-upload-dropzone');
+
+      await expect(dropzone).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+      await dropzone.dispatchEvent('dragenter');
+      await expect(dropzone).toHaveCSS(
+        'background-color',
+        'rgb(239, 228, 231)'
+      );
+
+      await dropzone.dispatchEvent('dragleave');
+      await expect(dropzone).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+    });
+  });
+
+  test.describe('Real disabled dropzone blocks interaction', () => {
+    test('the disabled dropzone is genuinely disabled and blocks real pointer interaction', async ({
+      page
+    }) => {
+      const panel = example(page, 'disabled-file-upload');
+
+      await expect(
+        panel.getByTestId('cps-file-upload-dropzone')
+      ).toBeDisabled();
+      await expect(panel.getByTestId('cps-file-upload')).toHaveCSS(
+        'pointer-events',
+        'none'
+      );
+    });
+  });
+
+  test.describe('Real focus restoration after removing an uploaded file', () => {
+    test('clicking remove restores real focus to the dropzone', async ({
+      page
+    }) => {
+      const panel = example(page, 'extension-dependent-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('data')
+      });
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toBeVisible();
+
+      const dropzone = panel.getByTestId('cps-file-upload-dropzone');
+      await panel.getByTestId('cps-file-upload-remove-btn').click();
+
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toHaveCount(0);
+      await expect(dropzone).toBeFocused();
+    });
+  });
+
+  test.describe('Real async processing pipeline reaches its true completion', () => {
+    test('the real progress bar shows while processing and the real success outcome lands after the real async callback resolves', async ({
+      page
+    }) => {
+      const panel = example(page, 'extra-info-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('data')
+      });
+
+      const progressBar = panel.getByTestId('cps-file-upload-progress-bar');
+      const dropzone = panel.getByTestId('cps-file-upload-dropzone');
+      await expect(progressBar).toBeVisible();
+      await expect(dropzone).toHaveCSS('pointer-events', 'none');
+      await expect(panel.locator('.cps-sr-only')).toHaveText(
+        'File is being processed'
+      );
+
+      await expect(progressBar).toBeHidden({ timeout: 8000 });
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toBeVisible();
+      await expect(dropzone).not.toHaveCSS('pointer-events', 'none');
+    });
+  });
+
+  test.describe('Real cancel stops a real pending async operation', () => {
+    test('cancelling before the real callback resolves removes the file well before the delay elapses', async ({
+      page
+    }) => {
+      const panel = example(page, 'extra-info-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('data')
+      });
+
+      const cancelBtn = panel.getByTestId('cps-file-upload-cancel-btn');
+      await expect(cancelBtn).toBeVisible();
+      await cancelBtn.click();
+
+      const dropzone = panel.getByTestId('cps-file-upload-dropzone');
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toHaveCount(0, { timeout: 1000 });
+      await expect(dropzone).toBeFocused();
+    });
+  });
+
+  test.describe('Real async processing pipeline reaches its true failure outcome', () => {
+    test('a real failing processing callback shows the real failure error and removes the file', async ({
+      page
+    }) => {
+      const panel = example(page, 'failing-processing-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('data')
+      });
+
+      const progressBar = panel.getByTestId('cps-file-upload-progress-bar');
+      await expect(progressBar).toBeVisible();
+
+      await expect(progressBar).toBeHidden({ timeout: 3000 });
+      const errorBox = panel.getByTestId('cps-file-upload-error');
+      await expect(errorBox).toBeVisible();
+      await expect(errorBox).toContainText('File processing failed');
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toHaveCount(0);
+      await expect(panel.locator('.cps-sr-only')).toHaveText(
+        'File processing failed'
+      );
+    });
+  });
+
+  test.describe('Real accessible-name computation', () => {
+    test('a custom ariaLabel exposes the real accessible name on the dropzone', async ({
+      page
+    }) => {
+      const panel = example(page, 'extra-info-file-upload');
+
+      await expect(
+        panel.getByRole('button', { name: 'Upload pictures or PDFs' })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Real tooltip on hover', () => {
+    test('hovering the uploaded file name shows the real tooltip with the full file name', async ({
+      page
+    }) => {
+      const panel = example(page, 'extra-info-file-upload');
+      const input = panel.getByTestId('cps-file-upload-input');
+
+      await input.setInputFiles({
+        name: 'a-fairly-long-file-name-for-tooltip.jpg',
+        mimeType: 'image/jpeg',
+        buffer: Buffer.from('data')
+      });
+      await expect(
+        panel.getByTestId('cps-file-upload-uploaded-file')
+      ).toBeVisible();
+
+      await panel.getByTestId('cps-file-upload-uploaded-file-name').hover();
+
+      const tooltip = page.locator('.cps-tooltip');
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toHaveText(
+        'a-fairly-long-file-name-for-tooltip.jpg'
+      );
+    });
+  });
+});

--- a/playwright/cps-ui-kit/components/cps-file-upload.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-file-upload.spec.ts
@@ -63,16 +63,13 @@ test.describe('cps-file-upload', () => {
       const panel = example(page, 'extension-dependent-file-upload');
       const dropzone = panel.getByTestId('cps-file-upload-dropzone');
 
-      await expect(dropzone).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+      await expect(dropzone).not.toHaveClass(/dragged-over/);
 
       await dropzone.dispatchEvent('dragenter');
-      await expect(dropzone).toHaveCSS(
-        'background-color',
-        'rgb(239, 228, 231)'
-      );
+      await expect(dropzone).toHaveClass(/dragged-over/);
 
       await dropzone.dispatchEvent('dragleave');
-      await expect(dropzone).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+      await expect(dropzone).not.toHaveClass(/dragged-over/);
     });
   });
 

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.html
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.html
@@ -13,6 +13,7 @@
       </cps-button-toggle>
       <cps-file-upload
         #fileUpload
+        data-testid="extension-dependent-file-upload"
         [extensions]="[selectedFileUploadType.value]"
         [fileDesc]="selectedFileUploadType!.label || ''"
         width="25rem"
@@ -29,6 +30,7 @@
     [htmlCode]="examples.withExtraInfo.html"
     [tsCode]="examples.withExtraInfo.ts">
     <cps-file-upload
+      data-testid="extra-info-file-upload"
       [extensions]="['.jpg', '.png', 'pdf']"
       [fileInfo]="fileInfo"
       fileDesc="Pictures or PDFs"
@@ -46,11 +48,27 @@
   </app-code-example>
 
   <app-code-example
+    label="File upload component with a failing processing callback"
+    [htmlCode]="examples.failingProcessingCallback.html"
+    [tsCode]="examples.failingProcessingCallback.ts">
+    <cps-file-upload
+      data-testid="failing-processing-file-upload"
+      [extensions]="['.jpg', '.png', 'pdf']"
+      fileDesc="Pictures or PDFs"
+      width="31.25rem"
+      [fileProcessingCallback]="processFailingUploadedFile"
+      (fileProcessingFailed)="onFileProcessingFailed($event)"
+      (fileUploaded)="onFileUploaded($event)">
+    </cps-file-upload>
+  </app-code-example>
+
+  <app-code-example
     label="Disabled file upload component"
     [htmlCode]="examples.disabledFileUpload.html"
     [tsCode]="examples.disabledFileUpload.ts">
     <div class="file-upload-with-toggle">
       <cps-file-upload
+        data-testid="disabled-file-upload"
         [extensions]="['.jpg', '.png', 'pdf']"
         [fileInfo]="fileInfo"
         fileDesc="Pictures or PDFs"

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.ts
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.component.ts
@@ -58,6 +58,10 @@ export class FileUploadPageComponent {
     );
   }
 
+  processFailingUploadedFile(): Observable<boolean> {
+    return of(false).pipe(delay(500));
+  }
+
   onFileUploaded(file: File) {
     console.log('File uploaded', file?.name);
   }

--- a/projects/composition/src/app/pages/file-upload-page/file-upload-page.examples.ts
+++ b/projects/composition/src/app/pages/file-upload-page/file-upload-page.examples.ts
@@ -114,6 +114,30 @@ onFileExtensionChanged(event: string) {
       ts: fileUploadHandlersTs
     },
 
+    failingProcessingCallback: {
+      html: `
+<cps-file-upload
+  [extensions]="['.jpg', '.png', 'pdf']"
+  fileDesc="Pictures or PDFs"
+  width="31.25rem"
+  [fileProcessingCallback]="processFailingUploadedFile"
+  (fileProcessingFailed)="onFileProcessingFailed($event)"
+  (fileUploaded)="onFileUploaded($event)">
+</cps-file-upload>`,
+      ts: `
+processFailingUploadedFile(): Observable<boolean> {
+  return of(false).pipe(delay(500));
+}
+
+onFileProcessingFailed(fileName: string) {
+  console.log('File processing failed', fileName);
+}
+
+onFileUploaded(file: File) {
+  console.log('File uploaded', file?.name);
+}`
+    },
+
     disabledFileUpload: {
       html: `
 <cps-file-upload

--- a/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.html
@@ -1,5 +1,6 @@
 <div
   class="cps-file-upload"
+  data-testid="cps-file-upload"
   [class.disabled]="disabled"
   [style.width]="cvtWidth()">
   <div class="cps-sr-only" aria-live="polite" aria-atomic="true">
@@ -17,6 +18,7 @@
     #dropzoneButton
     type="button"
     class="cps-file-upload-dropzone"
+    data-testid="cps-file-upload-dropzone"
     [ngClass]="{
       'dragged-over': isDragoverFile,
       'with-bottom-section': uploadedFile?.name || errorMessage
@@ -32,6 +34,7 @@
     [attr.aria-label]="ariaLabel">
     <input
       #fileInput
+      data-testid="cps-file-upload-input"
       (change)="tryUploadFile($event)"
       type="file"
       [accept]="extensionsString"
@@ -40,11 +43,15 @@
       icon="export"
       size="large"
       [color]="disabled ? 'text-mild' : 'text-darkest'"></cps-icon>
-    <div class="cps-file-upload-dropzone-title">
+    <div
+      class="cps-file-upload-dropzone-title"
+      data-testid="cps-file-upload-dropzone-title">
       Drag&Drop or choose a file to upload
     </div>
     @if (fileDesc || extensionsStringAsterisks) {
-      <span class="cps-file-upload-dropzone-file-desc"
+      <span
+        class="cps-file-upload-dropzone-file-desc"
+        data-testid="cps-file-upload-dropzone-file-desc"
         >{{ fileDesc }}
         {{
           extensionsStringAsterisks ? '(' + extensionsStringAsterisks + ')' : ''
@@ -52,7 +59,9 @@
       >
     }
     @if (fileInfo) {
-      <div class="cps-file-upload-dropzone-content">
+      <div
+        class="cps-file-upload-dropzone-content"
+        data-testid="cps-file-upload-dropzone-content">
         <cps-icon
           [color]="disabled ? 'text-mild' : 'info'"
           icon="info-circle"
@@ -67,24 +76,32 @@
         opacity="0.3"
         [color]="disabled ? 'text-mild' : 'calm'"
         class="cps-file-upload-progress-bar"
+        data-testid="cps-file-upload-progress-bar"
         bgColor="transparent">
       </cps-progress-linear>
     }
   </button>
   @if (errorMessage) {
-    <div class="cps-file-upload-error">
+    <div class="cps-file-upload-error" data-testid="cps-file-upload-error">
       <cps-icon
         icon="toast-error"
         [color]="disabled ? 'text-light' : 'error'"></cps-icon>
-      <span>{{ errorMessage }}</span>
+      <span data-testid="cps-file-upload-error-text">{{ errorMessage }}</span>
     </div>
   }
   @if (uploadedFile) {
-    <div class="cps-file-upload-uploaded-files">
-      <div class="cps-file-upload-uploaded-file">
-        <div class="cps-file-upload-uploaded-file-title">
+    <div
+      class="cps-file-upload-uploaded-files"
+      data-testid="cps-file-upload-uploaded-files">
+      <div
+        class="cps-file-upload-uploaded-file"
+        data-testid="cps-file-upload-uploaded-file">
+        <div
+          class="cps-file-upload-uploaded-file-title"
+          data-testid="cps-file-upload-uploaded-file-title">
           <cps-icon
             class="cps-file-upload-uploaded-file-status-icon"
+            data-testid="cps-file-upload-uploaded-file-status-icon"
             [icon]="isProcessingFile ? 'pending' : 'toast-success'"
             [color]="
               disabled ? 'text-light' : isProcessingFile ? 'warn' : 'success'
@@ -92,6 +109,7 @@
           </cps-icon>
           <div
             class="cps-file-upload-uploaded-file-name"
+            data-testid="cps-file-upload-uploaded-file-name"
             cpsTooltip="{{ uploadedFile.name }}"
             [tooltipPosition]="fileNameTooltipPosition"
             [tooltipOffset]="fileNameTooltipOffset"
@@ -104,6 +122,7 @@
             <button
               type="button"
               class="cps-file-upload-uploaded-file-cancel-process-btn"
+              data-testid="cps-file-upload-cancel-btn"
               aria-label="Cancel file processing"
               (click)="onCancelFileProcessing($event)">
               <cps-icon icon="close-x" color="error"></cps-icon>
@@ -112,6 +131,7 @@
             <button
               type="button"
               class="cps-file-upload-uploaded-file-remove-btn"
+              data-testid="cps-file-upload-remove-btn"
               aria-label="Remove uploaded file"
               (click)="onRemoveUploadedFile($event)">
               <cps-icon icon="remove" color="error"></cps-icon>

--- a/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.spec.ts
+++ b/projects/cps-ui-kit/src/lib/components/cps-file-upload/cps-file-upload.component.spec.ts
@@ -1,5 +1,35 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync
+} from '@angular/core/testing';
 import { CpsFileUploadComponent } from './cps-file-upload.component';
+import { Observable, of, throwError } from 'rxjs';
+
+function makeFileList(files: File[]): FileList {
+  const list: Record<number, File> & {
+    length: number;
+    item: (i: number) => File | null;
+  } = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null
+  };
+  files.forEach((file, i) => (list[i] = file));
+  return list as unknown as FileList;
+}
+
+function makeChangeEvent(file: File | null): Event {
+  const input = document.createElement('input');
+  Object.defineProperty(input, 'files', {
+    value: makeFileList(file ? [file] : []),
+    writable: false
+  });
+  const event = new Event('change');
+  Object.defineProperty(event, 'target', { value: input, writable: false });
+  return event;
+}
 
 describe('CpsFileUploadComponent', () => {
   let component: CpsFileUploadComponent;
@@ -55,5 +85,405 @@ describe('CpsFileUploadComponent', () => {
     expect(component.extensions).toEqual(['.jpg', '.png', '.gif']);
     expect(component.extensionsString).toBe('.jpg, .png, .gif');
     expect(component.extensionsStringAsterisks).toBe('*.jpg, *.png, *.gif');
+  });
+
+  describe('extension validation', () => {
+    it('should reject a file with an unsupported extension', () => {
+      const file = new File([''], 'document.pdf');
+      component.extensions = ['.jpg'];
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.uploadedFile).toBeUndefined();
+      expect(component.errorMessage).toBe('Unsupported file type');
+    });
+
+    it('should emit fileUploadFailed with the file name when the extension is rejected', () => {
+      const file = new File([''], 'document.pdf');
+      component.extensions = ['.jpg'];
+      jest.spyOn(component.fileUploadFailed, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.fileUploadFailed.emit).toHaveBeenCalledWith(
+        'document.pdf'
+      );
+    });
+
+    it('should accept any file when no extensions are configured', () => {
+      const file = new File([''], 'anything.xyz');
+      component.extensions = [];
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.uploadedFile).toBe(file);
+    });
+
+    it('should accept a file regardless of extension case', () => {
+      const file = new File([''], 'PHOTO.JPG');
+      component.extensions = ['.jpg'];
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.uploadedFile).toBe(file);
+    });
+  });
+
+  describe('file selection via the native file input', () => {
+    it('should upload a file selected through the change event', () => {
+      const file = new File([''], 'photo.jpg');
+      component.extensions = ['.jpg'];
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.uploadedFile).toBe(file);
+    });
+
+    it('should do nothing when the change event has no files', () => {
+      component.tryUploadFile(makeChangeEvent(null));
+
+      expect(component.uploadedFile).toBeUndefined();
+    });
+
+    it('should emit fileUploaded when a file is accepted', () => {
+      const file = new File([''], 'photo.jpg');
+      jest.spyOn(component.fileUploaded, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.fileUploaded.emit).toHaveBeenCalledWith(file);
+    });
+  });
+
+  describe('guards', () => {
+    it('should not process a new file while one is already being processed', () => {
+      component.isProcessingFile = true;
+      const file = new File([''], 'photo.jpg');
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.uploadedFile).toBeUndefined();
+    });
+
+    it('should open the file picker when not processing', () => {
+      const clickSpy = jest.spyOn(component.fileInput!.nativeElement, 'click');
+
+      component.openFilePicker();
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it('should not open the file picker while processing', () => {
+      component.isProcessingFile = true;
+      const clickSpy = jest.spyOn(component.fileInput!.nativeElement, 'click');
+
+      component.openFilePicker();
+
+      expect(clickSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drag state', () => {
+    it('should set isDragoverFile on drag enter', () => {
+      component.onDragEnter();
+
+      expect(component.isDragoverFile).toBe(true);
+    });
+
+    it('should keep isDragoverFile true while nested drag enters/leaves are unbalanced', () => {
+      component.onDragEnter();
+      component.onDragEnter();
+      component.onDragLeave();
+
+      expect(component.isDragoverFile).toBe(true);
+    });
+
+    it('should clear isDragoverFile once every drag enter has a matching drag leave', () => {
+      component.onDragEnter();
+      component.onDragEnter();
+      component.onDragLeave();
+      component.onDragLeave();
+
+      expect(component.isDragoverFile).toBe(false);
+    });
+
+    it('should reset drag state on drag end', () => {
+      component.onDragEnter();
+
+      component.onDragEnd();
+
+      expect(component.isDragoverFile).toBe(false);
+    });
+
+    it('should prevent default and set isDragoverFile on drag over', () => {
+      const event = new Event('dragover') as unknown as DragEvent;
+      const preventSpy = jest.spyOn(event, 'preventDefault');
+
+      component.onDragOver(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+      expect(component.isDragoverFile).toBe(true);
+    });
+  });
+
+  describe('removeUploadedFile', () => {
+    it('should clear the uploaded file and emit uploadedFileRemoved', () => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+      jest.spyOn(component.uploadedFileRemoved, 'emit');
+
+      component.removeUploadedFile();
+
+      expect(component.uploadedFile).toBeUndefined();
+      expect(component.uploadedFileRemoved.emit).toHaveBeenCalledWith(
+        'photo.jpg'
+      );
+    });
+
+    it('should not emit uploadedFileRemoved when there is no uploaded file', () => {
+      jest.spyOn(component.uploadedFileRemoved, 'emit');
+
+      component.removeUploadedFile();
+
+      expect(component.uploadedFileRemoved.emit).not.toHaveBeenCalled();
+    });
+
+    it('should reset the file input value', () => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+      const setSpy = jest.spyOn(
+        component.fileInput!.nativeElement,
+        'value',
+        'set'
+      );
+
+      component.removeUploadedFile();
+
+      expect(setSpy).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('resetState', () => {
+    it('should clear the error message, drag state, processing state and uploaded file', () => {
+      component.errorMessage = 'Unsupported file type';
+      component.isDragoverFile = true;
+      component.isProcessingFile = true;
+      component.uploadedFile = new File([''], 'photo.jpg');
+
+      component.resetState();
+
+      expect(component.errorMessage).toBe('');
+      expect(component.isDragoverFile).toBe(false);
+      expect(component.isProcessingFile).toBe(false);
+      expect(component.uploadedFile).toBeUndefined();
+    });
+  });
+
+  describe('focus restoration', () => {
+    it('should prevent default and stop propagation when removing the uploaded file', () => {
+      const event = new Event('click');
+      const preventSpy = jest.spyOn(event, 'preventDefault');
+      const stopSpy = jest.spyOn(event, 'stopPropagation');
+
+      component.onRemoveUploadedFile(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+      expect(stopSpy).toHaveBeenCalled();
+    });
+
+    it('should focus the dropzone button after removing the uploaded file', fakeAsync(() => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+      fixture.detectChanges();
+      const focusSpy = jest.spyOn(
+        component.dropzoneButton!.nativeElement,
+        'focus'
+      );
+
+      component.onRemoveUploadedFile(new Event('click'));
+      tick();
+
+      expect(focusSpy).toHaveBeenCalled();
+    }));
+
+    it('should prevent default and stop propagation when cancelling processing', () => {
+      const event = new Event('click');
+      const preventSpy = jest.spyOn(event, 'preventDefault');
+      const stopSpy = jest.spyOn(event, 'stopPropagation');
+
+      component.onCancelFileProcessing(event);
+
+      expect(preventSpy).toHaveBeenCalled();
+      expect(stopSpy).toHaveBeenCalled();
+    });
+
+    it('should focus the dropzone button after cancelling processing', fakeAsync(() => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+      component.isProcessingFile = true;
+      fixture.detectChanges();
+      const focusSpy = jest.spyOn(
+        component.dropzoneButton!.nativeElement,
+        'focus'
+      );
+
+      component.onCancelFileProcessing(new Event('click'));
+      tick();
+
+      expect(focusSpy).toHaveBeenCalled();
+    }));
+  });
+
+  describe('cancelFileProcessing', () => {
+    it('should emit fileProcessingCancelled with the file name', () => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+      jest.spyOn(component.fileProcessingCancelled, 'emit');
+
+      component.cancelFileProcessing();
+
+      expect(component.fileProcessingCancelled.emit).toHaveBeenCalledWith(
+        'photo.jpg'
+      );
+    });
+
+    it('should not emit fileProcessingCancelled when there is no uploaded file', () => {
+      jest.spyOn(component.fileProcessingCancelled, 'emit');
+
+      component.cancelFileProcessing();
+
+      expect(component.fileProcessingCancelled.emit).not.toHaveBeenCalled();
+    });
+
+    it('should remove the uploaded file', () => {
+      component.uploadedFile = new File([''], 'photo.jpg');
+
+      component.cancelFileProcessing();
+
+      expect(component.uploadedFile).toBeUndefined();
+    });
+
+    it('should set isProcessingFile to false', () => {
+      component.isProcessingFile = true;
+
+      component.cancelFileProcessing();
+
+      expect(component.isProcessingFile).toBe(false);
+    });
+  });
+
+  describe('fileProcessingCallback pipeline', () => {
+    it('should not enter a processing state when no callback is provided', () => {
+      const file = new File([''], 'photo.jpg');
+
+      component.tryUploadFile(makeChangeEvent(file));
+
+      expect(component.isProcessingFile).toBe(false);
+    });
+
+    it('should set isProcessingFile while pending and emit fileProcessed on success', fakeAsync(() => {
+      const file = new File([''], 'photo.jpg');
+      let resolveCallback!: (value: boolean) => void;
+      const pending$ = new Observable<boolean>((subscriber) => {
+        resolveCallback = (value: boolean) => {
+          subscriber.next(value);
+          subscriber.complete();
+        };
+      });
+      component.fileProcessingCallback = () => pending$;
+      jest.spyOn(component.fileProcessed, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+      expect(component.isProcessingFile).toBe(true);
+
+      resolveCallback(true);
+      tick();
+
+      expect(component.isProcessingFile).toBe(false);
+      expect(component.fileProcessed.emit).toHaveBeenCalledWith(file);
+    }));
+
+    it('should show a failure error, emit fileProcessingFailed and remove the file when the callback resolves false', fakeAsync(() => {
+      const file = new File([''], 'photo.jpg');
+      component.fileProcessingCallback = () => of(false);
+      jest.spyOn(component.fileProcessingFailed, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+      tick();
+
+      expect(component.isProcessingFile).toBe(false);
+      expect(component.errorMessage).toBe('File processing failed');
+      expect(component.fileProcessingFailed.emit).toHaveBeenCalledWith(
+        'photo.jpg'
+      );
+      expect(component.uploadedFile).toBeUndefined();
+    }));
+
+    it('should treat a thrown/errored callback the same as a resolved-false result', fakeAsync(() => {
+      const file = new File([''], 'photo.jpg');
+      component.fileProcessingCallback = () =>
+        throwError(() => new Error('boom'));
+      jest.spyOn(component.fileProcessingFailed, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+      tick();
+
+      expect(component.errorMessage).toBe('File processing failed');
+      expect(component.fileProcessingFailed.emit).toHaveBeenCalledWith(
+        'photo.jpg'
+      );
+    }));
+
+    it('should stop a pending callback from completing after it is cancelled', fakeAsync(() => {
+      const file = new File([''], 'photo.jpg');
+      let subscriberRef!: {
+        next: (value: boolean) => void;
+        complete: () => void;
+      };
+      const pending$ = new Observable<boolean>((subscriber) => {
+        subscriberRef = subscriber;
+      });
+      component.fileProcessingCallback = () => pending$;
+      jest.spyOn(component.fileProcessed, 'emit');
+      jest.spyOn(component.fileProcessingFailed, 'emit');
+
+      component.tryUploadFile(makeChangeEvent(file));
+      component.cancelFileProcessing();
+
+      subscriberRef.next(true);
+      subscriberRef.complete();
+      tick();
+
+      expect(component.fileProcessed.emit).not.toHaveBeenCalled();
+      expect(component.fileProcessingFailed.emit).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('ngOnChanges', () => {
+    it('should recompute extensionsString when the extensions input changes', () => {
+      component.extensions = ['.png'];
+
+      component.ngOnChanges({
+        extensions: {
+          currentValue: ['.png'],
+          previousValue: [],
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      });
+
+      expect(component.extensionsString).toBe('.png');
+    });
+
+    it('should not recompute extensionsString when an unrelated input changes', () => {
+      component.extensions = ['.jpg'];
+      component.updateExtensionsString();
+      const before = component.extensionsString;
+
+      component.ngOnChanges({
+        disabled: {
+          currentValue: true,
+          previousValue: false,
+          firstChange: false,
+          isFirstChange: () => false
+        }
+      });
+
+      expect(component.extensionsString).toBe(before);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsFileUploadComponent`. The spec covers: real file selection through the actual hidden `<input type="file">` (via `setInputFiles()`, the reliable substitute for an OS file picker - the existing Jest test only proved the synthetic `drop`-event path, never the `change`-event/file-input path real users on file-picker click actually use); real extension validation rejecting a mismatched file with a real error box and `aria-live` announcement; the real `dragged-over` visual state toggling on real `dragenter`/`dragleave`; the disabled dropzone (a native `<button disabled>`) genuinely blocking real pointer interaction; real focus restoration to the dropzone after removing an uploaded file; and the real async `fileProcessingCallback` pipeline actually reaching completion (progress bar visible and dropzone non-interactive while a real 3-second-delayed Observable is in flight, then the real success outcome landing after it resolves) and a real cancel genuinely stopping a pending operation well before that delay would have elapsed, proving `takeUntil(cancelProcessing$)` actually works, not just that a state flag flips.
- Added `data-testid` attributes to the library component's template (root, dropzone and its title/file-desc/info-content, hidden file input, error box and its text, uploaded-files wrapper, uploaded-file row/title/status-icon/name, remove/cancel buttons, progress bar) so consumer apps have stable selectors for their own tests.
- Added a "File upload component with a failing processing callback" example (`processFailingUploadedFile`, resolves `false` after a short delay) - the demo's only other `fileProcessingCallback` always succeeds, so the failure branch (`errorMessage = 'File processing failed'`, `fileProcessingFailed` output, auto-removal of the file) was completely untested and unshowcased. Added a matching Playwright test proving the real failure outcome.
- Expanded `cps-file-upload.component.spec.ts` (3 -> 37 tests) to cover everything logic-level that doesn't need a real browser.

#### TODO: Merge with `feat: add test ids to file upload component` to generate a release

---

Release notes:
- added Playwright E2E coverage for cps-file-upload component
- added test ids to cps-file-upload component