### PR TITLE
test: add Playwright coverage and test ids for CpsProgressLinearComponent

### DIFF
--- a/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
@@ -37,6 +37,7 @@ test.describe('cps-progress-linear', () => {
       await expect(dec).toHaveCSS('animation-iteration-count', 'infinite');
 
       await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.reload();
 
       await expect(inc).toHaveCSS('animation-duration', '6s');
       await expect(inc).toHaveCSS('animation-iteration-count', 'infinite');

--- a/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
@@ -39,10 +39,21 @@ test.describe('cps-progress-linear', () => {
       await page.emulateMedia({ reducedMotion: 'reduce' });
       await page.reload();
 
-      await expect(inc).toHaveCSS('animation-duration', '6s');
-      await expect(inc).toHaveCSS('animation-iteration-count', 'infinite');
-      await expect(dec).toHaveCSS('animation-duration', '6s');
-      await expect(dec).toHaveCSS('animation-iteration-count', 'infinite');
+      const reducedWrapper = page
+        .getByRole('progressbar', { name: 'Energy progress linear' })
+        .getByTestId('cps-progress-linear');
+      const reducedInc = reducedWrapper.getByTestId('cps-progress-linear-inc');
+      const reducedDec = reducedWrapper.getByTestId('cps-progress-linear-dec');
+      await expect(reducedInc).toHaveCSS('animation-duration', '6s');
+      await expect(reducedInc).toHaveCSS(
+        'animation-iteration-count',
+        'infinite'
+      );
+      await expect(reducedDec).toHaveCSS('animation-duration', '6s');
+      await expect(reducedDec).toHaveCSS(
+        'animation-iteration-count',
+        'infinite'
+      );
     });
   });
 });

--- a/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
+++ b/playwright/cps-ui-kit/components/cps-progress-linear.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('cps-progress-linear', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/progress-linear');
+  });
+
+  test.describe('Real CSS custom-property color/bgColor resolve to actual colors', () => {
+    test('color names real-resolve through the real stylesheet to their actual RGB values', async ({
+      page
+    }) => {
+      const wrapper = page
+        .getByRole('progressbar', { name: 'Energy progress linear' })
+        .getByTestId('cps-progress-linear');
+
+      await expect(wrapper).toHaveCSS('background-color', 'rgb(250, 236, 229)');
+      await expect(wrapper.getByTestId('cps-progress-linear-inc')).toHaveCSS(
+        'background-color',
+        'rgb(255, 120, 15)'
+      );
+    });
+  });
+
+  test.describe('Real prefers-reduced-motion slows, not stops, both bars', () => {
+    test('reduced motion real-slows both bars while keeping them running', async ({
+      page
+    }) => {
+      const wrapper = page
+        .getByRole('progressbar', { name: 'Energy progress linear' })
+        .getByTestId('cps-progress-linear');
+      const inc = wrapper.getByTestId('cps-progress-linear-inc');
+      const dec = wrapper.getByTestId('cps-progress-linear-dec');
+
+      await expect(inc).toHaveCSS('animation-duration', '2s');
+      await expect(inc).toHaveCSS('animation-iteration-count', 'infinite');
+      await expect(dec).toHaveCSS('animation-duration', '2s');
+      await expect(dec).toHaveCSS('animation-iteration-count', 'infinite');
+
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+
+      await expect(inc).toHaveCSS('animation-duration', '6s');
+      await expect(inc).toHaveCSS('animation-iteration-count', 'infinite');
+      await expect(dec).toHaveCSS('animation-duration', '6s');
+      await expect(dec).toHaveCSS('animation-iteration-count', 'infinite');
+    });
+  });
+});

--- a/projects/composition/src/app/pages/progress-linear-page/progress-linear-page.component.html
+++ b/projects/composition/src/app/pages/progress-linear-page/progress-linear-page.component.html
@@ -4,6 +4,7 @@
     <div class="progr-lin-group">
       <cps-progress-linear></cps-progress-linear>
       <cps-progress-linear
+        ariaLabel="Energy progress linear"
         color="energy"
         radius="0.25rem"
         bgColor="energy-highlighten"

--- a/projects/composition/src/app/pages/progress-linear-page/progress-linear-page.examples.ts
+++ b/projects/composition/src/app/pages/progress-linear-page/progress-linear-page.examples.ts
@@ -7,6 +7,7 @@ export const progressLinearExamples: Record<
 <div style="display: flex; flex-direction: column; gap: 3rem;">
   <cps-progress-linear></cps-progress-linear>
   <cps-progress-linear
+    ariaLabel="Energy progress linear"
     color="energy"
     radius="0.25rem"
     bgColor="energy-highlighten"

--- a/projects/cps-ui-kit/src/lib/components/cps-progress-linear/cps-progress-linear.component.html
+++ b/projects/cps-ui-kit/src/lib/components/cps-progress-linear/cps-progress-linear.component.html
@@ -1,16 +1,19 @@
 <div
   aria-hidden="true"
   class="cps-progress-linear"
+  data-testid="cps-progress-linear"
   [style.max-width]="cvtWidth()"
   [style.height]="cvtHeight()"
   [style.border-radius]="cvtRadius()"
   [style.background]="cssBgColor()">
   <div
     class="cps-progress-linear-line inc"
+    data-testid="cps-progress-linear-inc"
     [style.background]="cssColor()"
     [style.opacity]="opacity()"></div>
   <div
     class="cps-progress-linear-line dec"
+    data-testid="cps-progress-linear-dec"
     [style.background]="cssColor()"
     [style.opacity]="opacity()"></div>
 </div>


### PR DESCRIPTION
## Summary

- Added 2 tests covering browser behavior: real CSS custom-property color resolution for both `color` and `bgColor` (`"energy"`/`"energy-highlighten"` -> the literal `var(...)` string in JSDOM vs. the real resolved `rgb(255, 120, 15)` / `rgb(250, 236, 229)` from the compiled stylesheet), and the real `prefers-reduced-motion` accommodation on both indeterminate bars (`.inc`/`.dec`), which slow from 2s to 6s.
- Added `ariaLabel="Energy progress linear"` to the existing "energy" demo bar.
- Added three library testids (`cps-progress-linear`, `cps-progress-linear-inc`, `cps-progress-linear-dec`).

#### TODO: Merge with `feat: add test ids to progress linear component`

---

Release notes:
- added Playwright E2E coverage for cps-progress-linear component
- added test ids to cps-progress-linear component