### PR TITLE
test: add Playwright coverage and test ids for CpsIconComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-icon.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-icon.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function example(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+function resolveCssColorVar(page: Page, varName: string): Promise<string> {
+  return page.evaluate((name) => {
+    const probe = document.createElement('div');
+    probe.style.color = `var(${name})`;
+    document.body.appendChild(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    return resolved;
+  }, varName);
+}
+
+test.describe('cps-icon', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/icon');
+  });
+
+  test.describe('Real color resolution - raw CSS value', () => {
+    test('a raw var() expression renders literally as the real computed color', async ({
+      page
+    }) => {
+      const icon = example(page, 'basic-icon').getByTestId('cps-icon');
+
+      const expectedColor = await resolveCssColorVar(
+        page,
+        '--cps-text-primary'
+      );
+      await expect(icon).toHaveCSS('color', expectedColor);
+    });
+  });
+
+  test.describe('Real color resolution - design-token color', () => {
+    test('a design-token color name resolves through a real CSS variable', async ({
+      page
+    }) => {
+      const icon = example(page, 'token-color-icon').getByTestId('cps-icon');
+
+      const expectedColor = await resolveCssColorVar(page, '--cps-color-error');
+      await expect(icon).toHaveCSS('color', expectedColor);
+    });
+  });
+
+  test.describe('Real SVG sprite rendering', () => {
+    test('the icon sprite asset resolves and renders a real visible svg', async ({
+      page
+    }) => {
+      const icon = example(page, 'basic-icon');
+      const svg = icon.locator('svg');
+
+      await expect(svg).toBeVisible();
+      const box = await svg.boundingBox();
+      if (!box) throw new Error('boundingBox() returned null');
+      expect(box.width).toBeGreaterThan(0);
+      expect(box.height).toBeGreaterThan(0);
+    });
+  });
+
+  test.describe('Real computed size dimensions', () => {
+    test('each size variant renders its real pixel dimensions', async ({
+      page
+    }) => {
+      const rootFontSizePx = await page.evaluate(() =>
+        parseFloat(getComputedStyle(document.documentElement).fontSize)
+      );
+
+      const sizes: { testId: string; rem: number }[] = [
+        { testId: 'xsmall-icon', rem: 0.75 },
+        { testId: 'small-icon', rem: 1 },
+        { testId: 'normal-icon', rem: 1.5 },
+        { testId: 'large-icon', rem: 2 }
+      ];
+
+      for (const { testId, rem } of sizes) {
+        const box = await example(page, testId)
+          .getByTestId('cps-icon')
+          .boundingBox();
+        if (!box) throw new Error('boundingBox() returned null');
+
+        expect(box.width).toBeCloseTo(rem * rootFontSizePx, 0);
+        expect(box.height).toBeCloseTo(rem * rootFontSizePx, 0);
+      }
+    });
+  });
+});

--- a/playwright/cps-ui-kit/components/cps-icon.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-icon.spec.ts
@@ -4,15 +4,30 @@ function example(page: Page, testId: string): Locator {
   return page.getByTestId(testId);
 }
 
-function resolveCssColorVar(page: Page, varName: string): Promise<string> {
-  return page.evaluate((name) => {
-    const probe = document.createElement('div');
-    probe.style.color = `var(${name})`;
-    document.body.appendChild(probe);
-    const resolved = getComputedStyle(probe).color;
-    probe.remove();
-    return resolved;
-  }, varName);
+const UNRESOLVED_VAR_SENTINEL = 'rgb(1, 2, 3)';
+
+async function resolveCssColorVar(
+  page: Page,
+  varName: string
+): Promise<string> {
+  const resolved = await page.evaluate(
+    ({ name, sentinel }) => {
+      const probe = document.createElement('div');
+      probe.style.color = `var(${name}, ${sentinel})`;
+      document.body.appendChild(probe);
+      const value = getComputedStyle(probe).color;
+      probe.remove();
+      return value;
+    },
+    { name: varName, sentinel: UNRESOLVED_VAR_SENTINEL }
+  );
+
+  if (resolved === UNRESOLVED_VAR_SENTINEL) {
+    throw new Error(
+      `CSS variable ${varName} is not defined on this page (resolved to the fallback sentinel instead of a real value).`
+    );
+  }
+  return resolved;
 }
 
 test.describe('cps-icon', () => {
@@ -46,17 +61,20 @@ test.describe('cps-icon', () => {
   });
 
   test.describe('Real SVG sprite rendering', () => {
-    test('the icon sprite asset resolves and renders a real visible svg', async ({
+    test('the icon sprite asset resolves and renders real geometry', async ({
       page
     }) => {
       const icon = example(page, 'basic-icon');
-      const svg = icon.locator('svg');
+      const use = icon.locator('svg use');
 
-      await expect(svg).toBeVisible();
-      const box = await svg.boundingBox();
-      if (!box) throw new Error('boundingBox() returned null');
-      expect(box.width).toBeGreaterThan(0);
-      expect(box.height).toBeGreaterThan(0);
+      await expect(use).toHaveAttribute('href', /icons\.svg#like$/);
+
+      const bbox = await use.evaluate((el: SVGUseElement) => {
+        const box = el.getBBox();
+        return { width: box.width, height: box.height };
+      });
+      expect(bbox.width).toBeGreaterThan(0);
+      expect(bbox.height).toBeGreaterThan(0);
     });
   });
 

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.html
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.html
@@ -2,9 +2,31 @@
   <!-- Example of component's usage -->
   <app-code-example label="Basic usage" [htmlCode]="examples.basicUsage.html">
     <cps-icon
+      data-testid="basic-icon"
       icon="like"
       size="normal"
       color="var(--cps-text-primary)"></cps-icon>
+  </app-code-example>
+
+  <app-code-example
+    label="Icon with a custom color token"
+    [htmlCode]="examples.customColorToken.html">
+    <cps-icon
+      data-testid="token-color-icon"
+      icon="warning"
+      size="normal"
+      color="error"></cps-icon>
+  </app-code-example>
+
+  <app-code-example
+    label="Icons at different sizes"
+    [htmlCode]="examples.differentSizes.html">
+    <div class="icon-sizes-row">
+      <cps-icon data-testid="xsmall-icon" icon="star" size="xsmall"></cps-icon>
+      <cps-icon data-testid="small-icon" icon="star" size="small"></cps-icon>
+      <cps-icon data-testid="normal-icon" icon="star" size="normal"></cps-icon>
+      <cps-icon data-testid="large-icon" icon="star" size="large"></cps-icon>
+    </div>
   </app-code-example>
 
   <h2 class="section-title">Browse all icons</h2>

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.scss
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.component.scss
@@ -10,6 +10,13 @@
   margin-bottom: 1.5rem;
 }
 
+.icon-sizes-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--cps-text-primary);
+}
+
 .icon-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
@@ -2,5 +2,18 @@ export const iconsExamples: Record<string, { html: string; ts?: string }> = {
   basicUsage: {
     html: `
 <cps-icon icon="like" size="normal" color="var(--cps-text-primary)"></cps-icon>`
+  },
+
+  customColorToken: {
+    html: `
+<cps-icon icon="warning" size="normal" color="error"></cps-icon>`
+  },
+
+  differentSizes: {
+    html: `
+<cps-icon icon="star" size="xsmall"></cps-icon>
+<cps-icon icon="star" size="small"></cps-icon>
+<cps-icon icon="star" size="normal"></cps-icon>
+<cps-icon icon="star" size="large"></cps-icon>`
   }
 };

--- a/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
+++ b/projects/composition/src/app/pages/icons-page/icons-page/icons-page.examples.ts
@@ -11,9 +11,11 @@ export const iconsExamples: Record<string, { html: string; ts?: string }> = {
 
   differentSizes: {
     html: `
-<cps-icon icon="star" size="xsmall"></cps-icon>
-<cps-icon icon="star" size="small"></cps-icon>
-<cps-icon icon="star" size="normal"></cps-icon>
-<cps-icon icon="star" size="large"></cps-icon>`
+<div class="icon-sizes-row">
+  <cps-icon icon="star" size="xsmall"></cps-icon>
+  <cps-icon icon="star" size="small"></cps-icon>
+  <cps-icon icon="star" size="normal"></cps-icon>
+  <cps-icon icon="star" size="large"></cps-icon>
+</div>`
   }
 };

--- a/projects/cps-ui-kit/src/lib/components/cps-icon/cps-icon.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-icon/cps-icon.component.html
@@ -1,5 +1,6 @@
 @if (icon) {
   <i
+    data-testid="cps-icon"
     [ngClass]="classesList"
     [style.color]="iconColor"
     [style.width]="cvtSize || 'none'"


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsIconComponent`. Its Jest spec already thoroughly covers the `role`/`aria-hidden`/`aria-label` host-attribute logic and `setClasses()`'s CSS-class switching - pure Angular/DOM mechanics JSDOM handles reliably. Three genuinely real-browser-only gaps remained: real color resolution (`getCSSColor`/`isValidCSSColor`, the same real-browser-sensitive mechanism already covered for `CpsDividerComponent`/`CpsExpansionPanelComponent`), Jest only checked that `component.iconColor` changed, never the actual resolved value; real SVG sprite-asset rendering (`<use href="...icons.svg#...">` depends on an external SVG sprite resolving, which JSDOM doesn't fetch/render); and real computed size dimensions - `setClasses()` only applies CSS class names, and Angular component stylesheets aren't loaded into the JSDOM test environment at all, so the actual pixel dimensions from `cps-icon.component.scss` were unverified anywhere, not just inconveniently but literally unable to be checked in Jest.
- Added `data-testid="cps-icon"` to the library template's host `<i>` element.
- Added two new examples: "Icon with a custom color token" (`color="error"`, contrasting the existing raw `var(--cps-text-primary)` case) and "Icons at different sizes" (`xsmall`/`small`/`normal`/`large` in a row) - both inputs had zero live example showing their non-default/non-raw-value behavior before this.

#### TODO: Merge with `feat: add test id to icon component` to generate a release

---

Release notes:
- added Playwright E2E coverage for cps-icon component
- added test id to cps-icon component
