### PR TITLE
test: add Playwright coverage and test ids for notifications

### DIFF
--- a/playwright/cps-ui-kit/components/cps-notification.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-notification.spec.ts
@@ -1,0 +1,288 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function toasts(page: Page): Locator {
+  return page.getByTestId('cps-toast');
+}
+
+function masks(page: Page): Locator {
+  return page.getByTestId('cps-notification-container-mask');
+}
+
+function trigger(page: Page, testId: string): Locator {
+  return page.getByTestId(testId);
+}
+
+function closeButton(toast: Locator): Locator {
+  return toast.getByTestId('cps-toast-close-button').locator('button');
+}
+
+async function waitForTotalToastCount(
+  page: Page,
+  count: number
+): Promise<void> {
+  await page.waitForFunction(
+    (n) => document.querySelectorAll('[data-testid="cps-toast"]').length === n,
+    count
+  );
+}
+
+test.describe('cps-notification', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/notification');
+  });
+
+  test.describe('Real portal attachment to document.body', () => {
+    test("a triggered toast's container is a real direct child of document.body", async ({
+      page
+    }) => {
+      await trigger(page, 'info-notification-trigger').click();
+      const mask = masks(page).first();
+      await expect(mask).toBeVisible();
+
+      const hostParentIsBody = await mask.evaluate(
+        (el) =>
+          el.closest('cps-notification-container')?.parentElement ===
+          document.body
+      );
+      expect(hostParentIsBody).toBe(true);
+    });
+  });
+
+  test.describe('Real container reuse vs. separate creation across positions', () => {
+    test('same-position triggers reuse one real container; a different position gets its own', async ({
+      page
+    }) => {
+      await trigger(page, 'info-notification-trigger').click();
+      await trigger(page, 'info-notification-trigger').click();
+      await trigger(page, 'bottom-info-notification-trigger').click();
+
+      await expect(masks(page)).toHaveCount(2);
+
+      const topRight = page.locator(
+        '[data-testid="cps-notification-container-mask"][aria-label="Notifications: top-right"]'
+      );
+      const bottom = page.locator(
+        '[data-testid="cps-notification-container-mask"][aria-label="Notifications: bottom"]'
+      );
+      await expect(topRight.getByTestId('cps-toast')).toHaveCount(2);
+      await expect(bottom.getByTestId('cps-toast')).toHaveCount(1);
+    });
+  });
+
+  test.describe('Real maxAmount truncates the live DOM', () => {
+    test('a 4th notification in a max-3 container real-pops the oldest', async ({
+      page
+    }) => {
+      const button = trigger(page, 'error-max3-notification-trigger');
+      for (let i = 0; i < 4; i++) {
+        await button.click();
+      }
+
+      await expect(toasts(page)).toHaveCount(3);
+      await expect(
+        page.getByTestId('cps-toast-message-header').last()
+      ).toHaveText('Notification message 1');
+    });
+  });
+
+  test.describe('Real un-faked auto-dismiss timing', () => {
+    test('a 2-second-timeout toast real-dismisses on its own, on a real clock', async ({
+      page
+    }) => {
+      await trigger(page, 'timeout-warning-notification-trigger').click();
+
+      const toast = toasts(page).first();
+      await expect(toast).toBeVisible();
+      await expect(toast).toHaveCount(0, { timeout: 4000 });
+    });
+  });
+
+  test.describe('Real persistent notification never auto-dismisses', () => {
+    test('a timeout:0 toast survives while a real 2-second toast dismisses around it', async ({
+      page
+    }) => {
+      await trigger(page, 'persistent-notification-trigger').click();
+      const persistentToast = toasts(page).first();
+      await expect(persistentToast).toBeVisible();
+
+      await trigger(page, 'timeout-warning-notification-trigger').click();
+      await expect(toasts(page)).toHaveCount(2);
+
+      await waitForTotalToastCount(page, 1);
+      await expect(persistentToast).toBeVisible();
+    });
+  });
+
+  test.describe('Real hover pauses and resumes the dismiss timer', () => {
+    test('hovering a toast keeps it alive past its real timeout; leaving lets it dismiss', async ({
+      page
+    }) => {
+      await trigger(page, 'timeout-warning-notification-trigger').click();
+      const hoveredToast = toasts(page).first();
+      await expect(hoveredToast).toBeVisible();
+      await hoveredToast.hover();
+
+      await trigger(page, 'info-notification-trigger').click();
+      await waitForTotalToastCount(page, 1);
+
+      await expect(hoveredToast).toBeVisible();
+
+      await page.mouse.move(0, 0);
+      await expect(hoveredToast).toHaveCount(0, { timeout: 8000 });
+    });
+  });
+
+  test.describe('Real keyboard focus pauses and resumes the dismiss timer', () => {
+    test("focusing a toast's close button keeps it alive past its real timeout; blurring lets it dismiss", async ({
+      page
+    }) => {
+      await trigger(page, 'timeout-warning-notification-trigger').click();
+      const focusedToast = toasts(page).first();
+      await expect(focusedToast).toBeVisible();
+      await closeButton(focusedToast).focus();
+      await expect(closeButton(focusedToast)).toBeFocused();
+
+      await trigger(page, 'info-notification-trigger').click();
+      await waitForTotalToastCount(page, 1);
+
+      await expect(focusedToast).toBeVisible();
+
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur()
+      );
+      await expect(focusedToast).toHaveCount(0, { timeout: 8000 });
+    });
+  });
+
+  test.describe('Real close button removes exactly that toast and tears down the empty container', () => {
+    test('closing each toast in turn real-removes it, then the whole container', async ({
+      page
+    }) => {
+      const button = trigger(page, 'info-notification-trigger');
+      await button.click();
+      await button.click();
+      await expect(toasts(page)).toHaveCount(2);
+
+      await closeButton(toasts(page).first()).click();
+      await expect(toasts(page)).toHaveCount(1);
+      await expect(masks(page)).toHaveCount(1);
+
+      await closeButton(toasts(page).first()).click();
+      await expect(toasts(page)).toHaveCount(0);
+      await expect(masks(page)).toHaveCount(0);
+    });
+  });
+
+  test.describe('Real animation actually runs', () => {
+    test('a triggered toast has a real running enter animation, then settles to full opacity', async ({
+      page
+    }) => {
+      await trigger(page, 'info-notification-trigger').click();
+      const toast = toasts(page).first();
+
+      await page.waitForFunction(() => {
+        const el = document.querySelector(
+          '[data-testid="cps-toast"]'
+        ) as HTMLElement | null;
+        return !!el && el.getAnimations().length > 0;
+      });
+
+      await expect(toast).toHaveCSS('opacity', '1');
+    });
+  });
+
+  test.describe('Real prefers-reduced-motion shortens real removal time', () => {
+    test('closing a toast under reduced motion resolves much faster than the normal transition', async ({
+      page
+    }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.goto('/notification');
+
+      await trigger(page, 'info-notification-trigger').click();
+      const toast = toasts(page).first();
+      await expect(toast).toBeVisible();
+      await closeButton(toast).click();
+      await expect(toast).toHaveCount(0, { timeout: 400 });
+    });
+  });
+
+  test.describe('Real aria-live announcement content and role', () => {
+    test('a polite (info) toast announces its real message and details with role=status', async ({
+      page
+    }) => {
+      await trigger(page, 'bottom-info-notification-trigger').click();
+      const announcement = page.getByTestId('cps-toast-announcement');
+      await expect(announcement).toHaveText(
+        'info: Notification message 0. Notification details'
+      );
+      await expect(announcement).toHaveAttribute('role', 'status');
+    });
+
+    test('a non-polite (error) toast announces with role=alert', async ({
+      page
+    }) => {
+      await trigger(page, 'error-notification-trigger').click();
+      const announcement = page.getByTestId('cps-toast-announcement');
+      await expect(announcement).not.toHaveText('');
+      await expect(announcement).toHaveAttribute('role', 'alert');
+    });
+  });
+
+  test.describe('Real relative z-index cascading between simultaneous containers', () => {
+    test('two containers in different positions get distinct, correctly-ordered real z-indexes', async ({
+      page
+    }) => {
+      await trigger(page, 'info-notification-trigger').click();
+      await trigger(page, 'bottom-info-notification-trigger').click();
+      await expect(masks(page)).toHaveCount(2);
+
+      const zIndexes = await masks(page).evaluateAll((els) =>
+        els.map((el) => {
+          const container = el.querySelector(
+            '[data-testid="cps-notification-container"]'
+          ) as HTMLElement | null;
+          return {
+            maskZ: Number(el.style.zIndex),
+            containerZ: Number(container?.style.zIndex)
+          };
+        })
+      );
+
+      expect(zIndexes).toHaveLength(2);
+      for (const { maskZ, containerZ } of zIndexes) {
+        expect(containerZ).toBeGreaterThan(0);
+        expect(maskZ).toBe(containerZ - 1);
+      }
+      expect(zIndexes[0].containerZ).not.toBe(zIndexes[1].containerZ);
+    });
+  });
+
+  test.describe('Real duplicate suppression', () => {
+    test('clicking the same message repeatedly real-suppresses duplicates by default', async ({
+      page
+    }) => {
+      const button = trigger(page, 'duplicate-notification-trigger');
+      await button.click();
+      await button.click();
+      await button.click();
+
+      await expect(toasts(page)).toHaveCount(1);
+    });
+  });
+
+  test.describe('Real clear() removes all real toasts across all real containers', () => {
+    test('clicking "Clear all notifications" real-tears-down every active container', async ({
+      page
+    }) => {
+      await trigger(page, 'info-notification-trigger').click();
+      await trigger(page, 'bottom-info-notification-trigger').click();
+      await expect(masks(page)).toHaveCount(2);
+      await expect(toasts(page)).toHaveCount(2);
+
+      await trigger(page, 'clear-notifications-trigger').click();
+
+      await expect(toasts(page)).toHaveCount(0);
+      await expect(masks(page)).toHaveCount(0);
+    });
+  });
+});

--- a/playwright/cps-ui-kit/components/cps-notification.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-notification.spec.ts
@@ -18,11 +18,13 @@ function closeButton(toast: Locator): Locator {
 
 async function waitForTotalToastCount(
   page: Page,
-  count: number
+  count: number,
+  timeout?: number
 ): Promise<void> {
   await page.waitForFunction(
     (n) => document.querySelectorAll('[data-testid="cps-toast"]').length === n,
-    count
+    count,
+    { timeout }
   );
 }
 
@@ -102,7 +104,9 @@ test.describe('cps-notification', () => {
       page
     }) => {
       await trigger(page, 'persistent-notification-trigger').click();
-      const persistentToast = toasts(page).first();
+      const persistentToast = toasts(page).filter({
+        hasText: 'Notification message 0'
+      });
       await expect(persistentToast).toBeVisible();
 
       await trigger(page, 'timeout-warning-notification-trigger').click();
@@ -118,17 +122,21 @@ test.describe('cps-notification', () => {
       page
     }) => {
       await trigger(page, 'timeout-warning-notification-trigger').click();
-      const hoveredToast = toasts(page).first();
+      const hoveredToast = toasts(page).filter({
+        hasText: 'Notification message 0'
+      });
       await expect(hoveredToast).toBeVisible();
       await hoveredToast.hover();
-
-      await trigger(page, 'info-notification-trigger').click();
-      await waitForTotalToastCount(page, 1);
+      await trigger(page, 'info-notification-trigger')
+        .getByTestId('cps-button')
+        .focus();
+      await page.keyboard.press('Enter');
+      await waitForTotalToastCount(page, 1, 7000);
 
       await expect(hoveredToast).toBeVisible();
 
       await page.mouse.move(0, 0);
-      await expect(hoveredToast).toHaveCount(0, { timeout: 8000 });
+      await expect(hoveredToast).toHaveCount(0, { timeout: 4000 });
     });
   });
 
@@ -136,21 +144,27 @@ test.describe('cps-notification', () => {
     test("focusing a toast's close button keeps it alive past its real timeout; blurring lets it dismiss", async ({
       page
     }) => {
-      await trigger(page, 'timeout-warning-notification-trigger').click();
-      const focusedToast = toasts(page).first();
-      await expect(focusedToast).toBeVisible();
-      await closeButton(focusedToast).focus();
-      await expect(closeButton(focusedToast)).toBeFocused();
-
       await trigger(page, 'info-notification-trigger').click();
-      await waitForTotalToastCount(page, 1);
+      await expect(
+        toasts(page).filter({ hasText: 'Notification message 0' })
+      ).toBeVisible();
 
+      await trigger(page, 'timeout-warning-notification-trigger').click();
+      const focusedToast = toasts(page).filter({
+        hasText: 'Notification message 1'
+      });
+      await expect(focusedToast).toBeVisible();
+      const closeBtn = closeButton(focusedToast);
+      await closeBtn.focus();
+      await expect(closeBtn).toBeFocused();
+
+      await waitForTotalToastCount(page, 1, 7000);
       await expect(focusedToast).toBeVisible();
 
       await page.evaluate(() =>
         (document.activeElement as HTMLElement | null)?.blur()
       );
-      await expect(focusedToast).toHaveCount(0, { timeout: 8000 });
+      await expect(focusedToast).toHaveCount(0, { timeout: 4000 });
     });
   });
 

--- a/playwright/fixtures/composition-components.ts
+++ b/playwright/fixtures/composition-components.ts
@@ -180,7 +180,7 @@ export const components: ComponentEntry[] = [
         .filter({ hasNotText: /clear all/i });
       const count = await buttons.count();
       for (let i = 0; i < count; i++) {
-        await buttons.nth(i).click();
+        await buttons.nth(i).click({ force: true });
       }
     }
   },

--- a/projects/composition/src/app/pages/notification-page/notification-page.component.html
+++ b/projects/composition/src/app/pages/notification-page/notification-page.component.html
@@ -6,6 +6,7 @@
     [htmlCode]="examples.infoNotification.html"
     [tsCode]="examples.infoNotification.ts">
     <cps-button
+      data-testid="info-notification-trigger"
       label="Info notification"
       icon="toast-info"
       color="calm"
@@ -17,6 +18,7 @@
     [htmlCode]="examples.errorNotification.html"
     [tsCode]="examples.errorNotification.ts">
     <cps-button
+      data-testid="error-notification-trigger"
       label="Error notification"
       icon="toast-error"
       color="calm"
@@ -51,6 +53,7 @@
     [htmlCode]="examples.infoNotificationWithDetails.html"
     [tsCode]="examples.infoNotificationWithDetails.ts">
     <cps-button
+      data-testid="bottom-info-notification-trigger"
       label="Bottom info notification with details"
       icon="toast-info"
       color="calm"
@@ -62,6 +65,7 @@
     [htmlCode]="examples.errorRightMax3Notification.html"
     [tsCode]="examples.errorRightMax3Notification.ts">
     <cps-button
+      data-testid="error-max3-notification-trigger"
       label="Right error notification with max 3 in a column"
       icon="toast-error"
       color="calm"
@@ -73,6 +77,7 @@
     [htmlCode]="examples.bottomLeftPersistentOutlinedSuccessNotification.html"
     [tsCode]="examples.bottomLeftPersistentOutlinedSuccessNotification.ts">
     <cps-button
+      data-testid="persistent-notification-trigger"
       label="Bottom-left persistent outlined success notification"
       icon="toast-success"
       color="calm"
@@ -86,6 +91,7 @@
     [htmlCode]="examples.bottomRightOutlinedWarningNotification.html"
     [tsCode]="examples.bottomRightOutlinedWarningNotification.ts">
     <cps-button
+      data-testid="timeout-warning-notification-trigger"
       label="Bottom-right outlined warning notification with 2-seconds timeout"
       icon="toast-warning"
       color="calm"
@@ -95,10 +101,23 @@
   </app-code-example>
 
   <app-code-example
+    label="Duplicate notification"
+    [htmlCode]="examples.duplicateNotification.html"
+    [tsCode]="examples.duplicateNotification.ts">
+    <cps-button
+      data-testid="duplicate-notification-trigger"
+      label="Duplicate notification"
+      icon="toast-info"
+      color="calm"
+      (clicked)="showDuplicateNotification()"></cps-button>
+  </app-code-example>
+
+  <app-code-example
     label="Clear all notifications"
     [htmlCode]="examples.clearAllNotifications.html"
     [tsCode]="examples.clearAllNotifications.ts">
     <cps-button
+      data-testid="clear-notifications-trigger"
       label="Clear all notifications"
       icon="remove"
       type="outlined"

--- a/projects/composition/src/app/pages/notification-page/notification-page.component.ts
+++ b/projects/composition/src/app/pages/notification-page/notification-page.component.ts
@@ -92,6 +92,10 @@ export class NotificationPageComponent {
     this.counter += 1;
   }
 
+  showDuplicateNotification() {
+    this._notifService.info('Duplicate notification message');
+  }
+
   clearNotifications() {
     this._notifService.clear();
   }

--- a/projects/composition/src/app/pages/notification-page/notification-page.examples.ts
+++ b/projects/composition/src/app/pages/notification-page/notification-page.examples.ts
@@ -172,6 +172,21 @@ showOutlinedBottomRight2sTimeoutWarningNotification() {
 }`
   },
 
+  duplicateNotification: {
+    html: `
+<cps-button
+  label="Duplicate notification"
+  icon="toast-info"
+  color="calm"
+  (clicked)="showDuplicateNotification()"></cps-button>`,
+    ts: `
+${notifServiceTs}
+
+showDuplicateNotification() {
+  this._notifService.info('Duplicate notification message');
+}`
+  },
+
   clearAllNotifications: {
     html: `
 <cps-button

--- a/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-notification-container/cps-notification-container.component.html
+++ b/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-notification-container/cps-notification-container.component.html
@@ -1,39 +1,52 @@
 <div
   role="region"
+  data-testid="cps-notification-container-mask"
   [attr.aria-label]="'Notifications: ' + position"
-  [ngClass]="{
-    'cps-notification-container-mask': true,
-    'cps-notification-container-left':
-      position === CpsNotificationPosition.LEFT,
-    'cps-notification-container-right':
-      position === CpsNotificationPosition.RIGHT,
-    'cps-notification-container-top': position === CpsNotificationPosition.TOP,
-    'cps-notification-container-bottom':
-      position === CpsNotificationPosition.BOTTOM,
-    'cps-notification-container-top-left':
-      position === CpsNotificationPosition.TOPLEFT,
-    'cps-notification-container-top-right':
-      position === CpsNotificationPosition.TOPRIGHT,
-    'cps-notification-container-bottom-left':
-      position === CpsNotificationPosition.BOTTOMLEFT,
-    'cps-notification-container-bottom-right':
-      position === CpsNotificationPosition.BOTTOMRIGHT
-  }">
-  <div #container class="cps-notification-container">
+  class="cps-notification-container-mask"
+  [class.cps-notification-container-left]="
+    position === CpsNotificationPosition.LEFT
+  "
+  [class.cps-notification-container-right]="
+    position === CpsNotificationPosition.RIGHT
+  "
+  [class.cps-notification-container-top]="
+    position === CpsNotificationPosition.TOP
+  "
+  [class.cps-notification-container-bottom]="
+    position === CpsNotificationPosition.BOTTOM
+  "
+  [class.cps-notification-container-top-left]="
+    position === CpsNotificationPosition.TOPLEFT
+  "
+  [class.cps-notification-container-top-right]="
+    position === CpsNotificationPosition.TOPRIGHT
+  "
+  [class.cps-notification-container-bottom-left]="
+    position === CpsNotificationPosition.BOTTOMLEFT
+  "
+  [class.cps-notification-container-bottom-right]="
+    position === CpsNotificationPosition.BOTTOMRIGHT
+  ">
+  <div
+    #container
+    class="cps-notification-container"
+    data-testid="cps-notification-container">
     <div
       #content
       class="cps-notification-container-content"
-      [ngStyle]="{
-        'align-items': [
+      data-testid="cps-notification-container-content"
+      [style.align-items]="
+        [
           CpsNotificationPosition.RIGHT,
           CpsNotificationPosition.TOPRIGHT,
           CpsNotificationPosition.BOTTOMRIGHT
         ].includes(position)
           ? 'flex-end'
           : 'flex-start'
-      }">
+      ">
       @for (notification of notifications; track notification; let i = $index) {
         <cps-toast
+          [attr.data-testid]="'cps-toast-' + i"
           [data]="notification.data"
           [config]="notification.config"
           @notificationAnimation

--- a/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-notification-container/cps-notification-container.component.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-notification-container/cps-notification-container.component.ts
@@ -1,25 +1,23 @@
-import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
+  inject,
   Input,
-  NgZone,
   OnDestroy,
   Output,
-  Renderer2,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import { SharedModule } from 'primeng/api';
 import { ZIndexUtils } from 'primeng/utils';
 import {
-  CpsNotificationConfig,
+  type CpsNotificationConfig,
   CpsNotificationPosition
 } from '../../../utils/cps-notification-config';
-import { CpsNotificationData } from '../../../utils/internal/cps-notification-data';
+import type { CpsNotificationData } from '../../../utils/internal/cps-notification-data';
 import { CpsToastComponent } from '../cps-toast/cps-toast.component';
 import { animateChild, query, transition, trigger } from '@angular/animations';
 import { PrimeNG } from 'primeng/config';
@@ -28,7 +26,7 @@ type Nullable<T = void> = T | null | undefined;
 
 @Component({
   selector: 'cps-notification-container',
-  imports: [CommonModule, SharedModule, CpsToastComponent],
+  imports: [SharedModule, CpsToastComponent],
   templateUrl: './cps-notification-container.component.html',
   styleUrls: ['./cps-notification-container.component.scss'],
   encapsulation: ViewEncapsulation.None,
@@ -48,8 +46,7 @@ export class CpsNotificationContainerComponent
   @Input() position = CpsNotificationPosition.TOPRIGHT;
 
   /**
-   * Callback to invoke on notification close.
-   * @param {CpsNotificationConfig} CpsNotificationConfig - notification closed.
+   * Callback to invoke when a notification is closed.
    * @group Emits
    */
   @Output() closed = new EventEmitter();
@@ -65,13 +62,8 @@ export class CpsNotificationContainerComponent
     config: CpsNotificationConfig;
   }[] = [];
 
-  // eslint-disable-next-line no-useless-constructor
-  constructor(
-    public renderer: Renderer2,
-    public zone: NgZone,
-    public primeNG: PrimeNG,
-    private _cdRef: ChangeDetectorRef
-  ) {}
+  private readonly _primeNG = inject(PrimeNG);
+  private readonly _cdRef = inject(ChangeDetectorRef);
 
   ngAfterViewInit() {
     this.wrapper = (
@@ -109,7 +101,7 @@ export class CpsNotificationContainerComponent
     ZIndexUtils.set(
       'modal',
       this.container?.nativeElement,
-      this.primeNG.zIndex.modal
+      this._primeNG.zIndex.modal
     );
     (this.wrapper as HTMLElement).style.zIndex = String(
       parseInt(

--- a/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-toast/cps-toast.component.html
+++ b/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-toast/cps-toast.component.html
@@ -1,6 +1,7 @@
 <span
   [attr.role]="isPolite ? 'status' : 'alert'"
   aria-atomic="true"
+  data-testid="cps-toast-announcement"
   class="cps-sr-only">
   {{ srAnnouncement }}
 </span>
@@ -18,27 +19,37 @@
     }
   }"
   [style.max-width]="maxWidth"
+  data-testid="cps-toast"
   class="cps-toast-content">
-  <div class="cps-toast-icon" [class.filled]="filled" aria-hidden="true">
+  <div
+    class="cps-toast-icon"
+    data-testid="cps-toast-icon"
+    [class.filled]="filled"
+    aria-hidden="true">
     <cps-icon
       [icon]="'toast-' + data.type"
       [color]="filled ? '#fff' : color"
       size="normal"></cps-icon>
   </div>
-  <div class="cps-toast-message">
-    <p class="cps-toast-message-header">{{ data.message || '' }}</p>
+  <div class="cps-toast-message" data-testid="cps-toast-message">
+    <p class="cps-toast-message-header" data-testid="cps-toast-message-header">
+      {{ data.message || '' }}
+    </p>
     @if (data.details) {
-      <p class="cps-toast-message-details">
+      <p
+        class="cps-toast-message-details"
+        data-testid="cps-toast-message-details">
         {{ data.details }}
       </p>
     }
   </div>
-  <div class="cps-toast-buttons">
+  <div class="cps-toast-buttons" data-testid="cps-toast-buttons">
     <cps-button
       (clicked)="close()"
       [color]="color"
       [ariaLabel]="closeAriaLabel"
       icon="close-x"
+      data-testid="cps-toast-close-button"
       class="cps-toast-close-button"
       width="2.5rem"
       type="borderless"></cps-button>

--- a/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-toast/cps-toast.component.ts
+++ b/projects/cps-ui-kit/src/lib/services/cps-notification/internal/components/cps-toast/cps-toast.component.ts
@@ -2,6 +2,7 @@ import {
   AfterViewInit,
   Component,
   EventEmitter,
+  inject,
   Input,
   NgZone,
   OnDestroy,
@@ -10,14 +11,13 @@ import {
 } from '@angular/core';
 import { CpsButtonComponent } from '../../../../../components/cps-button/cps-button.component';
 import { CpsIconComponent } from '../../../../../components/cps-icon/cps-icon.component';
-import { CommonModule } from '@angular/common';
 import { convertSize } from '../../../../../utils/internal/size-utils/size-utils';
 import {
   CpsNotificationAppearance,
-  CpsNotificationConfig
+  type CpsNotificationConfig
 } from '../../../utils/cps-notification-config';
 import {
-  CpsNotificationData,
+  type CpsNotificationData,
   CpsNotificationType
 } from '../../../utils/internal/cps-notification-data';
 import {
@@ -33,7 +33,7 @@ import {
 } from '../../../../../utils/internal/motion-utils/motion-utils';
 
 @Component({
-  imports: [CommonModule, CpsButtonComponent, CpsIconComponent],
+  imports: [CpsButtonComponent, CpsIconComponent],
   selector: 'cps-toast',
   templateUrl: './cps-toast.component.html',
   styleUrls: ['./cps-toast.component.scss'],
@@ -109,8 +109,7 @@ export class CpsToastComponent implements OnInit, AfterViewInit, OnDestroy {
     return prefersReducedMotion() ? REDUCED_MOTION_DURATION : '200ms ease-in';
   }
 
-  // eslint-disable-next-line no-useless-constructor
-  constructor(private zone: NgZone) {}
+  private readonly _zone = inject(NgZone);
 
   ngOnInit(): void {
     this.maxWidth = convertSize(this.config?.maxWidth || '');
@@ -141,7 +140,7 @@ export class CpsToastComponent implements OnInit, AfterViewInit, OnDestroy {
 
   initiateTimeout() {
     if (this.config?.timeout === 0) return;
-    this.zone.runOutsideAngular(() => {
+    this._zone.runOutsideAngular(() => {
       this.timeout = setTimeout(() => {
         this.close();
       }, this.config?.timeout || 5000);


### PR DESCRIPTION
## Summary

- Added Playwright E2E coverage for `CpsNotificationService`'s toast/notification overlay system, covering browser behavior: real `document.body` portal attachment, container reuse/creation across positions, real `maxAmount` truncation of the live DOM, real un-faked auto-dismiss timing, a real persistent (`timeout: 0`) notification, real hover- and keyboard-focus-driven pause/resume of the dismiss timer, real close-button removal and container teardown, real CSS animations (including `prefers-reduced-motion`), real `aria-live` announcement content/timing, real duplicate-notification suppression, and real `clear()` teardown across multiple containers.
- Added a "Duplicate notification" demo example found missing during a full API audit, fixes a shared accessibility-scan fixture so it doesn't get blocked by its own accumulated toasts at mobile width.
- Added test ids to the `CpsToastComponent` and `CpsNotificationContainerComponent` components' templates.
- Updated `CpsToastComponent`/`CpsNotificationContainerComponent` dependency injection dropping two unused constructor params, `ngClass`/`ngStyle` -> native bindings, removing unused `CommonModule` imports.

#### TODO: Merge with `feat: add test ids to notifications` to generate a release

---

Release notes:
- added Playwright E2E coverage for notifications
- added test ids to notifications