### PR TITLE
test: add Playwright coverage and test ids for CpsProgressCircularComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-progress-circular.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-progress-circular.spec.ts
@@ -30,9 +30,16 @@ test.describe('cps-progress-circular', () => {
       await expect(circle).toHaveCSS('animation-iteration-count', 'infinite');
 
       await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.reload();
+      const reducedCircle = page
+        .getByRole('progressbar', { name: 'Luxury progress circular' })
+        .getByTestId('cps-progress-circular');
 
-      await expect(circle).toHaveCSS('animation-duration', '2.4s');
-      await expect(circle).toHaveCSS('animation-iteration-count', 'infinite');
+      await expect(reducedCircle).toHaveCSS('animation-duration', '2.4s');
+      await expect(reducedCircle).toHaveCSS(
+        'animation-iteration-count',
+        'infinite'
+      );
     });
   });
 });

--- a/playwright/cps-ui-kit/components/cps-progress-circular.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-progress-circular.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('cps-progress-circular', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/progress-circular');
+  });
+
+  test.describe('Real CSS custom-property color resolves to an actual color', () => {
+    test('a color name real-resolves through the real stylesheet to its actual RGB value', async ({
+      page
+    }) => {
+      const circle = page
+        .getByRole('progressbar', { name: 'Luxury progress circular' })
+        .getByTestId('cps-progress-circular');
+
+      await expect(circle).toHaveCSS('border-top-color', 'rgb(100, 0, 50)');
+      await expect(circle).toHaveCSS('width', '120px');
+    });
+  });
+
+  test.describe('Real prefers-reduced-motion slows, not stops, the spin animation', () => {
+    test('reduced motion real-slows the animation while keeping it running', async ({
+      page
+    }) => {
+      const circle = page
+        .getByRole('progressbar', { name: 'Luxury progress circular' })
+        .getByTestId('cps-progress-circular');
+
+      await expect(circle).toHaveCSS('animation-duration', '0.8s');
+      await expect(circle).toHaveCSS('animation-iteration-count', 'infinite');
+
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+
+      await expect(circle).toHaveCSS('animation-duration', '2.4s');
+      await expect(circle).toHaveCSS('animation-iteration-count', 'infinite');
+    });
+  });
+});

--- a/projects/composition/src/app/pages/progress-circular-page/progress-circular-page.component.html
+++ b/projects/composition/src/app/pages/progress-circular-page/progress-circular-page.component.html
@@ -13,6 +13,7 @@
     [htmlCode]="examples.variants.html">
     <div class="progr-circ-group">
       <cps-progress-circular
+        ariaLabel="Luxury progress circular"
         color="luxury"
         diameter="7.5rem"
         strokeWidth="0.5rem"></cps-progress-circular>

--- a/projects/composition/src/app/pages/progress-circular-page/progress-circular-page.examples.ts
+++ b/projects/composition/src/app/pages/progress-circular-page/progress-circular-page.examples.ts
@@ -6,6 +6,7 @@ export const progressCircularExamples: Record<
     html: `
 <div style="display: flex; align-items: center; gap: 3rem; overflow: hidden;">
   <cps-progress-circular
+    ariaLabel="Luxury progress circular"
     color="luxury"
     diameter="7.5rem"
     strokeWidth="0.5rem"></cps-progress-circular>

--- a/projects/cps-ui-kit/src/lib/components/cps-progress-circular/cps-progress-circular.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-progress-circular/cps-progress-circular.component.html
@@ -1,5 +1,6 @@
 <div
   aria-hidden="true"
   class="cps-progress-circular"
+  data-testid="cps-progress-circular"
   [style.width]="cvtDiameter"
   [style.border]="`${cvtStrokeWidth} solid ${cvtColor}`"></div>


### PR DESCRIPTION
## Summary

- Added 2 tests covering browser behavior: real CSS custom-property color resolution (`color="luxury"` -> the literal string `var(--cps-color-luxury)` in JSDOM vs. the real resolved `rgb(100, 0, 50)` from the compiled stylesheet in a live app) and a real, deliberate `prefers-reduced-motion` accommodation that slows the spin animation (0.8s -> 2.4s).
- Added `ariaLabel="Luxury progress circular"` to the existing "luxury" demo circle.
- Added one library testid (`cps-progress-circular`) on the component's styled div.

#### TODO: Merge with `feat: add test id to progress circular component`

---

Release notes:
- added Playwright E2E coverage for cps-progress-circular component
- added test id to cps-progress-circular component
