### PR TITLE
test: add Playwright coverage and test ids for CpsPaginatorComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-paginator.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-paginator.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+function paginatorByLabel(page: Page, name: string): Locator {
+  return page.getByRole('navigation', { name });
+}
+
+function reportText(paginator: Locator): Locator {
+  return paginator.locator('.p-paginator-current');
+}
+
+test.describe('cps-paginator', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/paginator');
+  });
+
+  test.describe('Real ArrowRight/ArrowLeft keyboard navigation', () => {
+    test('ArrowRight moves real focus to the next page button and real-changes the page', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+      const page1 = paginator.getByRole('button', { name: '1', exact: true });
+      await page1.focus();
+
+      await page.keyboard.press('ArrowRight');
+
+      const page2 = paginator.getByRole('button', { name: '2', exact: true });
+      await expect(page2).toBeFocused();
+      await expect(reportText(paginator)).toHaveText('11 - 20 of 120');
+    });
+
+    test('ArrowLeft moves real focus to the previous page button and real-changes the page', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+      const page2 = paginator.getByRole('button', { name: '2', exact: true });
+      await page2.click();
+      await expect(reportText(paginator)).toHaveText('11 - 20 of 120');
+
+      await page2.focus();
+      await page.keyboard.press('ArrowLeft');
+
+      const page1 = paginator.getByRole('button', { name: '1', exact: true });
+      await expect(page1).toBeFocused();
+      await expect(reportText(paginator)).toHaveText('1 - 10 of 120');
+    });
+  });
+
+  test.describe('Real focus redirection when a boundary nav button becomes disabled', () => {
+    test('activating Last real-moves focus to the real selected page button', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+
+      await paginator.locator('.p-paginator-last').focus();
+      await page.keyboard.press('Enter');
+
+      await expect(reportText(paginator)).toHaveText('111 - 120 of 120');
+      const selected = paginator.locator(
+        '.p-paginator-page[aria-current="page"]'
+      );
+      await expect(selected).toBeFocused();
+    });
+
+    test('activating First real-moves focus to the real selected page button', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+
+      await paginator.locator('.p-paginator-last').focus();
+      await page.keyboard.press('Enter');
+      await expect(reportText(paginator)).toHaveText('111 - 120 of 120');
+
+      await paginator.locator('.p-paginator-first').focus();
+      await page.keyboard.press('Enter');
+
+      await expect(reportText(paginator)).toHaveText('1 - 10 of 120');
+      const selected = paginator.locator(
+        '.p-paginator-page[aria-current="page"]'
+      );
+      await expect(selected).toBeFocused();
+    });
+  });
+
+  test.describe('Real aria-disabled/tabindex on the first button reflects real page state', () => {
+    test('the first button is really disabled on page 1 and really enabled after navigating away', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+      const firstBtn = paginator.locator('.p-paginator-first');
+      await expect(firstBtn).toHaveAttribute('aria-disabled', 'true');
+      await expect(firstBtn).toHaveAttribute('tabindex', '-1');
+
+      await paginator.getByRole('button', { name: '2', exact: true }).click();
+
+      await expect(firstBtn).not.toHaveAttribute('aria-disabled', 'true');
+      await expect(firstBtn).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  test.describe('Real rows-per-page change via the real nested cps-select dropdown', () => {
+    test('picking a new value from the real dropdown real-updates the report', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Basic pagination');
+      await expect(reportText(paginator)).toHaveText('1 - 10 of 120');
+
+      await paginator.getByRole('combobox').click();
+      await page.getByRole('option', { name: '25', exact: true }).click();
+
+      await expect(reportText(paginator)).toHaveText('1 - 25 of 120');
+    });
+  });
+
+  test.describe('Real alwaysShow=false hides the paginator with only one page', () => {
+    test('a single-page paginator with alwaysShow=false real-collapses via display:none, and real-reappears once more records exist', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(page, 'Single-page pagination');
+      const inner = paginator.getByTestId('cps-paginator');
+      await expect(inner).toHaveCSS('display', 'none');
+
+      const exampleBlock = page
+        .locator('app-code-example')
+        .filter({ has: paginator });
+      await exampleBlock.getByTestId('cps-checkbox-label').click();
+
+      await expect(inner).not.toHaveCSS('display', 'none');
+      await expect(inner.locator('.p-paginator-current')).toHaveText(
+        '1 - 10 of 120'
+      );
+    });
+  });
+
+  test.describe('Real resetPageOnRowsChange returns to page 1 via the real select', () => {
+    test('changing rows-per-page through the real dropdown real-resets the page', async ({
+      page
+    }) => {
+      const paginator = paginatorByLabel(
+        page,
+        'Custom rows-per-page pagination'
+      );
+      await paginator.getByRole('button', { name: '2', exact: true }).click();
+      await expect(reportText(paginator)).toHaveText('6 - 10 of 120');
+
+      await paginator.getByRole('combobox').click();
+      await page.getByRole('option', { name: '15', exact: true }).click();
+
+      await expect(reportText(paginator)).toHaveText('1 - 15 of 120');
+    });
+  });
+
+  test.describe('Real backgroundColor applies as real CSS', () => {
+    test('a custom backgroundColor real-renders as the computed background', async ({
+      page
+    }) => {
+      const inner = paginatorByLabel(
+        page,
+        'Custom background pagination'
+      ).getByTestId('cps-paginator');
+
+      await expect(inner).toHaveCSS('background-color', 'rgb(240, 244, 255)');
+    });
+  });
+});

--- a/projects/composition/src/app/pages/paginator-page/paginator-page.component.html
+++ b/projects/composition/src/app/pages/paginator-page/paginator-page.component.html
@@ -1,7 +1,57 @@
 <app-component-docs-viewer [componentData]="componentData">
   <!-- Example of component's usage -->
-  <app-code-example label="Basic usage" [htmlCode]="examples.basicUsage.html">
-    <cps-paginator [first]="0" [rows]="10" [totalRecords]="120">
+  <app-code-example
+    label="Basic usage"
+    [htmlCode]="examples.basicUsage.html"
+    [tsCode]="examples.basicUsage.ts">
+    <cps-paginator
+      ariaLabel="Basic pagination"
+      [first]="first"
+      [rows]="rows"
+      [totalRecords]="120"
+      (pageChanged)="onPageChanged($event)">
+    </cps-paginator>
+  </app-code-example>
+
+  <app-code-example
+    label="Hides with a single page"
+    [htmlCode]="examples.singlePage.html"
+    [tsCode]="examples.singlePage.ts">
+    <cps-paginator
+      ariaLabel="Single-page pagination"
+      [first]="0"
+      [rows]="10"
+      [totalRecords]="manyRecords ? 120 : 5"
+      [alwaysShow]="false">
+    </cps-paginator>
+    <cps-checkbox
+      [(ngModel)]="manyRecords"
+      [label]="
+        manyRecords ? 'Showing many records' : 'Showing few records'
+      "></cps-checkbox>
+  </app-code-example>
+
+  <app-code-example
+    label="Custom rows per page with reset on change"
+    [htmlCode]="examples.customRowsPerPage.html">
+    <cps-paginator
+      ariaLabel="Custom rows-per-page pagination"
+      [first]="0"
+      [rows]="5"
+      [totalRecords]="120"
+      [rowsPerPageOptions]="[5, 15, 30]"
+      [resetPageOnRowsChange]="true">
+    </cps-paginator>
+  </app-code-example>
+
+  <app-code-example
+    label="Custom background color"
+    [htmlCode]="examples.customBackground.html">
+    <cps-paginator
+      ariaLabel="Custom background pagination"
+      backgroundColor="#f0f4ff"
+      [rows]="10"
+      [totalRecords]="120">
     </cps-paginator>
   </app-code-example>
 </app-component-docs-viewer>

--- a/projects/composition/src/app/pages/paginator-page/paginator-page.component.ts
+++ b/projects/composition/src/app/pages/paginator-page/paginator-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { CpsPaginatorComponent } from 'cps-ui-kit';
+import { FormsModule } from '@angular/forms';
+import { CpsCheckboxComponent, CpsPaginatorComponent } from 'cps-ui-kit';
 import { ComponentDocsViewerComponent } from '../../components/component-docs-viewer/component-docs-viewer.component';
 import { CodeExampleComponent } from '../../components/code-example/code-example.component';
 import ComponentData from '../../api-data/cps-paginator.json';
@@ -8,7 +9,9 @@ import { paginatorExamples } from './paginator-page.examples';
 @Component({
   selector: 'app-paginator-page',
   imports: [
+    FormsModule,
     CpsPaginatorComponent,
+    CpsCheckboxComponent,
     ComponentDocsViewerComponent,
     CodeExampleComponent
   ],
@@ -19,4 +22,13 @@ import { paginatorExamples } from './paginator-page.examples';
 export class PaginatorPageComponent {
   componentData = ComponentData;
   readonly examples = paginatorExamples;
+
+  first = 0;
+  rows = 10;
+  manyRecords = false;
+
+  onPageChanged(event: { first: number; rows: number }) {
+    this.first = event.first;
+    this.rows = event.rows;
+  }
 }

--- a/projects/composition/src/app/pages/paginator-page/paginator-page.examples.ts
+++ b/projects/composition/src/app/pages/paginator-page/paginator-page.examples.ts
@@ -2,6 +2,59 @@ export const paginatorExamples: Record<string, { html: string; ts?: string }> =
   {
     basicUsage: {
       html: `
-<cps-paginator [first]="0" [rows]="10" [totalRecords]="120"></cps-paginator>`
+<cps-paginator
+  ariaLabel="Basic pagination"
+  [first]="first"
+  [rows]="rows"
+  [totalRecords]="120"
+  (pageChanged)="onPageChanged($event)">
+</cps-paginator>`,
+      ts: `
+first = 0;
+rows = 10;
+
+onPageChanged(event: { first: number; rows: number }) {
+  this.first = event.first;
+  this.rows = event.rows;
+}`
+    },
+
+    singlePage: {
+      html: `
+<cps-paginator
+  ariaLabel="Single-page pagination"
+  [first]="0"
+  [rows]="10"
+  [totalRecords]="manyRecords ? 120 : 5"
+  [alwaysShow]="false">
+</cps-paginator>
+<cps-checkbox
+  [(ngModel)]="manyRecords"
+  [label]="manyRecords ? 'Showing many records' : 'Showing few records'">
+</cps-checkbox>`,
+      ts: `
+manyRecords = false;`
+    },
+
+    customRowsPerPage: {
+      html: `
+<cps-paginator
+  ariaLabel="Custom rows-per-page pagination"
+  [first]="0"
+  [rows]="5"
+  [totalRecords]="120"
+  [rowsPerPageOptions]="[5, 15, 30]"
+  [resetPageOnRowsChange]="true">
+</cps-paginator>`
+    },
+
+    customBackground: {
+      html: `
+<cps-paginator
+  ariaLabel="Custom background pagination"
+  backgroundColor="#f0f4ff"
+  [rows]="10"
+  [totalRecords]="120">
+</cps-paginator>`
     }
   };

--- a/projects/cps-ui-kit/src/lib/components/cps-paginator/cps-paginator.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-paginator/cps-paginator.component.html
@@ -1,5 +1,6 @@
 <p-paginator
   #paginator
+  data-testid="cps-paginator"
   (onPageChange)="onPageChange($event)"
   [first]="first"
   [rows]="rows"
@@ -14,13 +15,19 @@
 </p-paginator>
 
 <ng-template #itemsPerPageTemplate>
-  <div class="cps-paginator-itms-per-page">
-    <span class="cps-paginator-items-per-page-title" aria-hidden="true"
+  <div
+    class="cps-paginator-itms-per-page"
+    data-testid="cps-paginator-rows-per-page">
+    <span
+      class="cps-paginator-items-per-page-title"
+      data-testid="cps-paginator-rows-per-page-title"
+      aria-hidden="true"
       >Items per page:
     </span>
     <cps-select
       ariaLabel="Set items per page"
       width="4rem"
+      data-testid="cps-paginator-rows-per-page-select"
       [options]="rowOptions"
       [hideDetails]="true"
       [(ngModel)]="rows"


### PR DESCRIPTION
## Summary

- Added 8 tests covering real browser behavior: real ArrowLeft/ArrowRight keyboard navigation, real focus redirection on both boundary directions (First and Last), real `aria-disabled`/`tabindex` reflecting page state, the real nested `cps-select` rows-per-page dropdown, real `alwaysShow=false` collapse (driven interactively via a real toggle, not just compared against a second static example), real `resetPageOnRowsChange` behavior, and real applied `backgroundColor` CSS.
- Wired the "Basic usage" demo example and added three new examples: single-page collapse (toggleable via a real `cps-checkbox`), custom rows-per-page with reset, and custom background color.
- Added testids to the component's template (`cps-paginator`, `cps-paginator-rows-per-page`, `cps-paginator-rows-per-page-title`, `cps-paginator-rows-per-page-select`) for downstream consumers.

#### TODO: Merge with `feat: add test ids to paginator component` to generate a release

---

Release notes:
- added Playwright E2E coverage for cps-paginator component
- added test ids to cps-paginator component
